### PR TITLE
Add Bevy version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![2D docs.rs](https://img.shields.io/docsrs/avian2d?label=2D%20docs.rs)](https://docs.rs/avian2d)
 [![3D crates.io](https://img.shields.io/crates/v/avian3d?label=3D%20crates.io)](https://crates.io/crates/avian3d)
 [![3D docs.rs](https://img.shields.io/docsrs/avian3d?label=3D%20docs.rs)](https://docs.rs/avian3d)
+[![Bevy version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Favianphysics%2Favian%2Frefs%2Fheads%2Fmain%2Fcrates%2Favian2d%2FCargo.toml&query=%24.dependencies.bevy.version&prefix=v&label=bevy)](#version-table)
 
 **Avian** is an ECS-driven 2D and 3D physics engine for the [Bevy game engine](https://bevyengine.org/).
 


### PR DESCRIPTION
# Objective

Make it easily visible which Bevy version Avian currently supports.

## Solution

Add a badge to the README which automatically queries the currently used Bevy version.

This is implemented with the "Dynamic TOML Badge" feature from shields.io.
It's used to query the current Bevy version from the Cargo.toml of Avian 2D (assuming the Bevy version is consistent across 2D and 3D).

Clicking on the Badge links you to the version table in the README.

> [!NOTE]
>
> If the badge is desired, I can of course re-order it or change the labels to match your preference.

## Testing

N/A

---

## Showcase

[RENDERED](https://github.com/TimJentzsch/avian/blob/bevy-version-badge/README.md)
<img width="1720" height="559" alt="Screenshot of the README with the added Bevy badge" src="https://github.com/user-attachments/assets/5f88bf10-16ed-4004-bfda-34191f6ce145" />
