### PR TITLE
Don't take ownership of the vertices and indices parameters in the convex_decomposition and convex_hull methods

### DIFF
--- a/migration-guides/0.5-to-0.6.md
+++ b/migration-guides/0.5-to-0.6.md
@@ -75,3 +75,7 @@ To modify their values, reinsert the components with new values using `EntityCom
 
 The `SleepBody` and `WakeBody` commands now return an error when applied for an entity that doesn't exist
 or doesn't belong to an island. Previously, they logged a warning instead.
+
+## `Collider::convex_decomposition` and `Collider::convex_hull`
+
+The `Collider::convex_decomposition` and `Collider::convex_hull` methods now borrow the vertices and indices parameters.

--- a/migration-guides/0.5-to-0.6.md
+++ b/migration-guides/0.5-to-0.6.md
@@ -75,7 +75,3 @@ To modify their values, reinsert the components with new values using `EntityCom
 
 The `SleepBody` and `WakeBody` commands now return an error when applied for an entity that doesn't exist
 or doesn't belong to an island. Previously, they logged a warning instead.
-
-## `Collider::convex_decomposition` and `Collider::convex_hull`
-
-The `Collider::convex_decomposition` and `Collider::convex_hull` methods now borrow the vertices and indices parameters.

--- a/migration-guides/0.7-to-main.md
+++ b/migration-guides/0.7-to-main.md
@@ -99,3 +99,7 @@ of the solver body associated with a given entity is stored in the `SolverBodyIn
 
 `ColliderTreeOptimization::use_async_tasks` has been renamed to `ColliderTreeOptimization::use_compute_task`,
 as tree optimization is now run as a single task on the `ComputeTaskPool`.
+
+## `Collider::convex_decomposition` and `Collider::convex_hull`
+
+The `Collider::convex_decomposition` and `Collider::convex_hull` methods now borrow the vertices and indices parameters.

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -968,15 +968,15 @@ impl Collider {
     /// Creates a collider shape with a compound shape obtained from the decomposition of a given polyline
     /// defined by its vertex and index buffers.
     #[cfg(feature = "2d")]
-    pub fn convex_decomposition(vertices: Vec<RVector>, indices: Vec<[u32; 2]>) -> Self {
-        SharedShape::convex_decomposition(&vertices, &indices).into()
+    pub fn convex_decomposition(vertices: &[RVector], indices: &[[u32; 2]]) -> Self {
+        SharedShape::convex_decomposition(vertices, indices).into()
     }
 
     /// Creates a collider shape with a compound shape obtained from the decomposition of a given trimesh
     /// defined by its vertex and index buffers.
     #[cfg(feature = "3d")]
-    pub fn convex_decomposition(vertices: Vec<RVector>, indices: Vec<[u32; 3]>) -> Self {
-        SharedShape::convex_decomposition(&vertices, &indices).into()
+    pub fn convex_decomposition(vertices: &[RVector], indices: &[[u32; 3]]) -> Self {
+        SharedShape::convex_decomposition(vertices, indices).into()
     }
 
     /// Creates a collider shape with a compound shape obtained from the decomposition of a given polyline
@@ -984,11 +984,11 @@ impl Collider {
     /// the decomposition process.
     #[cfg(feature = "2d")]
     pub fn convex_decomposition_with_config(
-        vertices: Vec<RVector>,
-        indices: Vec<[u32; 2]>,
+        vertices: &[RVector],
+        indices: &[[u32; 2]],
         params: &VhacdParameters,
     ) -> Self {
-        SharedShape::convex_decomposition_with_params(&vertices, &indices, &params.clone().into())
+        SharedShape::convex_decomposition_with_params(vertices, indices, &params.clone().into())
             .into()
     }
 
@@ -997,26 +997,26 @@ impl Collider {
     /// the decomposition process.
     #[cfg(feature = "3d")]
     pub fn convex_decomposition_with_config(
-        vertices: Vec<RVector>,
-        indices: Vec<[u32; 3]>,
-        params: VhacdParameters,
+        vertices: &[RVector],
+        indices: &[[u32; 3]],
+        params: &VhacdParameters,
     ) -> Self {
-        SharedShape::convex_decomposition_with_params(&vertices, &indices, &params.clone().into())
+        SharedShape::convex_decomposition_with_params(vertices, indices, &params.clone().into())
             .into()
     }
 
     /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape obtained after computing
     /// the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points.
     #[cfg(feature = "2d")]
-    pub fn convex_hull(points: Vec<RVector>) -> Option<Self> {
-        SharedShape::convex_hull(&points).map(Into::into)
+    pub fn convex_hull(points: &[RVector]) -> Option<Self> {
+        SharedShape::convex_hull(points).map(Into::into)
     }
 
     /// Creates a collider with a [convex polyhedron](https://en.wikipedia.org/wiki/Convex_polytope) shape obtained after computing
     /// the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points.
     #[cfg(feature = "3d")]
-    pub fn convex_hull(points: Vec<RVector>) -> Option<Self> {
-        SharedShape::convex_hull(&points).map(Into::into)
+    pub fn convex_hull(points: &[RVector]) -> Option<Self> {
+        SharedShape::convex_hull(points).map(Into::into)
     }
 
     /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape **without** computing
@@ -1420,11 +1420,11 @@ impl Collider {
             } => Some(Self::trimesh_with_config(vertices, indices, flags)),
             #[cfg(feature = "2d")]
             ColliderConstructor::ConvexDecomposition { vertices, indices } => {
-                Some(Self::convex_decomposition(vertices, indices))
+                Some(Self::convex_decomposition(&vertices, &indices))
             }
             #[cfg(feature = "3d")]
             ColliderConstructor::ConvexDecomposition { vertices, indices } => {
-                Some(Self::convex_decomposition(vertices, indices))
+                Some(Self::convex_decomposition(&vertices, &indices))
             }
             #[cfg(feature = "2d")]
             ColliderConstructor::ConvexDecompositionWithConfig {
@@ -1432,7 +1432,7 @@ impl Collider {
                 indices,
                 params,
             } => Some(Self::convex_decomposition_with_config(
-                vertices, indices, &params,
+                &vertices, &indices, &params,
             )),
             #[cfg(feature = "3d")]
             ColliderConstructor::ConvexDecompositionWithConfig {
@@ -1440,12 +1440,12 @@ impl Collider {
                 indices,
                 params,
             } => Some(Self::convex_decomposition_with_config(
-                vertices, indices, params,
+                &vertices, &indices, &params,
             )),
             #[cfg(feature = "2d")]
-            ColliderConstructor::ConvexHull { points } => Self::convex_hull(points),
+            ColliderConstructor::ConvexHull { points } => Self::convex_hull(&points),
             #[cfg(feature = "3d")]
-            ColliderConstructor::ConvexHull { points } => Self::convex_hull(points),
+            ColliderConstructor::ConvexHull { points } => Self::convex_hull(&points),
             #[cfg(feature = "2d")]
             ColliderConstructor::ConvexPolyline { points } => Self::convex_polyline(points),
             ColliderConstructor::Voxels {

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -194,11 +194,11 @@ impl IntoCollider<Collider> for Rectangle {
 
 impl IntoCollider<Collider> for Polygon {
     fn collider(&self) -> Collider {
-        let vertices = self.vertices.iter().map(|v| v.real()).collect();
+        let vertices = self.vertices.iter().map(|v| v.real()).collect::<Vec<_>>();
         let indices = (0..self.vertices.len() as u32 - 1)
             .map(|i| [i, i + 1])
-            .collect();
-        Collider::convex_decomposition(vertices, indices)
+            .collect::<Vec<_>>();
+        Collider::convex_decomposition(&vertices, &indices)
     }
 }
 


### PR DESCRIPTION
# Objective

Don't take ownership of the vertices and indices in the `convex_decomposition` and `convex_hull` methods as it is not necessary.

## Solution

Replace the `Vec<_>` parameters with `&[_]`.

## Testing

I have tested the branch on my personal project (which only use convex_decomposition_with_config).
