### PR TITLE
Do not force all meshes visible on gizmo settings change.

### DIFF
--- a/migration-guides/0.6-to-main.md
+++ b/migration-guides/0.6-to-main.md
@@ -16,3 +16,14 @@ simply ignore the new parameter with `_`.
 
 Similar to many other plugins, the `SpatialQueryPlugin` now stores a schedule label,
 which by default is also passed via `PhysicsPlugins::new`.
+
+## Physics Debug Gizmo Mesh Visibility
+
+In past releases, `PhysicsGizmos::hide_meshes` forced all meshes to be visible when it is `false`.
+Im **Avian 0.7**, it instead sets the mesh visibility to `Visibility::Inherited`, which is a more
+appropriate default.
+
+This is still not perfect, as it does not fully respect the old visibility value. Doing so
+would require caching the old visibility in a separate component. This feature will likely
+undergo larger changes in the future, for example favoring `RenderLayers` over `Visibility`
+to create a dedicated "debug view".

--- a/migration-guides/0.6-to-main.md
+++ b/migration-guides/0.6-to-main.md
@@ -20,7 +20,7 @@ which by default is also passed via `PhysicsPlugins::new`.
 ## Physics Debug Gizmo Mesh Visibility
 
 In past releases, `PhysicsGizmos::hide_meshes` forced all meshes to be visible when it is `false`.
-Im **Avian 0.7**, it instead sets the mesh visibility to `Visibility::Inherited`, which is a more
+In **Avian 0.7**, it instead sets the mesh visibility to `Visibility::Inherited`, which is a more
 appropriate default.
 
 This is still not perfect, as it does not fully respect the old visibility value. Doing so

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -563,7 +563,7 @@ fn change_mesh_visibility(
             if hide_mesh {
                 *visibility = Visibility::Hidden;
             } else {
-                *visibility = Visibility::Visible;
+                *visibility = Visibility::Inherited;
             }
         }
     }


### PR DESCRIPTION
# Objective

- I have a scene with certain Mesh instances inside containers marked Visibility::Hidden, and a (now-fixed) issue where I was triggering a change to the `PhysicsGizmos` `GizmoConfigStore`. This was causing `change_mesh_visibility` to be called and modifying all the meshes to be visible.

## Solution

- Switch to using `Visibility::Inherited` to respect parent (in)visibility, as `Visibility::Visible` affects everything, even in hidden hierarchies.
- Since this code seems quite generic, I suppose the intent of may have been to intentionally expose all meshes for some reason, but that seems unlikely (debug rendering and the gizmos for colliders is "enough" IMO).

## Testing

- Tested with my code that toggles `PhysicsGizmos` enablement. It no longer reveals shows invisible meshes.

