### PR TITLE
clone collider trees

### DIFF
--- a/src/collider_tree/mod.rs
+++ b/src/collider_tree/mod.rs
@@ -117,7 +117,7 @@ pub enum ColliderTreeSystems {
 /// Trees for accelerating queries on a set of colliders.
 ///
 /// See the [`collider_tree`](crate::collider_tree) module for more information.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Clone)]
 pub struct ColliderTrees {
     /// A tree for the colliders of dynamic bodies.
     pub dynamic_tree: ColliderTree,


### PR DESCRIPTION
# Objective

- I'm writing a game with deterministic rollback which builds on Avian.  I found a class of desync issues with my game because ColliderTrees were out of sync with the rest of the state (adding/removing on frames).  Make this Clone so rollback easily works (ColliderTree itself is already Clone)

## Solution

- Add Clone to ColliderTrees

## Testing

- Did you test these changes? Rollbacks in this class of desync issue have been fixed
- Are there any parts that need more testing?  No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?  I appreciate Avian so much.  Thank you!
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?  Linux -- I did not test elsewhere