### PR TITLE
Fix 1-frame pause delay

### DIFF
--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -253,13 +253,11 @@ fn run_physics_schedule(world: &mut World, mut is_first_run: Local<IsFirstRun>) 
             schedule.run(world);
         }
 
-        // If physics is paused, reset delta time to stop the simulation
-        // unless users manually advance `Time<Physics>`.
-        if is_paused {
-            world
-                .resource_mut::<Time<Physics>>()
-                .advance_by(Duration::ZERO);
-        }
+        // Reset delta time, to continue the simulation `Time<Physics>`
+        // must be unpaused or manually advanced by users.
+        world
+            .resource_mut::<Time<Physics>>()
+            .advance_by(Duration::ZERO);
 
         // Set the generic `Time` resource back to the clock that was active before physics.
         *world.resource_mut::<Time>() = old_clock;


### PR DESCRIPTION
Fixes #776. Details available on the issue.

Summary: currently if the user pauses `Time<Physics>` the pause is delayed by 1 frame because we detect the delta time of the previous frame as if the user had manually advanced the clock. This PR fixed the issue by always resetting the delta time. This shouldn't cause regressions since it doesn't interfere with the 2 standard ways to advance the simulation on the next frame: if the clock is not paused then the delta time will be automatically set at the beginning of `run_physics_schedule` and if the user manually advances the time then the reset will get overridden.