### PR TITLE
Fix joint angle limits ignored for low-inertia bodies

### DIFF
--- a/src/dynamics/joints/tests.rs
+++ b/src/dynamics/joints/tests.rs
@@ -851,3 +851,66 @@ fn prismatic_motor_combined_position_velocity() {
         displacement
     );
 }
+
+/// Regression test: a revolute joint's angle limit must hold even for bodies with very
+/// low angular inertia. The angular constraint solver used to skip applying a correction
+/// when its Lagrange multiplier fell below `EPSILON`; because that multiplier is the
+/// correction scaled by inertia, low-inertia bodies produced multipliers that underflowed
+/// the threshold and rotated straight through their angle limits.
+#[cfg(feature = "2d")]
+#[test]
+fn revolute_angle_limit_holds_at_low_inertia() {
+    use core::f32::consts::PI;
+
+    let mut app = create_app();
+    app.finish();
+
+    let angle_limit = PI / 6.0; // 30 degrees
+
+    // Very low angular inertia is the regime where the old guard discarded the correction.
+    let inertia: f32 = 1.0e-7;
+
+    let anchor = app
+        .world_mut()
+        .spawn((RigidBody::Static, Position(RVector::ZERO)))
+        .id();
+
+    let dynamic = app
+        .world_mut()
+        .spawn((
+            RigidBody::Dynamic,
+            Position(RVector::ZERO),
+            Mass(1.0),
+            AngularInertia(inertia),
+            // Torque sized for a fixed 2 rad/s^2 angular acceleration, driving the body
+            // continuously into the +limit.
+            ConstantTorque(2.0 * inertia),
+        ))
+        .id();
+
+    app.world_mut()
+        .spawn(RevoluteJoint::new(anchor, dynamic).with_angle_limits(-angle_limit, angle_limit));
+
+    app.update();
+
+    // Run for 2 seconds: long enough to reach the limit and settle against it.
+    let steps = (2.0 / TIMESTEP) as usize;
+    for _ in 0..steps {
+        app.update();
+    }
+
+    let body = app.world().entity(dynamic);
+    let angle = body.get::<Rotation>().unwrap().as_radians();
+    let angular_velocity = body.get::<AngularVelocity>().unwrap().0;
+
+    // The limit must arrest the body. Without the fix it rotates through the limit and
+    // keeps spinning under the constant torque, so its angular velocity stays large.
+    assert!(
+        angular_velocity.abs() < 0.5,
+        "angle limit failed to hold low-inertia body: angular velocity = {angular_velocity} rad/s"
+    );
+    assert!(
+        (angle - angle_limit).abs() < 0.1,
+        "body should rest at the +limit ({angle_limit} rad) but is at {angle} rad"
+    );
+}

--- a/src/dynamics/solver/xpbd/angular_constraint.rs
+++ b/src/dynamics/solver/xpbd/angular_constraint.rs
@@ -21,10 +21,9 @@ pub trait AngularConstraint {
         inv_angular_inertia2: SymmetricTensor,
         delta_lagrange: f32,
     ) -> f32 {
-        if delta_lagrange.abs() <= f32::EPSILON {
-            return 0.0;
-        }
-
+        // Do not early-out on a small `delta_lagrange`: it is an impulse scaled by inertia,
+        // so for low-inertia bodies it can be tiny while the applied correction
+        // `inv_inertia * delta_lagrange` is large. Skipping here drops large corrections.
         self.apply_angular_impulse(
             body1,
             body2,
@@ -71,10 +70,7 @@ pub trait AngularConstraint {
         delta_lagrange: f32,
         axis: Vector,
     ) -> Vector {
-        if delta_lagrange.abs() <= f32::EPSILON {
-            return Vector::ZERO;
-        }
-
+        // See the 2D variant: gating on `delta_lagrange` drops large low-inertia corrections.
         let impulse = -delta_lagrange * axis;
 
         self.apply_angular_impulse(
@@ -208,10 +204,7 @@ pub trait AngularConstraint {
         delta_lagrange: f32,
         axis: Vec3,
     ) -> f32 {
-        if delta_lagrange.abs() <= f32::EPSILON {
-            return 0.0;
-        }
-
+        // See `apply_angular_lagrange_update`: gating on `delta_lagrange` drops large low-inertia corrections.
         // Compute angular impulse
         // `axis.z` is 1 or -1 and it controls if the body should rotate counterclockwise or clockwise
         let p = -delta_lagrange * axis.z;
@@ -239,10 +232,7 @@ pub trait AngularConstraint {
         delta_lagrange: f32,
         axis: Vector,
     ) -> Vector {
-        if delta_lagrange.abs() <= f32::EPSILON {
-            return Vector::ZERO;
-        }
-
+        // See `apply_angular_lagrange_update`: gating on `delta_lagrange` drops large low-inertia corrections.
         // Compute angular impulse
         let p = -delta_lagrange * axis;
 

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x63c9e1ff;
+    let expected = 0xfffec6df;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
## Objective

- Revolute joint angle limits are unstable for bodies with low angular inertia: they buzz / limit-cycle at low mass, get *worse* (not better) as `SubstepCount` increases, and at very low mass the limit is ignored entirely and the body rotates straight through it.
- Fixes #886.

### Solution

- Root cause: the angular constraint solver's apply functions early-out when `delta_lagrange.abs() <= Scalar::EPSILON`. But `delta_lagrange` is a Lagrange multiplier, i.e. the correction *scaled by inertia*: with a rigid limit `delta_lagrange = -C / w_sum` and `w_sum = 1/I`, so the applied rotation `inv_inertia * delta_lagrange = -C` is independent of inertia, while the multiplier itself shrinks with `I`. For low-inertia bodies the multiplier underflows `EPSILON`, so a geometrically large correction is silently discarded. (The positional constraint has no such guard.)
- Remove the multiplier-magnitude early-outs in the four angular apply functions: 2D/3D `apply_angular_lagrange_update` and 2D/3D `apply_angular_correction`. Near-zero multipliers now flow through and apply a near-zero rotation, as the positional path already does.
- No breaking changes and no public API change, so no migration guide is needed.

### Testing

- Added a regression test `revolute_angle_limit_holds_at_low_inertia` that drives a body with `1e-7` angular inertia into a 30 deg revolute limit with a constant torque and asserts the limit arrests it. It passes with the fix and fails on `main` (confirmed by stashing only the solver change and re-running).
- Existing joint tests still pass (11/11). Reviewers can run: `cargo test -p avian2d --lib joints`.
- Verified against the #886 reproduction (a real-size pinball flipper, 10 g, on a revolute joint with +/-30 deg limits): the flipper now reaches genuine rest at the limit, stays stable at `SubstepCount(50)`, and the limit holds even at mass `0.0001`.
- Tested on Linux in 2D with `f32`. The 3D apply functions carry the identical guard and are fixed the same way, but are not exercised at runtime by the new test (it is 2D-gated, matching the issue).

---

### Showcase

The flipper from #886 at rest against its `-30 deg` limit, logged every 0.2 s:

<details>
  <summary>Click to view before/after</summary>

Before (stock `main`) - a sustained limit cycle, ~1 deg past the stop, never settling:

```
angle=-31.30 deg  ang_vel= +1.40 rad/s
angle=-31.23 deg  ang_vel= -1.52 rad/s
angle=-31.13 deg  ang_vel= +1.04 rad/s   <- still ~1 rad/s after 4 s
```

After (this PR) - genuine rest at the limit:

```
angle=-30.0038 deg  ang_vel= +0.000165 rad/s
angle=-30.0038 deg  ang_vel= -0.000031 rad/s
angle=-30.0038 deg  ang_vel= +0.000017 rad/s
```

</details>
