### PR TITLE
2D picking with a 3D camera

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -173,6 +173,10 @@ name = "one_way_platform_2d"
 required-features = ["2d", "default-collider"]
 
 [[example]]
+name = "picking_2d_in_perspective"
+required-features = ["2d", "debug-plugin", "bevy_picking"]
+
+[[example]]
 name = "prismatic_joint_2d"
 required-features = ["2d", "default-collider"]
 

--- a/crates/avian2d/examples/picking_2d_in_perspective.rs
+++ b/crates/avian2d/examples/picking_2d_in_perspective.rs
@@ -8,7 +8,7 @@ fn main() {
             DefaultPlugins,
             ExampleCommonPlugin,
             PhysicsPlugins::default(),
-            PhysicsPickingPlugin::default(),
+            PhysicsPickingPlugin,
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Gravity(Vector::NEG_Y))
@@ -99,7 +99,7 @@ fn setup(
         // Default anchors are at body centers (Vector::ZERO)
         commands.spawn((
             RevoluteJoint::new(velocity_anchor, velocity_wheel).with_motor(AngularMotor {
-                target_velocity: 5.0 * flip,
+                target_velocity: 5.0 * flip.adjust_precision(),
                 max_torque: 1000.0,
                 motor_model: MotorModel::AccelerationBased {
                     stiffness: 0.0,

--- a/crates/avian2d/examples/picking_2d_in_perspective.rs
+++ b/crates/avian2d/examples/picking_2d_in_perspective.rs
@@ -1,0 +1,182 @@
+use avian2d::{math::*, prelude::*};
+use bevy::prelude::*;
+use examples_common_2d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            ExampleCommonPlugin,
+            PhysicsPlugins::default(),
+            PhysicsPickingPlugin::default(),
+        ))
+        .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
+        .insert_resource(Gravity(Vector::NEG_Y))
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_camera)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    // 2D camera with a perspective projection; completely unheard of!
+    commands.spawn((
+        Camera2d,
+        Projection::Perspective(PerspectiveProjection::default()),
+        Transform::from_xyz(0.0, 0.0, 1.0), // We have to start slightly away from the Z axis, since now everything is drawing at Z = 0
+    ));
+
+    let square_sprite = Sprite {
+        color: Color::srgb(0.7, 0.7, 0.8),
+        custom_size: Some(Vec2::splat(0.05)),
+        ..default()
+    };
+
+    // Ceiling
+    commands.spawn((
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, 0.05 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
+        RigidBody::Static,
+        Collider::rectangle(0.05, 0.05),
+    ));
+    // Floor
+    commands.spawn((
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, -0.05 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
+        RigidBody::Static,
+        Collider::rectangle(0.05, 0.05),
+    ));
+    // Left wall
+    commands.spawn((
+        square_sprite.clone(),
+        Transform::from_xyz(-0.05 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
+        RigidBody::Static,
+        Collider::rectangle(0.05, 0.05),
+    ));
+    // Right wall
+    commands.spawn((
+        square_sprite,
+        Transform::from_xyz(0.05 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
+        RigidBody::Static,
+        Collider::rectangle(0.05, 0.05),
+    ));
+
+    for flip in [-1.0, 1.0] {
+        // Static anchor for the churner
+        let velocity_anchor = commands
+            .spawn((
+                Sprite {
+                    color: Color::srgb(0.5, 0.5, 0.5),
+                    custom_size: Some(Vec2::splat(0.01)),
+                    ..default()
+                },
+                Transform::from_xyz(-0.3 * flip, -0.15, 0.0),
+                RigidBody::Static,
+            ))
+            .id();
+
+        // Spinning churner
+        let velocity_wheel = commands
+            .spawn((
+                Sprite {
+                    color: Color::srgb(0.9, 0.3, 0.3),
+                    custom_size: Some(vec2(0.24, 0.02)),
+                    ..default()
+                },
+                Transform::from_xyz(-0.3 * flip, -0.15, 0.0),
+                RigidBody::Dynamic,
+                Mass(1.0),
+                AngularInertia(1.0),
+                SleepingDisabled, // Prevent sleeping so motor can always control it
+                Collider::rectangle(0.24, 0.02),
+            ))
+            .id();
+
+        // Revolute joint with velocity-controlled motor
+        // Default anchors are at body centers (Vector::ZERO)
+        commands.spawn((
+            RevoluteJoint::new(velocity_anchor, velocity_wheel).with_motor(AngularMotor {
+                target_velocity: 5.0 * flip,
+                max_torque: 1000.0,
+                motor_model: MotorModel::AccelerationBased {
+                    stiffness: 0.0,
+                    damping: 1.0,
+                },
+                ..default()
+            }),
+        ));
+    }
+
+    let circle = Circle::new(0.0075);
+    let collider = circle.collider();
+    let mesh = meshes.add(circle);
+
+    let ball_color = Color::srgb(0.29, 0.33, 0.64);
+
+    for x in -12i32..=12 {
+        for y in -1_i32..=8 {
+            commands
+                .spawn((
+                    Mesh2d(mesh.clone()),
+                    MeshMaterial2d(materials.add(ball_color)),
+                    Transform::from_xyz(x as f32 * 0.025, y as f32 * 0.025, 0.0),
+                    collider.clone(),
+                    RigidBody::Dynamic,
+                    Friction::new(0.1),
+                ))
+                .observe(
+                    |over: On<Pointer<Over>>,
+                     mut materials: ResMut<Assets<ColorMaterial>>,
+                     balls: Query<&MeshMaterial2d<ColorMaterial>>| {
+                        materials
+                            .get_mut(balls.get(over.entity).unwrap())
+                            .unwrap()
+                            .color = Color::WHITE;
+                    },
+                )
+                .observe(
+                    move |out: On<Pointer<Out>>,
+                          mut materials: ResMut<Assets<ColorMaterial>>,
+                          balls: Query<&MeshMaterial2d<ColorMaterial>>| {
+                        materials
+                            .get_mut(balls.get(out.entity).unwrap())
+                            .unwrap()
+                            .color = ball_color;
+                    },
+                );
+        }
+    }
+}
+
+// TODO: if anyone would like to improve this example, a freecam could be fun to mess around with :D
+fn move_camera(
+    mut camera: Single<&mut Transform, With<Camera>>,
+    input: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+) {
+    const MOVE_SCALE: f32 = 1.0;
+
+    let mut delta = Vec3::ZERO;
+    if input.pressed(KeyCode::KeyW) {
+        delta.z -= time.delta_secs() * MOVE_SCALE;
+    }
+    if input.pressed(KeyCode::KeyS) {
+        delta.z += time.delta_secs() * MOVE_SCALE;
+    }
+    if input.pressed(KeyCode::KeyA) {
+        delta.x -= time.delta_secs() * MOVE_SCALE;
+    }
+    if input.pressed(KeyCode::KeyD) {
+        delta.x += time.delta_secs() * MOVE_SCALE;
+    }
+    if input.pressed(KeyCode::ShiftLeft) {
+        delta.y -= time.delta_secs() * MOVE_SCALE;
+    }
+    if input.pressed(KeyCode::Space) {
+        delta.y += time.delta_secs() * MOVE_SCALE;
+    }
+    camera.translation += delta;
+}

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -167,9 +167,11 @@ pub fn update_hits(
         #[cfg(feature = "2d")]
         {
             let mut hits: Vec<(Entity, HitData)> = vec![];
+            // Follow the ray to its intersection with the Z axis
+            let point = ray.origin.xy() - ray.direction.xy() * ray.origin.z / ray.direction.z;
 
             spatial_query.point_intersections_callback(
-                ray.origin.truncate().adjust_precision(),
+                point.adjust_precision(),
                 &filter.0,
                 |entity| {
                     let marker_requirement =
@@ -183,7 +185,7 @@ pub fn update_hits(
                     if marker_requirement && is_pickable {
                         hits.push((
                             entity,
-                            HitData::new(ray_id.camera, 0.0, Some(ray.origin.f32()), None),
+                            HitData::new(ray_id.camera, 0.0, Some(point.extend(0.0)), None),
                         ));
                     }
 


### PR DESCRIPTION
# Objective

Allow using perspective cameras with the 2D physics plugin

## Solution

Follow the ray that `bevy_picking` gives to its intersection with the Z axis rather than truncating the value to 2D

## Testing

(see below)

---

## Showcase

I added a demo to the repository under the name `picking_2d_in_perspective.rs` (in `avian2d`); it looks a bit like this:

[Screencast_20260320_083503.webm](https://github.com/user-attachments/assets/a2db47e8-0b60-47c7-9be7-05984c14981b)

I had hoped to add a free camera to the demo so you could see rotations working as well; as of yet, I haven't gotten around to it. I may finish that in a separate PR if I have the time, or someone else can add it in :smile: 
