### PR TITLE
perf: draw HeightField debug as grid wireframe instead of per-triangl…

### DIFF
--- a/src/debug_render/gizmos.rs
+++ b/src/debug_render/gizmos.rs
@@ -270,13 +270,45 @@ impl PhysicsGizmoExt for Gizmos<'_, '_, PhysicsGizmos> {
                     );
                 }
                 #[cfg(feature = "3d")]
-                for triangle in s.triangles() {
-                    self.draw_collider(
-                        &Collider::from(SharedShape::new(triangle)),
-                        position,
-                        rotation,
-                        color,
-                    );
+                {
+                    // Draw heightfield as a grid wireframe directly instead of
+                    // creating a SharedShape per triangle. This avoids O(rows*cols)
+                    // heap allocations per frame and is dramatically faster for
+                    // large heightfields.
+                    let nrows = s.nrows();
+                    let ncols = s.ncols();
+                    let scale = s.scale();
+                    let heights = s.heights();
+
+                    let cell_w = scale.x / ncols as Scalar;
+                    let cell_h = scale.z / nrows as Scalar;
+                    let half_x = scale.x * 0.5;
+                    let half_z = scale.z * 0.5;
+
+                    let vertex = |r: usize, c: usize| -> Vector {
+                        Vector::new(
+                            c as Scalar * cell_w - half_x,
+                            heights[(r, c)] * scale.y,
+                            r as Scalar * cell_h - half_z,
+                        )
+                    };
+
+                    // Horizontal edges (along columns)
+                    for r in 0..=nrows {
+                        for c in 0..ncols {
+                            let a = position.0 + rotation * vertex(r, c);
+                            let b = position.0 + rotation * vertex(r, c + 1);
+                            self.draw_line(a, b, color);
+                        }
+                    }
+                    // Vertical edges (along rows)
+                    for r in 0..nrows {
+                        for c in 0..=ncols {
+                            let a = position.0 + rotation * vertex(r, c);
+                            let b = position.0 + rotation * vertex(r + 1, c);
+                            self.draw_line(a, b, color);
+                        }
+                    }
                 }
             }
             TypedShape::Compound(s) => {


### PR DESCRIPTION
The 3D HeightField debug rendering previously created a SharedShape::new(triangle) for every triangle and recursed into draw_collider. For a 32×32 heightfield this means ~1922 heap allocations per collider per frame, making debug rendering unusable for chunked terrain with multiple heightfield colliders.

This replaces the per-triangle approach with direct grid wireframe drawing using the heightfield's heights matrix, scale, and dimensions. The result is visually identical but avoids all per-triangle allocations.

Tested on a project with a basic HeightField mesh that was tanking to around 20 FPS. Now hitting the cap at 120 FPS. 