### PR TITLE
allow accessing entity from intersections callback

### DIFF
--- a/migration-guides/0.6-to-main.md
+++ b/migration-guides/0.6-to-main.md
@@ -5,3 +5,9 @@ since the latest release. These guides are evolving and may not be polished yet.
 
 See [migration-guides/README.md](./README.md) and existing entries for information about Avian's
 migration guide process and what to put here.
+
+## Move and Slide Intersections
+
+The callback provided to `MoveAndSlide::intersections` now takes a third parameter, `Entity`. This
+allows accessing the entity being intersected per callback. Existing calls to this function can
+simply ignore the new parameter with `_`.

--- a/src/character_controller/move_and_slide.rs
+++ b/src/character_controller/move_and_slide.rs
@@ -997,7 +997,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
     )]
     ///         config.skin_width,
     ///         &filter,
-    ///         |contact_point, normal| {
+    ///         |_entity, contact_point, normal| {
     ///             intersections.push((normal, contact_point.penetration + config.skin_width));
     ///             true
     ///         },

--- a/src/character_controller/move_and_slide.rs
+++ b/src/character_controller/move_and_slide.rs
@@ -578,7 +578,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
                 // Depenetration still uses just the normal skin width.
                 skin_width * 2.0,
                 filter,
-                |contact_point, mut normal| {
+                |_, contact_point, mut normal| {
                     // Check if this plane is nearly parallel to an existing one.
                     // This can help prune redundant planes for velocity clipping.
                     for existing_normal in planes.iter_mut() {
@@ -922,7 +922,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
             shape_rotation,
             self.length_unit.0 * config.skin_width,
             filter,
-            |contact_point, normal| {
+            |_, contact_point, normal| {
                 intersections.push((
                     normal,
                     contact_point.penetration + self.length_unit.0 * config.skin_width,
@@ -1073,7 +1073,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
         shape_rotation: RotationValue,
         prediction_distance: Scalar,
         filter: &SpatialQueryFilter,
-        mut callback: impl FnMut(&ContactPoint, Dir) -> bool,
+        mut callback: impl FnMut(Entity, &ContactPoint, Dir) -> bool,
     ) {
         let expanded_aabb = shape
             .aabb(shape_position, shape_rotation)
@@ -1110,7 +1110,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
 
                 let normal = Dir::new_unchecked(-manifold.normal.f32());
 
-                if !callback(deepest, normal) {
+                if !callback(intersection_entity, deepest, normal) {
                     // Abort further processing.
                     break 'outer;
                 }


### PR DESCRIPTION
# Objective

Adds a new parameter to the callback in `MoveAndSlide::intersections`, to allow accessing the intersected entity.

## Solution

Adds a new parameter to the relevant callback.

## Testing

The change is extremely simple so as long as the logic is correct, it shouldn't need extensive testing.
I ran `cargo test` to try and catch all places that needed to be updated in the repo, and use the same logic in a vendored version of the function in a project and it has worked correctly so far.

I did see 4 failures in the `cargo test` but they seemed to be minor precision issues; float equality comparisons off by 0.0001 or so. Probably unrelated to the changes in this PR.