### PR TITLE
avian_derive: remove proc-macro-error2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,10 +436,10 @@ dependencies = [
 name = "avian_derive"
 version = "0.2.2"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -4560,28 +4560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5161,6 +5139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5401,6 +5388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5529,6 +5522,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5578,6 +5586,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -5661,6 +5675,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro2 = "1.0.78"
 proc-macro-error2 = "2.0"
 quote = "1.0"
 syn = "2.0"
+
+[dev-dependencies]
+trybuild = "1"

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -13,8 +13,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
-proc-macro2 = "1.0.78"
-proc-macro-error2 = "2.0"
+proc-macro2 = "1.0.106"
 quote = "1.0"
 syn = "2.0"
 

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -2,7 +2,6 @@
 
 use proc_macro::TokenStream;
 
-use proc_macro_error2::{abort, emit_error, proc_macro_error};
 use quote::quote;
 use syn::{Data, DeriveInput, parse_macro_input, spanned::Spanned};
 
@@ -39,39 +38,63 @@ use syn::{Data, DeriveInput, parse_macro_input, spanned::Spanned};
 /// // The `GameLayer::Ground` layer is the fourth layer, so its bit value is `1 << 3`.
 /// assert_eq!(GameLayer::Ground.to_bits(), 1 << 3);
 /// ```
-#[proc_macro_error]
 #[proc_macro_derive(PhysicsLayer)]
 pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+    match expand_physics_layer(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Accumulates a non-fatal diagnostic, combining it with any already collected so that
+/// `to_compile_error()` later emits all of them together (the old `emit_error!` behavior).
+fn push_err(acc: &mut Option<syn::Error>, err: syn::Error) {
+    match acc {
+        Some(existing) => existing.combine(err),
+        none => *none = Some(err),
+    }
+}
+
+fn expand_physics_layer(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let enum_ident = input.ident;
 
-    fn non_enum_item_error(span: proc_macro2::Span) -> TokenStream {
-        abort!(span, "only enums can automatically derive `PhysicsLayer`");
-    }
+    // Wrong item kind: nothing else can be computed, so this is fatal (was `abort!`).
     let variants = match &input.data {
         Data::Enum(data) => &data.variants,
         Data::Struct(data) => {
-            return non_enum_item_error(data.struct_token.span);
+            return Err(syn::Error::new(
+                data.struct_token.span,
+                "only enums can automatically derive `PhysicsLayer`",
+            ));
         }
         Data::Union(data) => {
-            return non_enum_item_error(data.union_token.span);
+            return Err(syn::Error::new(
+                data.union_token.span,
+                "only enums can automatically derive `PhysicsLayer`",
+            ));
         }
     };
 
     if variants.len() > 32 {
-        emit_error!(
-            enum_ident,
-            "`PhysicsLayer` only supports a maximum of 32 layers"
-        );
+        return Err(syn::Error::new_spanned(
+            &enum_ident,
+            "`PhysicsLayer` only supports a maximum of 32 layers",
+        ));
     }
 
-    let mut default_variant_index = None;
+    // Non-fatal diagnostics are collected here so several can be reported at once.
+    let mut errors: Option<syn::Error> = None;
 
+    let mut default_variant_index = None;
     for (i, variant) in variants.iter().enumerate() {
         for attr in variant.attrs.iter() {
             if attr.path().is_ident("default") {
                 if default_variant_index.is_some() {
-                    emit_error!(enum_ident, "multiple defaults");
+                    push_err(
+                        &mut errors,
+                        syn::Error::new_spanned(&enum_ident, "multiple defaults"),
+                    );
                     break;
                 }
                 default_variant_index = Some(i);
@@ -79,12 +102,18 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
         }
     }
 
+    // No default variant: required for the rest of the logic, so fatal (was `abort!` + note).
     let Some(default_variant_index) = default_variant_index else {
-        abort!(
-            enum_ident,
-            "`PhysicsLayer` enums must derive `Default` and have a variant annotated with the `#[default]` attribute.";
-            note = "Manually implementing `Default` using `impl Default for FooLayer` is not supported."
+        let mut err = syn::Error::new_spanned(
+            &enum_ident,
+            "`PhysicsLayer` enums must derive `Default` and have a variant annotated with the \
+             `#[default]` attribute.\n\nnote: Manually implementing `Default` using \
+             `impl Default for FooLayer` is not supported.",
         );
+        if let Some(existing) = errors {
+            err.combine(existing);
+        }
+        return Err(err);
     };
 
     // Move the default variant to the front (this probably isn't the best way to do this)
@@ -92,29 +121,27 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
     let default_variant = variants.remove(default_variant_index);
     variants.insert(0, default_variant);
 
-    let to_bits_result: Result<Vec<_>, _> = variants
-        .iter()
-        .enumerate()
-        .map(|(index, variant)| {
-            if !variant.fields.is_empty() {
-                return Err(variant.fields.span());
-            }
-            let bits: u32 = 1 << index;
-            let ident = &variant.ident;
-
-            Ok(quote! { #enum_ident::#ident => #bits, })
-        })
-        .collect();
-
-    let to_bits = match to_bits_result {
-        Ok(tokens) => tokens,
-        Err(span) => {
-            abort!(
-                span,
-                "can only derive `PhysicsLayer` for enums without fields"
+    let mut to_bits = Vec::with_capacity(variants.len());
+    for (index, variant) in variants.iter().enumerate() {
+        if !variant.fields.is_empty() {
+            push_err(
+                &mut errors,
+                syn::Error::new(
+                    variant.fields.span(),
+                    "can only derive `PhysicsLayer` for enums without fields",
+                ),
             );
+            continue;
         }
-    };
+        let bits: u32 = 1 << index;
+        let ident = &variant.ident;
+        to_bits.push(quote! { #enum_ident::#ident => #bits, });
+    }
+
+    // If anything was collected along the way, fail now with all of it.
+    if let Some(err) = errors {
+        return Err(err);
+    }
 
     let all_bits: u32 = if variants.len() == 32 {
         0xffffffff
@@ -122,7 +149,7 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
         (1 << variants.len()) - 1
     };
 
-    let expanded = quote! {
+    Ok(quote! {
         impl PhysicsLayer for #enum_ident {
             fn all_bits() -> u32 {
                 #all_bits
@@ -134,7 +161,5 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
                 }
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    })
 }

--- a/crates/avian_derive/tests/derive.rs
+++ b/crates/avian_derive/tests/derive.rs
@@ -1,0 +1,11 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive/happy_path.rs");
+    t.compile_fail("tests/derive/struct_derive.rs");
+    t.compile_fail("tests/derive/union_derive.rs");
+    t.compile_fail("tests/derive/too_many_layers.rs");
+    t.compile_fail("tests/derive/multiple_defaults.rs");
+    t.compile_fail("tests/derive/no_default.rs");
+    t.compile_fail("tests/derive/variant_with_fields.rs");
+}

--- a/crates/avian_derive/tests/derive/happy_path.rs
+++ b/crates/avian_derive/tests/derive/happy_path.rs
@@ -1,0 +1,23 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer, Default)]
+enum GameLayer {
+    #[default]
+    Default,
+    Player,
+    Enemy,
+    Ground,
+}
+
+fn main() {
+    assert_eq!(GameLayer::Default.to_bits(), 1 << 0);
+    assert_eq!(GameLayer::Player.to_bits(), 1 << 1);
+    assert_eq!(GameLayer::Enemy.to_bits(), 1 << 2);
+    assert_eq!(GameLayer::Ground.to_bits(), 1 << 3);
+    assert_eq!(GameLayer::all_bits(), 0b1111);
+}

--- a/crates/avian_derive/tests/derive/multiple_defaults.rs
+++ b/crates/avian_derive/tests/derive/multiple_defaults.rs
@@ -1,0 +1,16 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer, Default)]
+enum MultiDefault {
+    #[default]
+    A,
+    #[default]
+    B,
+}
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/multiple_defaults.stderr
+++ b/crates/avian_derive/tests/derive/multiple_defaults.stderr
@@ -1,0 +1,19 @@
+error: multiple defaults
+ --> tests/derive/multiple_defaults.rs:9:6
+  |
+9 | enum MultiDefault {
+  |      ^^^^^^^^^^^^
+
+error: multiple declared defaults
+  --> tests/derive/multiple_defaults.rs:8:24
+   |
+ 8 | #[derive(PhysicsLayer, Default)]
+   |                        ^^^^^^^
+...
+11 |     A,
+   |     - first default
+12 |     #[default]
+13 |     B,
+   |     - additional default
+   |
+   = note: only one variant can be default

--- a/crates/avian_derive/tests/derive/no_default.rs
+++ b/crates/avian_derive/tests/derive/no_default.rs
@@ -1,0 +1,14 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer)]
+enum NoDefault {
+    A,
+    B,
+}
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/no_default.stderr
+++ b/crates/avian_derive/tests/derive/no_default.stderr
@@ -1,0 +1,8 @@
+error: `PhysicsLayer` enums must derive `Default` and have a variant annotated with the `#[default]` attribute.
+
+         = note: Manually implementing `Default` using `impl Default for FooLayer` is not supported.
+
+ --> tests/derive/no_default.rs:9:6
+  |
+9 | enum NoDefault {
+  |      ^^^^^^^^^

--- a/crates/avian_derive/tests/derive/no_default.stderr
+++ b/crates/avian_derive/tests/derive/no_default.stderr
@@ -1,7 +1,6 @@
 error: `PhysicsLayer` enums must derive `Default` and have a variant annotated with the `#[default]` attribute.
 
-         = note: Manually implementing `Default` using `impl Default for FooLayer` is not supported.
-
+       note: Manually implementing `Default` using `impl Default for FooLayer` is not supported.
  --> tests/derive/no_default.rs:9:6
   |
 9 | enum NoDefault {

--- a/crates/avian_derive/tests/derive/struct_derive.rs
+++ b/crates/avian_derive/tests/derive/struct_derive.rs
@@ -1,0 +1,11 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer)]
+struct NotAnEnum;
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/struct_derive.stderr
+++ b/crates/avian_derive/tests/derive/struct_derive.stderr
@@ -1,0 +1,5 @@
+error: only enums can automatically derive `PhysicsLayer`
+ --> tests/derive/struct_derive.rs:9:1
+  |
+9 | struct NotAnEnum;
+  | ^^^^^^

--- a/crates/avian_derive/tests/derive/too_many_layers.rs
+++ b/crates/avian_derive/tests/derive/too_many_layers.rs
@@ -1,0 +1,17 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer, Default)]
+enum TooManyLayers {
+    #[default]
+    L00, L01, L02, L03, L04, L05, L06, L07,
+    L08, L09, L10, L11, L12, L13, L14, L15,
+    L16, L17, L18, L19, L20, L21, L22, L23,
+    L24, L25, L26, L27, L28, L29, L30, L31, L32,
+}
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/too_many_layers.stderr
+++ b/crates/avian_derive/tests/derive/too_many_layers.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> tests/derive/too_many_layers.rs:8:10
+error: `PhysicsLayer` only supports a maximum of 32 layers
+ --> tests/derive/too_many_layers.rs:9:6
   |
-8 | #[derive(PhysicsLayer, Default)]
-  |          ^^^^^^^^^^^^
-  |
-  = help: message: attempt to shift left with overflow
+9 | enum TooManyLayers {
+  |      ^^^^^^^^^^^^^

--- a/crates/avian_derive/tests/derive/too_many_layers.stderr
+++ b/crates/avian_derive/tests/derive/too_many_layers.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> tests/derive/too_many_layers.rs:8:10
+  |
+8 | #[derive(PhysicsLayer, Default)]
+  |          ^^^^^^^^^^^^
+  |
+  = help: message: attempt to shift left with overflow

--- a/crates/avian_derive/tests/derive/union_derive.rs
+++ b/crates/avian_derive/tests/derive/union_derive.rs
@@ -1,0 +1,14 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer)]
+union AlsoNotAnEnum {
+    x: u32,
+    y: f32,
+}
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/union_derive.stderr
+++ b/crates/avian_derive/tests/derive/union_derive.stderr
@@ -1,0 +1,5 @@
+error: only enums can automatically derive `PhysicsLayer`
+ --> tests/derive/union_derive.rs:9:1
+  |
+9 | union AlsoNotAnEnum {
+  | ^^^^^

--- a/crates/avian_derive/tests/derive/variant_with_fields.rs
+++ b/crates/avian_derive/tests/derive/variant_with_fields.rs
@@ -1,0 +1,15 @@
+use avian_derive::PhysicsLayer;
+
+trait PhysicsLayer {
+    fn all_bits() -> u32;
+    fn to_bits(&self) -> u32;
+}
+
+#[derive(PhysicsLayer, Default)]
+enum WithFields {
+    #[default]
+    Good,
+    Bad(u32),
+}
+
+fn main() {}

--- a/crates/avian_derive/tests/derive/variant_with_fields.stderr
+++ b/crates/avian_derive/tests/derive/variant_with_fields.stderr
@@ -1,0 +1,5 @@
+error: can only derive `PhysicsLayer` for enums without fields
+  --> tests/derive/variant_with_fields.rs:12:8
+   |
+12 |     Bad(u32),
+   |        ^^^^^


### PR DESCRIPTION
# Objective

Fix compiler warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

<details><summary>Full output of the suggested command:</summary>
<p>

```
The following warnings were discovered during the build. These warnings are an
indication that the packages contain code that will become an error in a
future release of Rust. These warnings typically cover changes to close
soundness problems, unintended or undocumented behavior, or critical problems
that cannot be fixed in a backwards-compatible fashion, and are not expected
to be in wide use.

Each warning should contain a link for more information on what the warning
means and how to resolve it.

to solve this problem, you can try the following approaches:

- ensure the maintainers know of this problem (e.g. creating a bug report if needed)
or even helping with a fix (e.g. by creating a pull request)
  - proc-macro-error2@2.0.1
  - repository: https://github.com/GnomedDev/proc-macro-error-2
  - detailed warning command: `cargo report future-incompatibilities --id 1 --package proc-macro-error2@2.0.1`

- use your own version of the dependency with the `[patch]` section in `Cargo.toml`
For more information, see:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

The package `proc-macro-error2 v2.0.1` currently triggers the following future incompatibility lints:
> warning[E0365]: extern crate `proc_macro` is private and cannot be re-exported
>    --> /home/pop/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proc-macro-error2-2.0.1/src/lib.rs:494:13
>     |
> 494 |     pub use proc_macro;
>     |             ^^^^^^^^^^
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
> help: consider making the `extern crate` item publicly accessible
>     |
> 277 | pub extern crate proc_macro;
>     | +++
> 
```

</p>
</details> 

## Solution

Removes the dependency on proc-macro-error2.
The main reason is that we _just_ a year ago removed `proc-macro-error` (https://github.com/avianphysics/avian/pull/627) because _that_ was unmaintained.
The dependency isn't _that_ big, and Avian's use of it isn't _that_ robust, so I think we can just write our own error handling in `avian_derive`.

## Testing

I added some regression tests to `avian_derive` using `trybuild`.

Below are the tests running _before_ updating the test fixtures, so they show the change in behavior as failures. The tests on the branch as-is pass, this is just informational that the output of the macro during failures has changed.

<details><summary>cargo test output for avian_derive</summary>
<p>

```
test tests/derive/happy_path.rs [should pass] ... ok
test tests/derive/struct_derive.rs [should fail to compile] ... ok
test tests/derive/union_derive.rs [should fail to compile] ... ok
test tests/derive/too_many_layers.rs [should fail to compile] ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: proc-macro derive panicked
 --> tests/derive/too_many_layers.rs:8:10
  |
8 | #[derive(PhysicsLayer, Default)]
  |          ^^^^^^^^^^^^
  |
  = help: message: attempt to shift left with overflow
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: `PhysicsLayer` only supports a maximum of 32 layers
 --> tests/derive/too_many_layers.rs:9:6
  |
9 | enum TooManyLayers {
  |      ^^^^^^^^^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite

test tests/derive/multiple_defaults.rs [should fail to compile] ... ok
test tests/derive/no_default.rs [should fail to compile] ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: `PhysicsLayer` enums must derive `Default` and have a variant annotated with the `#[default]` attribute.

         = note: Manually implementing `Default` using `impl Default for FooLayer` is not supported.

 --> tests/derive/no_default.rs:9:6
  |
9 | enum NoDefault {
  |      ^^^^^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: `PhysicsLayer` enums must derive `Default` and have a variant annotated with the `#[default]` attribute.

       note: Manually implementing `Default` using `impl Default for FooLayer` is not supported.
 --> tests/derive/no_default.rs:9:6
  |
9 | enum NoDefault {
  |      ^^^^^^^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite

test tests/derive/variant_with_fields.rs [should fail to compile] ... ok


error: test failed, to rerun pass `--test derive`
```

</p>
</details> 

## AI Disclosure

Yes, I wrote this with the assistance of Claude Code.
I promise this isn't slop, it's just better at navigating Macros than I am.