### PR TITLE
Granular configuration of debug render systems

### DIFF
--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -15,7 +15,7 @@ use bevy::{color::palettes::css::*, prelude::*};
 /// #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
 /// use bevy::prelude::*;
 ///
-/// fn disable_aabb(mut config: ResMut<GlobalPhysicsDebugConfig>) {
+/// fn disable_aabb(mut config: ResMut<PhysicsDebugRenderConfig>) {
 ///     config.enable_aabb = false;
 /// }
 /// ```

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -11,8 +11,8 @@ use bevy::{color::palettes::css::*, prelude::*};
 /// For example, to disable AABB rendering:
 ///
 /// ```no_run
-/// #[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
-/// #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
 /// use bevy::prelude::*;
 ///
 /// fn disable_aabb(mut config: ResMut<PhysicsDebugRenderConfig>) {

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -1,6 +1,76 @@
 use crate::prelude::*;
 use bevy::{color::palettes::css::*, prelude::*};
 
+#[derive(Resource, Reflect, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Resource)]
+/// A global configuration resource for enabling/disabling debug render systems.
+///
+/// This resource can be used to toggle debug rendering systems at runtime.
+/// For example, to disable AABB rendering:
+///
+/// ```no_run
+/// #[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+/// #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// fn disable_aabb(mut config: ResMut<GlobalPhysicsDebugConfig>) {
+///     config.enable_aabb = false;
+/// }
+/// ```
+pub struct PhysicsDebugRenderConfig {
+    /// Enable rendering of rigid body axes.
+    pub enable_axes: bool,
+    /// Enable rendering of collider AABBs.
+    pub enable_aabb: bool,
+    /// Enable rendering of BVH tree nodes.
+    pub enable_bvh: bool,
+    /// Enable rendering of collider wireframes.
+    pub enable_colliders: bool,
+    /// Enable rendering of contact points and normals.
+    pub enable_contacts: bool,
+    /// Enable rendering of joints.
+    pub enable_joints: bool,
+    /// Enable rendering of raycasts.
+    pub enable_raycasts: bool,
+    /// Enable rendering of shapecasts.
+    pub enable_shapecasts: bool,
+    /// Enable rendering of simulation islands.
+    pub enable_islands: bool,
+}
+
+impl Default for PhysicsDebugRenderConfig {
+    fn default() -> Self {
+        Self {
+            enable_axes: true,
+            enable_aabb: true,
+            enable_bvh: true,
+            enable_colliders: true,
+            enable_contacts: true,
+            enable_joints: true,
+            enable_raycasts: true,
+            enable_shapecasts: true,
+            enable_islands: true,
+        }
+    }
+}
+
+impl PhysicsDebugRenderConfig {
+    /// Enable or disable all of the debug rendering systems.
+    pub fn set_all(&mut self, enabled: bool) {
+        self.enable_axes = enabled;
+        self.enable_aabb = enabled;
+        self.enable_bvh = enabled;
+        self.enable_colliders = enabled;
+        self.enable_contacts = enabled;
+        self.enable_joints = enabled;
+        self.enable_raycasts = enabled;
+        self.enable_shapecasts = enabled;
+        self.enable_islands = enabled;
+    }
+}
+
 /// Gizmos used for debug rendering physics. See [`PhysicsDebugPlugin`]
 ///
 /// You can configure what is rendered by inserting the [`PhysicsGizmos`] configuration group

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -49,6 +49,9 @@ use bevy::{
 /// You can configure the [`PhysicsGizmos`] retrieved from `GizmoConfigStore` for the global configuration
 /// and the [`DebugRender`] component for entity-level configuration.
 ///
+/// The plugin also initializes the [`PhysicsDebugRenderConfig`] resource, which lets you
+/// enable or disable individual debug render systems at runtime. All systems are enabled by default.
+///
 /// # Example
 ///
 /// ```no_run
@@ -86,11 +89,26 @@ use bevy::{
 ///     ));
 /// }
 /// ```
+///
+/// # Runtime Configuration
+///
+/// To toggle debug render systems at runtime, use the [`PhysicsDebugRenderConfig`] resource:
+///
+/// ```no_run
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// fn disable_aabb(mut config: ResMut<PhysicsDebugRenderConfig>) {
+///     config.enable_aabb = false;
+/// }
+/// ```
 #[derive(Default)]
 pub struct PhysicsDebugPlugin;
 
 impl Plugin for PhysicsDebugPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<PhysicsDebugRenderConfig>();
         app.init_gizmo_group::<PhysicsGizmos>();
 
         let mut store = app.world_mut().resource_mut::<GizmoConfigStore>();
@@ -104,32 +122,38 @@ impl Plugin for PhysicsDebugPlugin {
             config.line.width = 1.5;
         }
 
+        macro_rules! configured {
+            ($field:ident) => {
+                (|r: Res<PhysicsDebugRenderConfig>| r.$field)
+            };
+        }
+
         app.add_systems(
             PostUpdate,
             (
-                debug_render_axes,
-                debug_render_aabbs,
-                debug_render_bvh,
+                debug_render_axes.run_if(configured!(enable_axes)),
+                debug_render_aabbs.run_if(configured!(enable_aabb)),
+                debug_render_bvh.run_if(configured!(enable_bvh)),
                 #[cfg(all(
                     feature = "default-collider",
                     any(feature = "parry-f32", feature = "parry-f64")
                 ))]
-                debug_render_colliders,
-                debug_render_contacts,
+                debug_render_colliders.run_if(configured!(enable_colliders)),
+                debug_render_contacts.run_if(configured!(enable_contacts)),
                 // TODO: Refactor joints to allow iterating over all of them without generics
-                debug_render_constraint::<FixedJoint, 2>,
-                debug_render_constraint::<PrismaticJoint, 2>,
-                debug_render_constraint::<DistanceJoint, 2>,
-                debug_render_constraint::<RevoluteJoint, 2>,
+                debug_render_constraint::<FixedJoint, 2>.run_if(configured!(enable_joints)),
+                debug_render_constraint::<PrismaticJoint, 2>.run_if(configured!(enable_joints)),
+                debug_render_constraint::<DistanceJoint, 2>.run_if(configured!(enable_joints)),
+                debug_render_constraint::<RevoluteJoint, 2>.run_if(configured!(enable_joints)),
                 #[cfg(feature = "3d")]
-                debug_render_constraint::<SphericalJoint, 2>,
-                debug_render_raycasts,
+                debug_render_constraint::<SphericalJoint, 2>.run_if(configured!(enable_joints)),
+                debug_render_raycasts.run_if(configured!(enable_raycasts)),
                 #[cfg(all(
                     feature = "default-collider",
                     any(feature = "parry-f32", feature = "parry-f64")
                 ))]
-                debug_render_shapecasts,
-                debug_render_islands.run_if(resource_exists::<PhysicsIslands>),
+                debug_render_shapecasts.run_if(configured!(enable_shapecasts)),
+                debug_render_islands.run_if(configured!(enable_islands)),
             )
                 .after(TransformSystems::Propagate)
                 .run_if(|store: Res<GizmoConfigStore>| store.config::<PhysicsGizmos>().0.enabled),


### PR DESCRIPTION
# Objective

- Enable/disable debug render systems via `run_if` conditions.
- Configure what parts of the physics should be rendered, e.g. only colliders and body axes.
- Can be configured both in runtime and before the app start.

## Solution

New resource `PhysicsDebugRenderConfig` with a bunch of bools for each group of render debug systems. By default, everything is enabled.

Alternative solution is to cram everything into `PhysicsGizmos`, but I think it's big enough already ?

## Testing

I tested this with `cargo run --example move_and_slide_3d --features use-debug-plugin` and toggling colliders rendering:

```diff
index 113216a..f4db8db 100644
--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -44,6 +44,16 @@ impl Plugin for ExampleCommonPlugin {
         if !app.is_plugin_added::<PhysicsDebugPlugin>() {
             app.add_plugins(PhysicsDebugPlugin);
         }
+
+        app.add_systems(
+            Update,
+            (
+                (|mut r: ResMut<PhysicsDebugRenderConfig>| {
+                    r.enable_colliders = !r.enable_colliders
+                })
+                    .run_if(input_just_pressed(KeyCode::KeyC)),
+            ),
+        );
     }
 }
```
