### PR TITLE
Avoid panic when responding to `ColliderConstructor[Hierarchy]`

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -281,7 +281,7 @@ fn init_collider_constructors(
                 "Tried to add a collider to entity {name} via {constructor:#?}, \
                 but that entity already holds a collider. Skipping.",
             );
-            commands.entity(entity).remove::<ColliderConstructor>();
+            commands.entity(entity).try_remove::<ColliderConstructor>();
             continue;
         }
         #[cfg(feature = "collider-from-mesh")]
@@ -305,7 +305,7 @@ fn init_collider_constructors(
         let collider = Collider::try_from_constructor(constructor.clone());
 
         if let Some(collider) = collider {
-            commands.entity(entity).insert(collider);
+            commands.entity(entity).try_insert(collider);
             commands.trigger(ColliderConstructorReady { entity })
         } else {
             error!(
@@ -313,7 +313,7 @@ fn init_collider_constructors(
                 but the collider could not be generated. Skipping.",
             );
         }
-        commands.entity(entity).remove::<ColliderConstructor>();
+        commands.entity(entity).try_remove::<ColliderConstructor>();
     }
 }
 
@@ -420,7 +420,7 @@ fn init_collider_constructor_hierarchies(
             let collider = Collider::try_from_constructor(constructor);
 
             if let Some(collider) = collider {
-                commands.entity(child_entity).insert((
+                commands.entity(child_entity).try_insert((
                     collider,
                     collider_data
                         .layers
@@ -439,7 +439,7 @@ fn init_collider_constructor_hierarchies(
 
         commands
             .entity(scene_entity)
-            .remove::<ColliderConstructorHierarchy>();
+            .try_remove::<ColliderConstructorHierarchy>();
 
         commands.trigger(ColliderConstructorHierarchyReady {
             entity: scene_entity,


### PR DESCRIPTION
# Objective

- Avoid a panic when an entity has `ColliderConstructor[Hierarchy]` but is despawned soon. 
 
The command that inserts the new `Collider` or deletes the old `ColliderConstructor...` raises a panic if the target entity happened to be removed.

Inserting case:
```
ncountered an error in command `<bevy_ecs::system::commands::entity_command::insert<avian3d::collision::collider::parry::Collider>::{{closure}} as bevy_ecs::error::command_handling::CommandWithEntity<core::result::Result<(), bevy_ecs::world::error::EntityMutableFetchError>>>::with_entity::{{closure}}`: Entity despawned: The entity with ID 792v7 is invalid; its index now has generation 8.
Note that interacting with a despawned entity is the most common cause of this error but there are others

    If you were attempting to apply a command to this entity,
    and want to handle this error gracefully, consider using `EntityCommands::queue_handled` or `queue_silenced`.
   0: from<bevy_ecs::world::error::EntityMutableFetchError>
             at /home/ejs/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.1/src/error/bevy_error.rs:115:28
   1: into<bevy_ecs::world::error::EntityMutableFetchError, bevy_ecs::error::bevy_error::BevyError>
             at /home/ejs/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:778:9
   2: {closure#0}<bevy_ecs::error::command_handling::{impl#3}::with_entity::{closure_env#0}<bevy_ecs::system::commands::entity_command::insert::{closure_env#0}<avian3d::collision::collider::parry::Collider>>, (), bevy_ecs::world::error::EntityMutableFetchError>
             at /home/ejs/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.1/src/error/command_handling.rs:48:21
   3: apply<bevy_ecs::error::command_handling::{impl#0}::handle_error::{closure_env#0}<bevy_ecs::error::command_handling::{impl#3}::with_entity::{closure_env#0}<bevy_ecs::system::commands::entity_command::insert::{closure_env#0}<avian3d::collision::collider::parry::Collider>>, (), bevy_ecs::world::error::EntityMutableFetchError>, ()>
             at /home/ejs/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.1/src/system/commands/command.rs:62:9
   4: {closure#0}<bevy_ecs::error::command_handling::{impl#0}::handle_error::{closure_env#0}<bevy_ecs::error::command_handling::{impl#3}::with_entity::{closure_env#0}<bevy_ecs::system::commands::entity_command::insert::{closure_env#0}<avian3d::collision::collider::parry::Collider>>, (), bevy_ecs::world::error::EntityMutableFetchError>>
```

Deleting case:
```
2026-06-05T16:34:37.047191Z  WARN bevy_ecs::error::handler: Encountered an error in command `<bevy_ecs::system::commands::entity_command::remove<avian3d::collision::collider::constructor::ColliderConstructor>::{{closure}} as bevy_ecs::error::command_handling::CommandWithEntity<core::result::Result<(), bevy_ecs::world::error::EntityMutableFetchError>>>::with_entity::{{closure}}`: Entity despawned: The entity with ID 861v1 is invalid; its index now has generation 2.
Note that interacting with a despawned entity is the most common cause of this error but there are others

    If you were attempting to apply a command to this entity,
    and want to handle this error gracefully, consider using `EntityCommands::queue_handled` or `queue_silenced`.
   0: from<bevy_ecs::world::error::EntityMutableFetchError>
             at /home/ejs/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.1/src/error/bevy_error.rs:115:28
   1: into<bevy_ecs::world::error::EntityMutableFetchError, bevy_ecs::error::bevy_error::BevyError>
             at /home/ejs/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:778:9
   2: {closure#0}<bevy_ecs::error::command_handling::{impl#3}::with_entity::{closure_env#0}<bevy_ecs::system::commands::entity_command::remove::{closure_env#0}<avian3d::collision::collider::constructor::ColliderConstructor>>, (), bevy_ecs::world::error::EntityMutableFetchError>
             at /home/ejs/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.1/src/error/command_handling.rs:36:21
...
```

## Solution

- Use `try_insert` and `try_remove` as recommended.

## Testing

- Did you test these changes? If so, how?

Tested with my own project which was triggering this.

