### PR TITLE
Fast CCD without ghost collisions (Box2D-inspired)

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -125,7 +125,18 @@ name = "kinematic_character_2d"
 required-features = ["2d", "default-collider"]
 
 [[example]]
-name = "ccd"
+name = "spinners"
+path = "examples/ccd/spinners.rs"
+required-features = ["2d", "default-collider"]
+
+[[example]]
+name = "projectile_bounce"
+path = "examples/ccd/projectile_bounce.rs"
+required-features = ["2d", "default-collider"]
+
+[[example]]
+name = "speculative_ghost"
+path = "examples/ccd/speculative_ghost.rs"
 required-features = ["2d", "default-collider"]
 
 [[example]]

--- a/crates/avian2d/examples/ccd.rs
+++ b/crates/avian2d/examples/ccd.rs
@@ -1,25 +1,17 @@
-//! Demonstrates Continuous Collision Detection (CCD) to prevent tunneling.
+//! Demonstrates Continuous Collision Detection (CCD) to prevent tunneling
+//! when fast-moving balls collide with fast-spinning thin objects.
 //!
-//! Two forms of CCD are supported:
+//! Two modes can be toggled between:
 //!
-//! 1. Speculative collision
-//!     - Predicts approximate contacts before they happen.
-//!     - Enabled by default for all rigid bodies.
-//!     - Very efficient and relatively reliable.
-//!     - Can sometimes cause ghost collisions.
-//!     - Can sometimes miss collisions against objects spinning at very high speeds.
+//! 1. Linear: Only considers translational motion.
+//! 2. Non-linear: Considers both translational and rotational motion. More expensive.
 //!
-//! 2. Swept CCD
-//!     - Sweeps colliders from their previous positions to their current ones,
-//!       and if a hit is found, moves the bodies to the time of impact.
-//!     - Enabled for rigid bodies with the `SweptCcd` component.
-//!     - Can prevent tunneling completely. More reliable than speculative collision.
-//!     - More expensive than speculative collision.
-//!     - Can cause "time loss" where bodies appear to stop for a moment
-//!       because they are essentially brought back in time.
-//!     - Two modes:
-//!         1. Linear: Only considers translational motion.
-//!         2. Non-linear: Considers both translation and rotation. More expensive.
+//! This example also demonstrates one CCD problem known as "time loss".
+//! To hit the balls correctly, the spinners need to stop at the first time of impact,
+//! causing them to lose the rest of their rotation for that frame. This can make
+//! the spinners look like they are stuttering, especially at high speeds and with
+//! many objects to collide with. A fix for this would require a substepping CCD solver,
+//! which is not currently implemented in Avian due to its high overhead and complexity.
 
 use avian2d::{math::*, prelude::*};
 use bevy::prelude::*;
@@ -34,6 +26,7 @@ fn main() {
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Gravity(Vector::NEG_Y * 9.81 * 100.0))
+        .init_resource::<ActiveSweepMode>()
         .add_systems(Startup, setup)
         .add_systems(Update, update_config)
         .add_systems(FixedUpdate, spawn_balls)
@@ -41,42 +34,74 @@ fn main() {
 }
 
 #[derive(Component)]
-struct SpeculativeCollisionEnabledText;
+struct SweepModeText;
 
-#[derive(Component)]
-struct SweptCcdModeText;
+/// The current CCD sweep mode configuration.
+#[derive(Resource, Clone, Copy, Default, PartialEq)]
+enum ActiveSweepMode {
+    #[default]
+    NonLinear,
+    Linear,
+    Off,
+}
+
+impl ActiveSweepMode {
+    fn ccd_settings(self) -> CcdSettings {
+        match self {
+            ActiveSweepMode::NonLinear => CcdSettings::default().with_include_dynamic(true),
+            ActiveSweepMode::Linear => CcdSettings::default()
+                .with_mode(SweepMode::Linear)
+                .with_include_dynamic(true),
+            ActiveSweepMode::Off => CcdSettings::default().with_enabled(false),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            ActiveSweepMode::NonLinear => "Non-linear (considers both translation and rotation)",
+            ActiveSweepMode::Linear => "Linear (considers only translation)",
+            ActiveSweepMode::Off => "Off (discrete collision detection only)",
+        }
+    }
+}
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    // Add two kinematic bodies spinning at high speeds.
+    let sweep_mode = ActiveSweepMode::default();
+    let ccd_settings = sweep_mode.ccd_settings();
+
+    // Add two dynamic bodies spinning at high speeds. Their translation is locked and they have a
+    // high dominance, so they spin in place without being pushed around.
     commands.spawn((
+        Name::new("Spinner 1"),
+        Transform::from_xyz(-200.1, -200.0, 0.0),
+        RigidBody::Dynamic,
+        LockedAxes::TRANSLATION_LOCKED,
+        AngularVelocity(25.0),
+        Dominance(1),
+        Collider::rectangle(1.0, 400.0),
+        ccd_settings,
         Sprite {
             color: Color::srgb(0.7, 0.7, 0.8),
             custom_size: Some(Vec2::new(1.0, 400.0)),
             ..default()
         },
-        Transform::from_xyz(-200.0, -200.0, 0.0),
-        RigidBody::Kinematic,
-        AngularVelocity(25.0),
-        Collider::rectangle(1.0, 400.0),
-        // Enable swept CCD for this body. Considers both translational and rotational motion by default.
-        // This could also be on the ball projectiles.
-        SweptCcd::default(),
     ));
     commands.spawn((
+        Name::new("Spinner 2"),
+        Transform::from_xyz(200.1, -200.0, 0.0),
+        RigidBody::Dynamic,
+        LockedAxes::TRANSLATION_LOCKED,
+        AngularVelocity(-25.0),
+        Dominance(1),
+        Collider::rectangle(1.0, 400.0),
+        ccd_settings,
         Sprite {
             color: Color::srgb(0.7, 0.7, 0.8),
             custom_size: Some(Vec2::new(1.0, 400.0)),
             ..default()
         },
-        Transform::from_xyz(200.0, -200.0, 0.0),
-        RigidBody::Kinematic,
-        AngularVelocity(-25.0),
-        Collider::rectangle(1.0, 400.0),
-        // Enable swept CCD for this body. Considers both translational and rotational motion by default.
-        // This could also be on the ball projectiles.
-        SweptCcd::default(),
     ));
 
     // Setup help text.
@@ -84,42 +109,29 @@ fn setup(mut commands: Commands) {
         font_size: 20.0,
         ..default()
     };
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(30.0),
-                left: Val::Px(10.0),
-                ..default()
-            },
-        ))
-        .with_children(|children| {
-            children.spawn((TextSpan::new("(1) Speculative Collision: "), font.clone()));
-            children.spawn((
-                TextSpan::new("On"),
-                font.clone(),
-                SpeculativeCollisionEnabledText,
-            ));
-        });
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(50.0),
-                left: Val::Px(10.0),
-                ..default()
-            },
-        ))
-        .with_children(|children| {
-            children.spawn((TextSpan::new("(2) Swept CCD: "), font.clone()));
-            children.spawn((
-                TextSpan::new("Non-linear (considers both translation and rotation)"),
-                font,
-                SweptCcdModeText,
-            ));
-        });
+    commands.spawn((
+        Text::new("Press Space to toggle CCD mode"),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(10.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+        font.clone(),
+    ));
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(40.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+        children![
+            (TextSpan::new("CCD: "), font.clone()),
+            (TextSpan::new(sweep_mode.label()), font, SweepModeText),
+        ],
+    ));
 }
 
 /// Spawns balls moving at the spinning objects at high speeds.
@@ -128,6 +140,7 @@ fn spawn_balls(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
     time: Res<Time<Physics>>,
+    sweep_mode: Res<ActiveSweepMode>,
 ) {
     let circle = Circle::new(2.0);
 
@@ -136,6 +149,7 @@ fn spawn_balls(
     let direction = Vector::new(cos, sin).rotate(Vector::X);
 
     commands.spawn((
+        Name::new("Ball"),
         Mesh2d(meshes.add(circle)),
         MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
         Transform::from_xyz(0.0, 350.0, 0.0),
@@ -143,62 +157,30 @@ fn spawn_balls(
         LinearVelocity(2000.0 * direction),
         Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
         Collider::from(circle),
+        sweep_mode.ccd_settings(),
     ));
 }
 
 fn update_config(
-    speculative_collision_text: Single<
-        &mut TextSpan,
-        (
-            With<SpeculativeCollisionEnabledText>,
-            Without<SweptCcdModeText>,
-        ),
-    >,
-    swept_ccd_mode_text: Single<
-        &mut TextSpan,
-        (
-            With<SweptCcdModeText>,
-            Without<SpeculativeCollisionEnabledText>,
-        ),
-    >,
+    sweep_mode_text: Single<&mut TextSpan, With<SweepModeText>>,
     keys: Res<ButtonInput<KeyCode>>,
-    mut narrow_phase_config: ResMut<NarrowPhaseConfig>,
-    mut ccd_bodies: Query<&mut SweptCcd>,
+    mut sweep_mode: ResMut<ActiveSweepMode>,
+    balls: Query<Entity, With<Collider>>,
+    mut commands: Commands,
 ) {
-    // Toggle speculative collision.
-    // Note: This sets the default speculative margin, but it can be overridden
-    //       for individual entities with the `SpeculativeMargin` component.
-    if keys.just_pressed(KeyCode::Digit1) {
-        let mut text = speculative_collision_text;
-        if narrow_phase_config.default_speculative_margin == Scalar::MAX {
-            narrow_phase_config.default_speculative_margin = 0.0;
-            text.0 = "Off".to_string();
-        } else {
-            narrow_phase_config.default_speculative_margin = Scalar::MAX;
-            text.0 = "On".to_string();
-        }
-    }
+    // Cycle the CCD configuration for the colliders.
+    if keys.just_pressed(KeyCode::Space) {
+        let mut text = sweep_mode_text;
+        *sweep_mode = match *sweep_mode {
+            ActiveSweepMode::NonLinear => ActiveSweepMode::Linear,
+            ActiveSweepMode::Linear => ActiveSweepMode::Off,
+            ActiveSweepMode::Off => ActiveSweepMode::NonLinear,
+        };
+        text.0 = sweep_mode.label().to_string();
 
-    // Change the sweep mode and whether swept CCD is enabled.
-    if keys.just_pressed(KeyCode::Digit2) {
-        let mut text = swept_ccd_mode_text;
-        for mut swept_ccd in &mut ccd_bodies {
-            if swept_ccd.mode == SweepMode::NonLinear && swept_ccd.include_dynamic {
-                swept_ccd.mode = SweepMode::Linear;
-                text.0 = "Linear (considers only translation)".to_string();
-            } else if swept_ccd.mode == SweepMode::Linear {
-                // Disable swept CCD for collisions against dynamic bodies.
-                // To disable it completely, you should remove the component.
-                swept_ccd.include_dynamic = false;
-
-                swept_ccd.mode = SweepMode::NonLinear;
-                text.0 = "Off".to_string();
-            } else {
-                // Enable swept CCD again.
-                swept_ccd.include_dynamic = true;
-
-                text.0 = "Non-linear (considers both translation and rotation)".to_string();
-            }
+        // Update the existing colliders to use the new configuration.
+        for entity in &balls {
+            commands.entity(entity).insert(sweep_mode.ccd_settings());
         }
     }
 }

--- a/crates/avian2d/examples/ccd/projectile_bounce.rs
+++ b/crates/avian2d/examples/ccd/projectile_bounce.rs
@@ -70,10 +70,10 @@ fn setup_scene(
             Restitution::new(1.0).with_combine_rule(CoefficientCombine::Max),
             Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
             LinearVelocity(velocity),
-            // Sweep against other dynamic bodies.
-            CcdSettings::default().with_include_dynamic(true),
+            // Sweep against other dynamic bodies too.
+            SweptCcd::default().with_filter(CcdFilter::ALL),
             // Enable speculative CCD and therefore AABB expansion so that
-            // the two projectiles can find each other with swept CCD.
+            // the two projectiles can find each other.
             SpeculativeCcd::default(),
             Mesh2d(mesh.clone()),
             MeshMaterial2d(materials.add(color)),

--- a/crates/avian2d/examples/ccd/projectile_bounce.rs
+++ b/crates/avian2d/examples/ccd/projectile_bounce.rs
@@ -1,0 +1,118 @@
+//! Demonstrates Continuous Collision Detection (CCD) between two fast-moving
+//! dynamic bodies that bounce off each other.
+//!
+//! Many physics engines only support CCD for fast-moving bodies colliding
+//! with static bodies. Avian additionally supports CCD for dynamic-kinematic
+//! pairs automatically, and opt-in CCD for dynamic-dynamic collisions.
+//!
+//! One problem with CCD for dynamic-dynamic pairs is that because the AABBs
+//! are typically tight, a sweep query for one body would miss the other body entirely
+//! if the other body is not already in the path of the sweep. Avian solves this
+//! with an opt-in [`SpeculativeAabb`] component that expands the body's AABB based on
+//! its velocity, allowing the sweeps of both bodies to find each other and trigger CCD.
+//!
+//! Because this can lead to more contact pairs being generated in the broad phase,
+//! the velocity-based AABB expansion is opt-in, but it can be useful for fast-moving
+//! bodies that do need to collide with each other at high speeds, such as projectiles.
+
+use avian2d::{math::*, prelude::*};
+use bevy::{camera::ScalingMode, input::common_conditions::input_just_pressed, prelude::*};
+use examples_common_2d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            PhysicsPlugins::default(),
+            ExampleCommonPlugin,
+        ))
+        .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
+        // Zero gravity, so the circles travel in straight lines until they collide.
+        .insert_resource(Gravity(Vector::ZERO))
+        .add_systems(Startup, (setup_camera, setup_scene))
+        .add_systems(
+            Update,
+            reset_scene.run_if(input_just_pressed(KeyCode::KeyR)),
+        )
+        .run();
+}
+
+const START_DISTANCE: f32 = 9.0;
+const SPEED: Scalar = 150.0;
+const RADIUS: f32 = 0.5;
+
+fn setup_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera2d,
+        Projection::Orthographic(OrthographicProjection {
+            scaling_mode: ScalingMode::FixedHorizontal {
+                viewport_width: 24.0,
+            },
+            ..OrthographicProjection::default_2d()
+        }),
+    ));
+}
+
+fn setup_scene(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    let circle = Circle::new(RADIUS);
+    let mesh = meshes.add(circle);
+
+    let mut projectile = |position: Vec2, velocity: Vector, color: Color| {
+        (
+            Name::new("Projectile"),
+            Transform::from_xyz(position.x, position.y, 0.0),
+            RigidBody::Dynamic,
+            Collider::from(circle),
+            Restitution::new(1.0).with_combine_rule(CoefficientCombine::Max),
+            Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
+            LinearVelocity(velocity),
+            // Sweep against other dynamic bodies.
+            CcdSettings::default().with_include_dynamic(true),
+            // Enable velocity-based AABB expansion so that the two projectiles
+            // can find each other with their sweeps and trigger CCD.
+            SpeculativeAabb,
+            Mesh2d(mesh.clone()),
+            MeshMaterial2d(materials.add(color)),
+        )
+    };
+
+    // Comes in from the left, moving right.
+    commands.spawn(projectile(
+        Vec2::new(-START_DISTANCE, 0.0),
+        Vector::X * SPEED,
+        Color::srgb(0.2, 0.7, 0.9),
+    ));
+
+    // Comes in from the bottom, moving up.
+    commands.spawn(projectile(
+        Vec2::new(0.0, -START_DISTANCE),
+        Vector::Y * SPEED,
+        Color::srgb(0.9, 0.3, 0.3),
+    ));
+
+    // Instruction text
+    commands.spawn((
+        Text::new("Press R to reset"),
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(10.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+    ));
+}
+
+fn reset_scene(mut commands: Commands, bodies: Query<Entity, With<RigidBody>>) {
+    for entity in &bodies {
+        commands.entity(entity).despawn();
+    }
+    commands.run_system_cached(setup_scene);
+}

--- a/crates/avian2d/examples/ccd/projectile_bounce.rs
+++ b/crates/avian2d/examples/ccd/projectile_bounce.rs
@@ -8,7 +8,7 @@
 //! One problem with CCD for dynamic-dynamic pairs is that because the AABBs
 //! are typically tight, a sweep query for one body would miss the other body entirely
 //! if the other body is not already in the path of the sweep. Avian solves this
-//! with an opt-in [`SpeculativeAabb`] component that expands the body's AABB based on
+//! with an opt-in [`SpeculativeCcd`] component that expands the body's AABB based on
 //! its velocity, allowing the sweeps of both bodies to find each other and trigger CCD.
 //!
 //! Because this can lead to more contact pairs being generated in the broad phase,
@@ -72,9 +72,9 @@ fn setup_scene(
             LinearVelocity(velocity),
             // Sweep against other dynamic bodies.
             CcdSettings::default().with_include_dynamic(true),
-            // Enable velocity-based AABB expansion so that the two projectiles
-            // can find each other with their sweeps and trigger CCD.
-            SpeculativeAabb,
+            // Enable speculative CCD and therefore AABB expansion so that
+            // the two projectiles can find each other with swept CCD.
+            SpeculativeCcd::default(),
             Mesh2d(mesh.clone()),
             MeshMaterial2d(materials.add(color)),
         )

--- a/crates/avian2d/examples/ccd/speculative_ghost.rs
+++ b/crates/avian2d/examples/ccd/speculative_ghost.rs
@@ -7,10 +7,14 @@
 //! an effectively infinite contact plane, even if the surface does not actually extend
 //! to intersect the body's path.
 //!
-//! Avian keeps the speculative contact distance very small and AABBs tight, and primarily relies
-//! on sweep-based CCD to prevent tunneling for fast-moving bodies. This avoids ghost collisions
-//! (except at *very* small distances; don't expect pixel-perfect collisions) while still
-//! preventing tunneling or deep overlaps for fast-moving bodies.
+//! Avian keeps the speculative contact distance very small and AABBs tight by default,
+//! and primarily relies on sweep-based CCD to prevent tunneling for fast-moving bodies.
+//! This avoids ghost collisions (except at *very* small distances), while still preventing
+//! tunneling or deep overlaps for fast-moving bodies.
+//!
+//! Avian does also support opt-in speculative collision with a larger speculative
+//! contact distance via the [`SpeculativeCcd`] component. If you add it, you will
+//! start seeing ghost collisions at high speeds again.
 //!
 //! This example is based on the SpeculativeGhost sample in Box2D.
 
@@ -80,6 +84,8 @@ fn setup_scene(
     commands.spawn((
         Name::new("Dynamic Box"),
         RigidBody::Dynamic,
+        // If you uncomment this, you will see a ghost collision
+        // SpeculativeCcd::default(),
         Collider::rectangle(0.5, 0.5),
         Transform::from_xyz(0.015, 2.515, 0.0),
         LinearVelocity(Vec2::new(0.1 * 3.1 * HZ, -0.1 * 3.1 * HZ)),

--- a/crates/avian2d/examples/ccd/speculative_ghost.rs
+++ b/crates/avian2d/examples/ccd/speculative_ghost.rs
@@ -1,0 +1,113 @@
+//! Demonstrates that even though Avian supports Continuous Collision Detection (CCD)
+//! and uses speculative contacts, it does not lead to ghost collisions at small distances.
+//!
+//! A common problem with speculative contacts is that they can cause "ghost collisions"
+//! when a dynamic body grazes past another body at a high speed. This happens because
+//! the increased contact distance catches the other body's surface, and treats it as
+//! an effectively infinite contact plane, even if the surface does not actually extend
+//! to intersect the body's path.
+//!
+//! Avian keeps the speculative contact distance very small and AABBs tight, and primarily relies
+//! on sweep-based CCD to prevent tunneling for fast-moving bodies. This avoids ghost collisions
+//! (except at *very* small distances; don't expect pixel-perfect collisions) while still
+//! preventing tunneling or deep overlaps for fast-moving bodies.
+//!
+//! This example is based on the SpeculativeGhost sample in Box2D.
+
+use avian2d::prelude::*;
+use bevy::{camera::ScalingMode, input::common_conditions::input_just_pressed, prelude::*};
+use examples_common_2d::ExampleCommonPlugin;
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins((
+        DefaultPlugins,
+        PhysicsPlugins::default().with_length_unit(0.5),
+        PhysicsDebugPlugin,
+        ExampleCommonPlugin,
+    ));
+
+    app.add_systems(Startup, (setup_camera, setup_scene));
+    app.add_systems(
+        Update,
+        reset_scene.run_if(input_just_pressed(KeyCode::KeyR)),
+    );
+
+    app.run();
+}
+
+fn setup_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera2d,
+        Projection::Orthographic(OrthographicProjection {
+            scaling_mode: ScalingMode::FixedHorizontal {
+                viewport_width: 12.0,
+            },
+            ..OrthographicProjection::default_2d()
+        }),
+        Transform::from_xyz(0.0, 2.5, 0.0),
+    ));
+}
+
+fn setup_scene(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Platform
+    commands.spawn((
+        Name::new("Platform"),
+        RigidBody::Static,
+        Collider::rectangle(2.0, 0.2),
+        Transform::from_xyz(0.0, 0.9, 0.0),
+        Mesh2d(meshes.add(Rectangle::new(2.0, 0.2))),
+        MeshMaterial2d(materials.add(Color::srgb(0.5, 0.5, 0.5))),
+    ));
+
+    // Ground
+    commands.spawn((
+        Name::new("Ground"),
+        RigidBody::Static,
+        Collider::rectangle(20.0, 0.05),
+        Mesh2d(meshes.add(Rectangle::new(20.0, 0.05))),
+        MeshMaterial2d(materials.add(Color::srgb(0.5, 0.5, 0.5))),
+    ));
+
+    const HZ: f32 = 64.0;
+
+    // Dynamic body that falls right past the platform and should not collide with it
+    commands.spawn((
+        Name::new("Dynamic Box"),
+        RigidBody::Dynamic,
+        Collider::rectangle(0.5, 0.5),
+        Transform::from_xyz(0.015, 2.515, 0.0),
+        LinearVelocity(Vec2::new(0.1 * 3.1 * HZ, -0.1 * 3.1 * HZ)),
+        GravityScale(0.0),
+        Mesh2d(meshes.add(Rectangle::new(0.5, 0.5))),
+        MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+    ));
+
+    // Instruction text
+    commands.spawn((
+        Text::new("Press R to reset the scene"),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(10.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+    ));
+}
+
+fn reset_scene(mut commands: Commands, query: Query<Entity, With<RigidBody>>) {
+    for entity in query.iter() {
+        commands.entity(entity).despawn();
+    }
+
+    commands.run_system_cached(setup_scene);
+}

--- a/crates/avian2d/examples/ccd/speculative_ghost.rs
+++ b/crates/avian2d/examples/ccd/speculative_ghost.rs
@@ -18,7 +18,10 @@
 //!
 //! This example is based on the SpeculativeGhost sample in Box2D.
 
-use avian2d::prelude::*;
+use avian2d::{
+    math::{Scalar, Vector},
+    prelude::*,
+};
 use bevy::{camera::ScalingMode, input::common_conditions::input_just_pressed, prelude::*};
 use examples_common_2d::ExampleCommonPlugin;
 
@@ -78,7 +81,7 @@ fn setup_scene(
         MeshMaterial2d(materials.add(Color::srgb(0.5, 0.5, 0.5))),
     ));
 
-    const HZ: f32 = 64.0;
+    const HZ: Scalar = 64.0;
 
     // Dynamic body that falls right past the platform and should not collide with it
     commands.spawn((
@@ -88,7 +91,7 @@ fn setup_scene(
         // SpeculativeCcd::default(),
         Collider::rectangle(0.5, 0.5),
         Transform::from_xyz(0.015, 2.515, 0.0),
-        LinearVelocity(Vec2::new(0.1 * 3.1 * HZ, -0.1 * 3.1 * HZ)),
+        LinearVelocity(Vector::new(0.1 * 3.1 * HZ, -0.1 * 3.1 * HZ)),
         GravityScale(0.0),
         Mesh2d(meshes.add(Rectangle::new(0.5, 0.5))),
         MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),

--- a/crates/avian2d/examples/ccd/spinners.rs
+++ b/crates/avian2d/examples/ccd/spinners.rs
@@ -1,17 +1,24 @@
 //! Demonstrates Continuous Collision Detection (CCD) to prevent tunneling
 //! when fast-moving balls collide with fast-spinning thin objects.
 //!
-//! Two modes can be toggled between:
+//! Three modes for swept CCD can be toggled between:
 //!
 //! 1. Linear: Only considers translational motion.
 //! 2. Non-linear: Considers both translational and rotational motion. More expensive.
+//! 3. Off: Discrete collision detection only, which can cause tunneling at high speeds.
 //!
-//! This example also demonstrates one CCD problem known as "time loss".
+//! Speculative CCD can also be toggled, predicting contacts before they happen
+//! at the risk of ghost collisions and larger collision AABBs.
+//!
+//! Additionally, this example demonstrates one problem with swept CCD known as "time loss".
 //! To hit the balls correctly, the spinners need to stop at the first time of impact,
 //! causing them to lose the rest of their rotation for that frame. This can make
 //! the spinners look like they are stuttering, especially at high speeds and with
-//! many objects to collide with. A fix for this would require a substepping CCD solver,
-//! which is not currently implemented in Avian due to its high overhead and complexity.
+//! many objects to collide with.
+//!
+//! Using speculative CCD together with swept CCD can help to some extent,
+//! but a proper fix would require a substepping CCD solver, which is not currently
+//! implemented in Avian due to its high overhead and complexity.
 
 use avian2d::{math::*, prelude::*};
 use bevy::prelude::*;
@@ -27,6 +34,7 @@ fn main() {
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Gravity(Vector::NEG_Y * 9.81 * 100.0))
         .init_resource::<ActiveSweepMode>()
+        .init_resource::<SpeculativeCcdEnabled>()
         .add_systems(Startup, setup)
         .add_systems(Update, update_config)
         .add_systems(FixedUpdate, spawn_balls)
@@ -34,7 +42,10 @@ fn main() {
 }
 
 #[derive(Component)]
-struct SweepModeText;
+struct SweptCcdText;
+
+#[derive(Component)]
+struct SpeculativeCcdText;
 
 /// The current CCD sweep mode configuration.
 #[derive(Resource, Clone, Copy, Default, PartialEq)]
@@ -46,13 +57,13 @@ enum ActiveSweepMode {
 }
 
 impl ActiveSweepMode {
-    fn ccd_settings(self) -> CcdSettings {
+    fn ccd_settings(self) -> SweptCcd {
         match self {
-            ActiveSweepMode::NonLinear => CcdSettings::default().with_include_dynamic(true),
-            ActiveSweepMode::Linear => CcdSettings::default()
+            ActiveSweepMode::NonLinear => SweptCcd::default().with_filter(CcdFilter::ALL),
+            ActiveSweepMode::Linear => SweptCcd::default()
                 .with_mode(SweepMode::Linear)
-                .with_include_dynamic(true),
-            ActiveSweepMode::Off => CcdSettings::default().with_enabled(false),
+                .with_filter(CcdFilter::ALL),
+            ActiveSweepMode::Off => SweptCcd::default().with_filter(CcdFilter::NONE),
         }
     }
 
@@ -65,11 +76,22 @@ impl ActiveSweepMode {
     }
 }
 
+/// Whether speculative CCD is enabled for the bodies.
+#[derive(Resource, Clone, Copy, Default, PartialEq)]
+struct SpeculativeCcdEnabled(bool);
+
+impl SpeculativeCcdEnabled {
+    fn label(self) -> &'static str {
+        if self.0 { "On" } else { "Off" }
+    }
+}
+
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     let sweep_mode = ActiveSweepMode::default();
-    let ccd_settings = sweep_mode.ccd_settings();
+    let swept_ccd = sweep_mode.ccd_settings();
+    let speculative_ccd_enabled = SpeculativeCcdEnabled::default();
 
     // Add two dynamic bodies spinning at high speeds. Their translation is locked and they have a
     // high dominance, so they spin in place without being pushed around.
@@ -81,7 +103,7 @@ fn setup(mut commands: Commands) {
         AngularVelocity(25.0),
         Dominance(1),
         Collider::rectangle(1.0, 400.0),
-        ccd_settings,
+        swept_ccd,
         Sprite {
             color: Color::srgb(0.7, 0.7, 0.8),
             custom_size: Some(Vec2::new(1.0, 400.0)),
@@ -96,7 +118,7 @@ fn setup(mut commands: Commands) {
         AngularVelocity(-25.0),
         Dominance(1),
         Collider::rectangle(1.0, 400.0),
-        ccd_settings,
+        swept_ccd,
         Sprite {
             color: Color::srgb(0.7, 0.7, 0.8),
             custom_size: Some(Vec2::new(1.0, 400.0)),
@@ -110,7 +132,7 @@ fn setup(mut commands: Commands) {
         ..default()
     };
     commands.spawn((
-        Text::new("Press Space to toggle CCD mode"),
+        Text::new("Press Space to toggle CCD mode\nPress S to toggle speculative CCD"),
         Node {
             position_type: PositionType::Absolute,
             top: Val::Px(10.0),
@@ -123,13 +145,34 @@ fn setup(mut commands: Commands) {
         Text::default(),
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(40.0),
+            top: Val::Px(70.0),
             left: Val::Px(10.0),
             ..default()
         },
         children![
             (TextSpan::new("CCD: "), font.clone()),
-            (TextSpan::new(sweep_mode.label()), font, SweepModeText),
+            (
+                TextSpan::new(sweep_mode.label()),
+                font.clone(),
+                SweptCcdText
+            ),
+        ],
+    ));
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(100.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+        children![
+            (TextSpan::new("Speculative CCD: "), font.clone()),
+            (
+                TextSpan::new(speculative_ccd_enabled.label()),
+                font,
+                SpeculativeCcdText
+            ),
         ],
     ));
 }
@@ -141,6 +184,7 @@ fn spawn_balls(
     mut meshes: ResMut<Assets<Mesh>>,
     time: Res<Time<Physics>>,
     sweep_mode: Res<ActiveSweepMode>,
+    speculative: Res<SpeculativeCcdEnabled>,
 ) {
     let circle = Circle::new(2.0);
 
@@ -148,7 +192,7 @@ fn spawn_balls(
     let (sin, cos) = (0.5 * time.elapsed_secs_f64().adjust_precision().sin() - PI / 2.0).sin_cos();
     let direction = Vector::new(cos, sin).rotate(Vector::X);
 
-    commands.spawn((
+    let mut ball = commands.spawn((
         Name::new("Ball"),
         Mesh2d(meshes.add(circle)),
         MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
@@ -159,28 +203,48 @@ fn spawn_balls(
         Collider::from(circle),
         sweep_mode.ccd_settings(),
     ));
+
+    if speculative.0 {
+        ball.insert(SpeculativeCcd::default());
+    }
 }
 
 fn update_config(
-    sweep_mode_text: Single<&mut TextSpan, With<SweepModeText>>,
+    mut sweep_mode_text: Single<&mut TextSpan, (With<SweptCcdText>, Without<SpeculativeCcdText>)>,
+    mut speculative_text: Single<&mut TextSpan, (With<SpeculativeCcdText>, Without<SweptCcdText>)>,
     keys: Res<ButtonInput<KeyCode>>,
     mut sweep_mode: ResMut<ActiveSweepMode>,
-    balls: Query<Entity, With<Collider>>,
+    mut speculative: ResMut<SpeculativeCcdEnabled>,
+    bodies: Query<Entity, With<Collider>>,
     mut commands: Commands,
 ) {
-    // Cycle the CCD configuration for the colliders.
+    // Cycle the CCD sweep mode for the colliders.
     if keys.just_pressed(KeyCode::Space) {
-        let mut text = sweep_mode_text;
         *sweep_mode = match *sweep_mode {
             ActiveSweepMode::NonLinear => ActiveSweepMode::Linear,
             ActiveSweepMode::Linear => ActiveSweepMode::Off,
             ActiveSweepMode::Off => ActiveSweepMode::NonLinear,
         };
-        text.0 = sweep_mode.label().to_string();
+        sweep_mode_text.0 = sweep_mode.label().to_string();
 
         // Update the existing colliders to use the new configuration.
-        for entity in &balls {
+        for entity in &bodies {
             commands.entity(entity).insert(sweep_mode.ccd_settings());
+        }
+    }
+
+    // Toggle speculative CCD for the colliders.
+    if keys.just_pressed(KeyCode::KeyS) {
+        speculative.0 = !speculative.0;
+        speculative_text.0 = speculative.label().to_string();
+
+        // Add or remove the `SpeculativeCcd` component on the existing colliders.
+        for entity in &bodies {
+            if speculative.0 {
+                commands.entity(entity).insert(SpeculativeCcd::default());
+            } else {
+                commands.entity(entity).remove::<SpeculativeCcd>();
+            }
         }
     }
 }

--- a/crates/avian2d/examples/ccd/spinners.rs
+++ b/crates/avian2d/examples/ccd/spinners.rs
@@ -104,7 +104,7 @@ fn setup(mut commands: Commands) {
         },
     ));
 
-    // Setup help text.
+    // Instruction text
     let font = TextFont {
         font_size: 20.0,
         ..default()

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -61,7 +61,7 @@ impl AnyCollider for CircleCollider {
         &self,
         position: Vector,
         _: impl Into<Rotation>,
-        _: AabbContext<Self::Context>,
+        _: ColliderContext<Self::Context>,
     ) -> ColliderAabb {
         ColliderAabb::new(position, Vector::splat(self.radius))
     }
@@ -77,7 +77,7 @@ impl AnyCollider for CircleCollider {
         _rotation2: impl Into<Rotation>,
         prediction_distance: Scalar,
         manifolds: &mut Vec<ContactManifold>,
-        _: ContactManifoldContext<Self::Context>,
+        _: ColliderPairContext<Self::Context>,
     ) {
         // Clear the previous manifolds.
         manifolds.clear();

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -41,12 +41,7 @@ pub enum MovementAction {
 /// to prevent Avian from automatically applying the character's velocity to its position,
 /// since the character controller will handle movement manually using move-and-slide.
 #[derive(Component)]
-#[require(
-    RigidBody::Kinematic,
-    CustomPositionIntegration,
-    // We don't want to impart speculative collision impulses in this case
-    SpeculativeMargin(0.0)
-)]
+#[require(RigidBody::Kinematic, CustomPositionIntegration)]
 pub struct CharacterController;
 
 /// Component for configuring movement settings for a character controller.

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -41,12 +41,7 @@ pub enum MovementAction {
 /// to prevent Avian from automatically applying the character's velocity to its position,
 /// since the character controller will handle movement manually using move-and-slide.
 #[derive(Component)]
-#[require(
-    RigidBody::Kinematic,
-    CustomPositionIntegration,
-    // We don't want to impart speculative collision impulses in this case
-    SpeculativeMargin(0.0)
-)]
+#[require(RigidBody::Kinematic, CustomPositionIntegration)]
 pub struct CharacterController;
 
 /// Component for configuring movement settings for a character controller.

--- a/migration-guides/0.7-to-main.md
+++ b/migration-guides/0.7-to-main.md
@@ -5,3 +5,40 @@ since the latest release. These guides are evolving and may not be polished yet.
 
 See [migration-guides/README.md](./README.md) and existing entries for information about Avian's
 migration guide process and what to put here.
+
+## Continuous Collision Detection (CCD)
+
+**Avian 0.8** overhauls the Continuous Collision Detection (CCD) algorithm.
+This involves some breaking changes.
+
+### Swept CCD
+
+Sweep-based CCD is now enabled by default for fast-moving dynamic bodies,
+but only against static and kinematic bodies. It can be configured using
+the `SweptCcd` component.
+
+`SweptCcd::include_dynamic` has been replaced by `SweptCcd::filter` bitflags.
+The `linear_threshold` and `angular_threshold` properties have also been
+replaced by a single `threshold`, which is now the fraction of a body's
+minimum "CCD thickness" that it may safely travel in a timestep before
+being treated as a fast-moving body.
+
+`new_with_mode` has also been removed in favor of `new` and `with_mode`,
+`with_velocity_threshold` has been removed in favor of `with_threshold`,
+and `include_dynamic` has been removed in favor of `with_filter`.
+
+The `SweptCcdSystem` system set has been replaced by `SolverSystems::ContinuousCollision`.
+
+### Speculative CCD
+
+Pure speculative collision is no longer enabled by default.
+It can be opted into using the `SpeculativeCcd` component
+(previously `SpeculativeMargin`).
+
+`NarrowPhaseConfig::default_speculative_margin` has been removed.
+
+### Plugins
+
+A new `BodySizeMetricsPlugin<C: AnyCollider>` plugin has been added.
+It is included in `PhysicsPlugins` for the default `Collider` type,
+but apps using a custom collider type may want to add it manually.

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -95,7 +95,7 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
 
                     // TODO: Should we instead do this in `add_to_tree_on`?
                     // Update tight-fitting AABB.
-                    let context = AabbContext::new(trigger.entity, &*collider_context);
+                    let context = ColliderContext::new(trigger.entity, &*collider_context);
                     let growth = Vector::splat(contact_tolerance + collision_margin);
                     *aabb = collider
                         .aabb_with_context(pos.0, *rot, context)
@@ -734,7 +734,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                     speculative_margin.map_or(default_speculative_margin, |margin| margin.0)
                 };
 
-                let context = AabbContext::new(collider_entity, &*collider_context);
+                let context = ColliderContext::new(collider_entity, &*collider_context);
                 let growth = Vector::splat(contact_tolerance + collision_margin);
 
                 if speculative_margin <= 0.0 {
@@ -900,7 +900,7 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
             let collision_margin = collision_margin.map_or(0.0, |margin| margin.0);
 
             // Update tight-fitting AABB.
-            let context = AabbContext::new(entity, &*collider_context);
+            let context = ColliderContext::new(entity, &*collider_context);
             let growth = Vector::splat(contact_tolerance + collision_margin);
             *aabb = collider
                 .aabb_with_context(pos.0, *rot, context)

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -103,8 +103,8 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
 
                     // Compute and cache the size-relative AABB margin for the collider.
                     let context = ColliderContext::new(trigger.entity, &*collider_context);
-                    *aabb_margin = ColliderAabbMargin::from_max_extent(
-                        collider.max_extent_with_context(context),
+                    *aabb_margin = ColliderAabbMargin::from_bounding_radius(
+                        collider.bounding_radius_with_context(context),
                         length_unit.0,
                     );
 
@@ -776,8 +776,8 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                 // Recompute the cached AABB margin if the collider shape changed.
                 if collider.is_changed() {
                     let context = ColliderContext::new(collider_entity, &*collider_context);
-                    *aabb_margin = ColliderAabbMargin::from_max_extent(
-                        collider.max_extent_with_context(context),
+                    *aabb_margin = ColliderAabbMargin::from_bounding_radius(
+                        collider.bounding_radius_with_context(context),
                         length_unit.0,
                     );
                 }
@@ -929,8 +929,8 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
             // Recompute the cached AABB margin if the collider shape changed.
             if collider_changed {
                 let context = ColliderContext::new(entity, &*collider_context);
-                *aabb_margin = ColliderAabbMargin::from_max_extent(
-                    collider.max_extent_with_context(context),
+                *aabb_margin = ColliderAabbMargin::from_bounding_radius(
+                    collider.bounding_radius_with_context(context),
                     length_unit.0,
                 );
             }

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -7,7 +7,7 @@ use crate::{
         ColliderTreeSystems, ColliderTreeType, ColliderTrees, ProxyId,
         tree::ColliderTreeProxyFlags,
     },
-    collision::collider::EnlargedAabb,
+    collision::collider::{ColliderAabbMargin, EnlargedAabb},
     data_structures::bit_vec::BitVec,
     dynamics::solver::solver_body::SolverBody,
     prelude::*,
@@ -25,13 +25,6 @@ use bevy::{
 };
 use obvhs::aabb::Aabb;
 use thread_local::ThreadLocal;
-
-/// An extra margin added around the [`EnlargedAabb`]. This allows proxies
-/// to move a small amount without triggering a tree update.
-///
-/// This is implicitly scaled by the [`PhysicsLengthUnit`].
-// TODO: This should probably be configurable.
-const AABB_MARGIN: Scalar = 0.05;
 
 /// A plugin for updating [`ColliderTree`]s for a collider type `C`.
 ///
@@ -81,15 +74,22 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
                 Option<&CollisionMargin>,
                 &mut ColliderAabb,
                 &mut EnlargedAabb,
+                &mut ColliderAabbMargin,
             )>,
              narrow_phase_config: Res<NarrowPhaseConfig>,
              length_unit: Res<PhysicsLengthUnit>,
              collider_context: StaticSystemParam<C::Context>| {
                 let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
-                let margin = length_unit.0 * AABB_MARGIN;
 
-                if let Ok((collider, pos, rot, collision_margin, mut aabb, mut enlarged_aabb)) =
-                    query.get_mut(trigger.entity)
+                if let Ok((
+                    collider,
+                    pos,
+                    rot,
+                    collision_margin,
+                    mut aabb,
+                    mut enlarged_aabb,
+                    mut aabb_margin,
+                )) = query.get_mut(trigger.entity)
                 {
                     let collision_margin = collision_margin.map_or(0.0, |m| m.0);
 
@@ -101,7 +101,15 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
                         .aabb_with_context(pos.0, *rot, context)
                         .grow(growth);
 
-                    enlarged_aabb.update(&aabb, margin);
+                    // Compute and cache the size-relative AABB margin for the collider.
+                    let context = ColliderContext::new(trigger.entity, &*collider_context);
+                    *aabb_margin = ColliderAabbMargin::from_max_extent(
+                        collider.max_extent_with_context(context),
+                        length_unit.0,
+                    );
+
+                    // Use the cached margin for the initial enlarged AABB.
+                    enlarged_aabb.update(&aabb, aabb_margin.0);
                 }
             },
         );
@@ -649,13 +657,24 @@ impl EnlargedProxiesBitVec {
 //       we should use those instead of `SolverBody`. Solver bodies should
 //       be an implementation detail of the solver.
 fn update_solver_body_aabbs<C: AnyCollider>(
-    body_query: Query<&RigidBodyColliders, With<SolverBody>>,
+    body_query: Query<
+        (
+            &Position,
+            &ComputedCenterOfMass,
+            &LinearVelocity,
+            &AngularVelocity,
+            &RigidBodyColliders,
+            Has<SpeculativeAabb>,
+        ),
+        With<SolverBody>,
+    >,
     mut colliders: ParamSet<(
         Query<
             (
                 Ref<C>,
                 &mut ColliderAabb,
                 &mut EnlargedAabb,
+                &mut ColliderAabbMargin,
                 &ColliderTreeProxyKey,
                 &Position,
                 &Rotation,
@@ -667,6 +686,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     )>,
     narrow_phase_config: Res<NarrowPhaseConfig>,
     length_unit: Res<PhysicsLengthUnit>,
+    time: Res<Time>,
     mut trees: ResMut<ColliderTrees>,
     mut moved_proxies: ResMut<MovedProxies>,
     mut enlarged_proxies: ResMut<EnlargedProxies>,
@@ -693,21 +713,18 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     // can predict slightly separated contacts. This is needed for continuous collision.
     let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
 
-    // An extra margin is added to the enlarged AABB to allow for some movement without tree updates.
-    // TODO: Compute and cache the AABB margin, use only speculative margin for static bodies,
-    //       and the AABB margin for dynamic and kinematic bodies. Remember to clamp by max AABB margin
-    //       and AABB margin fraction.
-    let aabb_margin = length_unit.0 * AABB_MARGIN;
+    let delta_secs = time.delta_seconds_adjusted();
 
     let collider_query = colliders.p0();
 
     body_query.par_iter().for_each(
-        |body_colliders| {
+        |(rb_pos, center_of_mass, lin_vel, ang_vel, body_colliders, speculative_aabb)| {
             for collider_entity in body_colliders.iter() {
                 let Ok((
                     collider,
                     mut aabb,
                     mut enlarged_aabb,
+                    mut aabb_margin,
                     proxy_key,
                     pos,
                     rot,
@@ -722,11 +739,49 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                 let context = ColliderContext::new(collider_entity, &*collider_context);
                 let growth = Vector::splat(speculative_margin + collision_margin);
 
-                *aabb = collider
-                    .aabb_with_context(pos.0, *rot, context)
-                    .grow(growth);
+                *aabb = if speculative_aabb {
+                    // Opt-in velocity-expanded AABB: sweep the collider from its current pose to
+                    // where it would be next frame, so the broad phase and swept CCD can predict
+                    // contacts ahead. Note that this is only really needed by CCD for cases like
+                    // two fast-moving objects coming into contact from different directions,
+                    // because with tight AABBs, sweeping the shapes would not find any AABB intersection.
 
-                let moved = enlarged_aabb.update(&aabb, aabb_margin);
+                    // Velocity of this collider. For off-center (child) colliders on a rotating
+                    // body, the collider orbits the center of mass, which adds to its velocity.
+                    let offset = pos.0 - rb_pos.0 - center_of_mass.0;
+                    #[cfg(feature = "2d")]
+                    let vel = lin_vel.0 + Vector::new(-ang_vel.0 * offset.y, ang_vel.0 * offset.x);
+                    #[cfg(feature = "3d")]
+                    let vel = lin_vel.0 + ang_vel.0.cross(offset);
+
+                    let movement = vel * delta_secs;
+
+                    #[cfg(feature = "2d")]
+                    let end_rot = *rot * Rotation::radians(ang_vel.0 * delta_secs);
+                    #[cfg(feature = "3d")]
+                    let end_rot =
+                        Rotation(Quaternion::from_scaled_axis(ang_vel.0 * delta_secs) * rot.0)
+                            .fast_renormalize();
+
+                    collider
+                        .swept_aabb_with_context(pos.0, *rot, pos.0 + movement, end_rot, context)
+                        .grow(growth)
+                } else {
+                    collider.aabb_with_context(pos.0, *rot, context).grow(growth)
+                };
+
+                // Recompute the cached AABB margin if the collider shape changed.
+                if collider.is_changed() {
+                    let context = ColliderContext::new(collider_entity, &*collider_context);
+                    *aabb_margin = ColliderAabbMargin::from_max_extent(
+                        collider.max_extent_with_context(context),
+                        length_unit.0,
+                    );
+                }
+
+                // Solver bodies are always dynamic or kinematic, so they use the size-relative
+                // AABB margin to allow some movement without triggering tree updates.
+                let moved = enlarged_aabb.update(&aabb, aabb_margin.0);
 
                 if moved {
                     let tree_type = proxy_key.tree_type();
@@ -794,6 +849,7 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
                 Ref<Rotation>,
                 &mut ColliderAabb,
                 &mut EnlargedAabb,
+                &mut ColliderAabbMargin,
                 Ref<C>,
                 Option<&CollisionMargin>,
                 &ColliderTreeProxyKey,
@@ -830,18 +886,28 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
     e.standalone_proxies.clear_and_set_capacity(cap_standalone);
 
     let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
-    let margin = length_unit.0 * AABB_MARGIN;
 
     // TODO: This doesn't do velocity-based enlargement like the dynamic/kinematic AABB update.
     //       We should overall rework CCD to not rely on velocity-based AABB enlargement for all bodies.
     // TODO: par-iter over all colliders, check if they have actually changed since the `LastPhysicsTick`
     let mut collider_query = colliders.p0();
     collider_query.par_iter_mut().for_each(
-        |(entity, pos, rot, mut aabb, mut enlarged_aabb, collider, collision_margin, proxy_key)| {
+        |(
+            entity,
+            pos,
+            rot,
+            mut aabb,
+            mut enlarged_aabb,
+            mut aabb_margin,
+            collider,
+            collision_margin,
+            proxy_key,
+        )| {
             // Skip if the collider's AABB can't have changed since the last physics tick.
+            let collider_changed = collider.last_changed().is_newer_than(last_tick.0, this_run);
             if !pos.last_changed().is_newer_than(last_tick.0, this_run)
                 && !rot.last_changed().is_newer_than(last_tick.0, this_run)
-                && !collider.last_changed().is_newer_than(last_tick.0, this_run)
+                && !collider_changed
             {
                 return;
             }
@@ -854,6 +920,22 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
             *aabb = collider
                 .aabb_with_context(pos.0, *rot, context)
                 .grow(growth);
+
+            // Recompute the cached AABB margin if the collider shape changed.
+            if collider_changed {
+                let context = ColliderContext::new(entity, &*collider_context);
+                *aabb_margin = ColliderAabbMargin::from_max_extent(
+                    collider.max_extent_with_context(context),
+                    length_unit.0,
+                );
+            }
+
+            // Dynamic and kinematic colliders use the size-relative AABB margin, while static and
+            // standalone colliders only use the smaller speculative margin to keep their AABBs tight.
+            let margin = match proxy_key.tree_type() {
+                ColliderTreeType::Dynamic | ColliderTreeType::Kinematic => aabb_margin.0,
+                ColliderTreeType::Static | ColliderTreeType::Standalone => speculative_margin,
+            };
 
             // Try to update the enlarged AABB, and if it changed, mark the proxy as moved.
             let moved = enlarged_aabb.update(&aabb, margin);

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -664,7 +664,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
             &LinearVelocity,
             &AngularVelocity,
             &RigidBodyColliders,
-            Has<SpeculativeAabb>,
+            Option<&SpeculativeCcd>,
         ),
         With<SolverBody>,
     >,
@@ -718,7 +718,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     let collider_query = colliders.p0();
 
     body_query.par_iter().for_each(
-        |(rb_pos, center_of_mass, lin_vel, ang_vel, body_colliders, speculative_aabb)| {
+        |(rb_pos, center_of_mass, lin_vel, ang_vel, body_colliders, speculative_ccd)| {
             for collider_entity in body_colliders.iter() {
                 let Ok((
                     collider,
@@ -739,7 +739,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                 let context = ColliderContext::new(collider_entity, &*collider_context);
                 let growth = Vector::splat(contact_tolerance + collision_margin);
 
-                *aabb = if speculative_aabb {
+                *aabb = if let Some(max_distance) = speculative_ccd.map(|s| s.max_distance) {
                     // Opt-in velocity-expanded AABB: sweep the collider from its current pose to
                     // where it would be next frame, so the broad phase and swept CCD can predict
                     // contacts ahead. Note that this is only really needed by CCD for cases like
@@ -754,7 +754,8 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                     #[cfg(feature = "3d")]
                     let vel = lin_vel.0 + ang_vel.0.cross(offset);
 
-                    let movement = vel * delta_secs;
+                    // Expand the AABB along the velocity, but no further than the speculative margin.
+                    let movement = (vel * delta_secs).clamp_length_max(max_distance);
 
                     #[cfg(feature = "2d")]
                     let end_rot = *rot * Rotation::radians(ang_vel.0 * delta_secs);
@@ -767,7 +768,9 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                         .swept_aabb_with_context(pos.0, *rot, pos.0 + movement, end_rot, context)
                         .grow(growth)
                 } else {
-                    collider.aabb_with_context(pos.0, *rot, context).grow(growth)
+                    collider
+                        .aabb_with_context(pos.0, *rot, context)
+                        .grow(growth)
                 };
 
                 // Recompute the cached AABB margin if the collider shape changed.

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -85,7 +85,7 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
              narrow_phase_config: Res<NarrowPhaseConfig>,
              length_unit: Res<PhysicsLengthUnit>,
              collider_context: StaticSystemParam<C::Context>| {
-                let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
+                let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
                 let margin = length_unit.0 * AABB_MARGIN;
 
                 if let Ok((collider, pos, rot, collision_margin, mut aabb, mut enlarged_aabb)) =
@@ -96,7 +96,7 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
                     // TODO: Should we instead do this in `add_to_tree_on`?
                     // Update tight-fitting AABB.
                     let context = ColliderContext::new(trigger.entity, &*collider_context);
-                    let growth = Vector::splat(contact_tolerance + collision_margin);
+                    let growth = Vector::splat(speculative_margin + collision_margin);
                     *aabb = collider
                         .aabb_with_context(pos.0, *rot, context)
                         .grow(growth);
@@ -648,20 +648,8 @@ impl EnlargedProxiesBitVec {
 // TODO: Once dynamic an kinematic bodies have their own marker components,
 //       we should use those instead of `SolverBody`. Solver bodies should
 //       be an implementation detail of the solver.
-// TODO: This approach with velocity-expanded AABBs is quite inefficient.
-//       We could switch to Box2D-style CCD with fast bodies.
 fn update_solver_body_aabbs<C: AnyCollider>(
-    body_query: Query<
-        (
-            &Position,
-            &ComputedCenterOfMass,
-            &LinearVelocity,
-            &AngularVelocity,
-            &RigidBodyColliders,
-            Has<SweptCcd>,
-        ),
-        With<SolverBody>,
-    >,
+    body_query: Query<&RigidBodyColliders, With<SolverBody>>,
     mut colliders: ParamSet<(
         Query<
             (
@@ -672,7 +660,6 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                 &Position,
                 &Rotation,
                 Option<&CollisionMargin>,
-                Option<&SpeculativeMargin>,
             ),
             Without<ColliderDisabled>,
         >,
@@ -683,7 +670,6 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     mut trees: ResMut<ColliderTrees>,
     mut moved_proxies: ResMut<MovedProxies>,
     mut enlarged_proxies: ResMut<EnlargedProxies>,
-    time: Res<Time>,
     collider_context: StaticSystemParam<C::Context>,
     mut diagnostics: ResMut<ColliderTreeDiagnostics>,
     mut last_tick: ResMut<LastDynamicKinematicAabbUpdate>,
@@ -703,15 +689,20 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     e.dynamic_proxies.clear_and_set_capacity(cap_dynamic);
     e.kinematic_proxies.clear_and_set_capacity(cap_kinematic);
 
-    let delta_secs = time.delta_seconds_adjusted();
-    let default_speculative_margin = length_unit.0 * narrow_phase_config.default_speculative_margin;
-    let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
-    let margin = length_unit.0 * AABB_MARGIN;
+    // A small, fixed speculative distance is added to each AABB so the narrow phase
+    // can predict slightly separated contacts. This is needed for continuous collision.
+    let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
+
+    // An extra margin is added to the enlarged AABB to allow for some movement without tree updates.
+    // TODO: Compute and cache the AABB margin, use only speculative margin for static bodies,
+    //       and the AABB margin for dynamic and kinematic bodies. Remember to clamp by max AABB margin
+    //       and AABB margin fraction.
+    let aabb_margin = length_unit.0 * AABB_MARGIN;
 
     let collider_query = colliders.p0();
 
     body_query.par_iter().for_each(
-        |(rb_pos, center_of_mass, lin_vel, ang_vel, body_colliders, has_swept_ccd)| {
+        |body_colliders| {
             for collider_entity in body_colliders.iter() {
                 let Ok((
                     collider,
@@ -721,63 +712,21 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                     pos,
                     rot,
                     collision_margin,
-                    speculative_margin,
                 )) = (unsafe { collider_query.get_unchecked(collider_entity) })
                 else {
                     continue;
                 };
 
                 let collision_margin = collision_margin.map_or(0.0, |margin| margin.0);
-                let speculative_margin = if has_swept_ccd {
-                    Scalar::MAX
-                } else {
-                    speculative_margin.map_or(default_speculative_margin, |margin| margin.0)
-                };
 
                 let context = ColliderContext::new(collider_entity, &*collider_context);
-                let growth = Vector::splat(contact_tolerance + collision_margin);
+                let growth = Vector::splat(speculative_margin + collision_margin);
 
-                if speculative_margin <= 0.0 {
-                    *aabb = collider
-                        .aabb_with_context(pos.0, *rot, context)
-                        .grow(growth);
-                } else {
-                    // If the rigid body is rotating, off-center colliders will orbit around it,
-                    // which affects their linear velocities. We need to compute the linear velocity
-                    // at the offset position.
-                    // TODO: This assumes that the colliders would continue moving in the same direction,
-                    //       but because they are orbiting, the direction will change. We should take
-                    //       into account the uniform circular motion.
-                    let offset = pos.0 - rb_pos.0 - center_of_mass.0;
-                    #[cfg(feature = "2d")]
-                    let vel = lin_vel.0 + Vector::new(-ang_vel.0 * offset.y, ang_vel.0 * offset.x);
-                    #[cfg(feature = "3d")]
-                    let vel = lin_vel.0 + ang_vel.cross(offset);
-                    let movement = (vel * delta_secs)
-                        .clamp_length_max(speculative_margin.max(contact_tolerance));
+                *aabb = collider
+                    .aabb_with_context(pos.0, *rot, context)
+                    .grow(growth);
 
-                    // Current position and predicted position for next feame
-                    #[cfg(feature = "2d")]
-                    let (end_pos, end_rot) = (
-                        pos.0 + movement,
-                        *rot * Rotation::radians(ang_vel.0 * delta_secs),
-                    );
-
-                    #[cfg(feature = "3d")]
-                    let (end_pos, end_rot) = (
-                        pos.0 + movement,
-                        Rotation(Quaternion::from_scaled_axis(ang_vel.0 * delta_secs) * rot.0)
-                            .fast_renormalize(),
-                    );
-
-                    // Compute swept AABB, the space that the body would occupy if it was integrated for one frame
-                    // TODO: Should we expand the AABB in all directions for speculative contacts?
-                    *aabb = collider
-                        .swept_aabb_with_context(pos.0, *rot, end_pos, end_rot, context)
-                        .grow(growth);
-                }
-
-                let moved = enlarged_aabb.update(&aabb, margin);
+                let moved = enlarged_aabb.update(&aabb, aabb_margin);
 
                 if moved {
                     let tree_type = proxy_key.tree_type();
@@ -880,7 +829,7 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
     e.static_proxies.clear_and_set_capacity(cap_static);
     e.standalone_proxies.clear_and_set_capacity(cap_standalone);
 
-    let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
+    let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
     let margin = length_unit.0 * AABB_MARGIN;
 
     // TODO: This doesn't do velocity-based enlargement like the dynamic/kinematic AABB update.
@@ -901,7 +850,7 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
 
             // Update tight-fitting AABB.
             let context = ColliderContext::new(entity, &*collider_context);
-            let growth = Vector::splat(contact_tolerance + collision_margin);
+            let growth = Vector::splat(speculative_margin + collision_margin);
             *aabb = collider
                 .aabb_with_context(pos.0, *rot, context)
                 .grow(growth);

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -79,7 +79,7 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
              narrow_phase_config: Res<NarrowPhaseConfig>,
              length_unit: Res<PhysicsLengthUnit>,
              collider_context: StaticSystemParam<C::Context>| {
-                let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
+                let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
                 if let Ok((
                     collider,
@@ -96,7 +96,7 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
                     // TODO: Should we instead do this in `add_to_tree_on`?
                     // Update tight-fitting AABB.
                     let context = ColliderContext::new(trigger.entity, &*collider_context);
-                    let growth = Vector::splat(speculative_margin + collision_margin);
+                    let growth = Vector::splat(contact_tolerance + collision_margin);
                     *aabb = collider
                         .aabb_with_context(pos.0, *rot, context)
                         .grow(growth);
@@ -709,9 +709,9 @@ fn update_solver_body_aabbs<C: AnyCollider>(
     e.dynamic_proxies.clear_and_set_capacity(cap_dynamic);
     e.kinematic_proxies.clear_and_set_capacity(cap_kinematic);
 
-    // A small, fixed speculative distance is added to each AABB so the narrow phase
-    // can predict slightly separated contacts. This is needed for continuous collision.
-    let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
+    // A small, fixed contact tolerance is added to each AABB so the narrow phase
+    // can predict slightly separated contacts.
+    let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
     let delta_secs = time.delta_seconds_adjusted();
 
@@ -737,7 +737,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
                 let collision_margin = collision_margin.map_or(0.0, |margin| margin.0);
 
                 let context = ColliderContext::new(collider_entity, &*collider_context);
-                let growth = Vector::splat(speculative_margin + collision_margin);
+                let growth = Vector::splat(contact_tolerance + collision_margin);
 
                 *aabb = if speculative_aabb {
                     // Opt-in velocity-expanded AABB: sweep the collider from its current pose to
@@ -885,7 +885,9 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
     e.static_proxies.clear_and_set_capacity(cap_static);
     e.standalone_proxies.clear_and_set_capacity(cap_standalone);
 
-    let speculative_margin = length_unit.0 * narrow_phase_config.speculative_margin;
+    // A small, fixed contact tolerance is added to each AABB so the narrow phase
+    // can predict slightly separated contacts.
+    let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
     // TODO: This doesn't do velocity-based enlargement like the dynamic/kinematic AABB update.
     //       We should overall rework CCD to not rely on velocity-based AABB enlargement for all bodies.
@@ -916,7 +918,7 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
 
             // Update tight-fitting AABB.
             let context = ColliderContext::new(entity, &*collider_context);
-            let growth = Vector::splat(speculative_margin + collision_margin);
+            let growth = Vector::splat(contact_tolerance + collision_margin);
             *aabb = collider
                 .aabb_with_context(pos.0, *rot, context)
                 .grow(growth);
@@ -931,10 +933,10 @@ pub fn update_moved_collider_aabbs<C: AnyCollider>(
             }
 
             // Dynamic and kinematic colliders use the size-relative AABB margin, while static and
-            // standalone colliders only use the smaller speculative margin to keep their AABBs tight.
+            // standalone colliders only use the smaller contact tolerance to keep their AABBs tight.
             let margin = match proxy_key.tree_type() {
                 ColliderTreeType::Dynamic | ColliderTreeType::Kinematic => aabb_margin.0,
-                ColliderTreeType::Static | ColliderTreeType::Standalone => speculative_margin,
+                ColliderTreeType::Static | ColliderTreeType::Standalone => contact_tolerance,
             };
 
             // Try to update the enlarged AABB, and if it changed, mark the proxy as moved.

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
 use crate::collision::collider::cache::ColliderCache;
 use crate::{
-    collision::collider::EnlargedAabb,
+    collision::collider::{ColliderAabbMargin, EnlargedAabb},
     physics_transform::{PhysicsTransformConfig, PhysicsTransformSystems, init_physics_transform},
     prelude::*,
 };
@@ -97,6 +97,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         let _ = app.try_register_required_components::<C, ColliderMarker>();
         let _ = app.try_register_required_components::<C, ColliderAabb>();
         let _ = app.try_register_required_components::<C, EnlargedAabb>();
+        let _ = app.try_register_required_components::<C, ColliderAabbMargin>();
         let _ = app.try_register_required_components::<C, CollisionLayers>();
         let _ = app.try_register_required_components::<C, ColliderDensity>();
         let _ = app.try_register_required_components::<C, ColliderMassProperties>();

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -53,71 +53,71 @@ pub trait IntoCollider<C: AnyCollider> {
     fn collider(&self) -> C;
 }
 
-/// Context necessary to calculate [`ColliderAabb`]s for an [`AnyCollider`]
+/// Context necessary for operations involving an [`AnyCollider`].
 #[derive(Deref)]
-pub struct AabbContext<'a, 'w, 's, T: ReadOnlySystemParam> {
-    /// The entity for which the aabb is being calculated
-    pub entity: Entity,
+pub struct ColliderContext<'a, 'w, 's, T: ReadOnlySystemParam> {
+    /// The collider entity involved in the operation.
+    pub collider: Entity,
     #[deref]
     item: &'a SystemParamItem<'w, 's, T>,
 }
 
-impl<T: ReadOnlySystemParam> Clone for AabbContext<'_, '_, '_, T> {
+impl<T: ReadOnlySystemParam> Clone for ColliderContext<'_, '_, '_, T> {
     fn clone(&self) -> Self {
         Self {
-            entity: self.entity,
+            collider: self.collider,
             item: self.item,
         }
     }
 }
 
-impl<'a, 'w, 's, T: ReadOnlySystemParam> AabbContext<'a, 'w, 's, T> {
-    /// Construct an [`AabbContext`]
-    pub fn new(entity: Entity, item: &'a <T as SystemParam>::Item<'w, 's>) -> Self {
-        Self { entity, item }
+impl<'a, 'w, 's, T: ReadOnlySystemParam> ColliderContext<'a, 'w, 's, T> {
+    /// Constructs a [`ColliderContext`].
+    pub fn new(collider: Entity, item: &'a <T as SystemParam>::Item<'w, 's>) -> Self {
+        Self { collider, item }
     }
 }
 
-impl AabbContext<'_, '_, '_, ()> {
+impl ColliderContext<'_, '_, '_, ()> {
     fn fake() -> Self {
         Self {
-            entity: Entity::PLACEHOLDER,
+            collider: Entity::PLACEHOLDER,
             item: &(),
         }
     }
 }
 
-/// Context necessary to calculate [`ContactManifold`]s for a set of [`AnyCollider`]
+/// Context necessary for operations involving a pair of [`AnyCollider`]s.
 #[derive(Deref)]
-pub struct ContactManifoldContext<'a, 'w, 's, T: ReadOnlySystemParam> {
-    /// The first collider entity involved in the contact.
-    pub entity1: Entity,
-    /// The second collider entity involved in the contact.
-    pub entity2: Entity,
+pub struct ColliderPairContext<'a, 'w, 's, T: ReadOnlySystemParam> {
+    /// The first collider entity involved in the operation.
+    pub collider1: Entity,
+    /// The second collider entity involved in the operation.
+    pub collider2: Entity,
     #[deref]
     item: &'a SystemParamItem<'w, 's, T>,
 }
 
-impl<'a, 'w, 's, T: ReadOnlySystemParam> ContactManifoldContext<'a, 'w, 's, T> {
-    /// Construct a [`ContactManifoldContext`]
+impl<'a, 'w, 's, T: ReadOnlySystemParam> ColliderPairContext<'a, 'w, 's, T> {
+    /// Constructs a [`ColliderPairContext`].
     pub fn new(
-        entity1: Entity,
-        entity2: Entity,
+        collider1: Entity,
+        collider2: Entity,
         item: &'a <T as SystemParam>::Item<'w, 's>,
     ) -> Self {
         Self {
-            entity1,
-            entity2,
+            collider1,
+            collider2,
             item,
         }
     }
 }
 
-impl ContactManifoldContext<'_, '_, '_, ()> {
+impl ColliderPairContext<'_, '_, '_, ()> {
     fn fake() -> Self {
         Self {
-            entity1: Entity::PLACEHOLDER,
-            entity2: Entity::PLACEHOLDER,
+            collider1: Entity::PLACEHOLDER,
+            collider2: Entity::PLACEHOLDER,
             item: &(),
         }
     }
@@ -179,7 +179,7 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
     /// #       &self,
     /// #       _: Vector,
     /// #       _: impl Into<Rotation>,
-    /// #       _: AabbContext<Self::Context>,
+    /// #       _: ColliderContext<Self::Context>,
     /// #   ) -> ColliderAabb { unimplemented!() }
     /// #
     ///     fn contact_manifolds_with_context(
@@ -191,9 +191,9 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
     ///         rotation2: impl Into<Rotation>,
     ///         prediction_distance: Scalar,
     ///         manifolds: &mut Vec<ContactManifold>,
-    ///         context: ContactManifoldContext<Self::Context>,
+    ///         context: ColliderPairContext<Self::Context>,
     ///     ) {
-    ///         let [voxels1, voxels2] = context.0.get_many([context.entity1, context.entity2])
+    ///         let [voxels1, voxels2] = context.0.get_many([context.collider1, context.collider2])
     ///             .expect("our own `VoxelCollider` entities should have `VoxelData`");
     ///         let elapsed = context.1.elapsed();
     ///         // do some computation...
@@ -206,7 +206,7 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
     /// Computes the [Axis-Aligned Bounding Box](ColliderAabb) of the collider
     /// with the given position and rotation.
     ///
-    /// See [`SimpleCollider::aabb`] for collider types with empty [`AnyCollider::Context`]
+    /// See [`SimpleCollider::aabb`] for collider types with an empty [`AnyCollider::Context`].
     #[cfg_attr(
         feature = "2d",
         doc = "\n\nThe rotation is counterclockwise and in radians."
@@ -215,14 +215,14 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         &self,
         position: Vector,
         rotation: impl Into<Rotation>,
-        context: AabbContext<Self::Context>,
+        context: ColliderContext<Self::Context>,
     ) -> ColliderAabb;
 
     /// Computes the swept [Axis-Aligned Bounding Box](ColliderAabb) of the collider.
     /// This corresponds to the space the shape would occupy if it moved from the given
     /// start position to the given end position.
     ///
-    /// See [`SimpleCollider::swept_aabb`] for collider types with empty [`AnyCollider::Context`]
+    /// See [`SimpleCollider::swept_aabb`] for collider types with an empty [`AnyCollider::Context`].
     #[cfg_attr(
         feature = "2d",
         doc = "\n\nThe rotation is counterclockwise and in radians."
@@ -233,7 +233,7 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         start_rotation: impl Into<Rotation>,
         end_position: Vector,
         end_rotation: impl Into<Rotation>,
-        context: AabbContext<Self::Context>,
+        context: ColliderContext<Self::Context>,
     ) -> ColliderAabb {
         self.aabb_with_context(start_position, start_rotation, context.clone())
             .merged(self.aabb_with_context(end_position, end_rotation, context))
@@ -244,7 +244,7 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
     /// Returns an empty vector if the colliders are separated by a distance greater than `prediction_distance`
     /// or if the given shapes are invalid.
     ///
-    /// See [`SimpleCollider::contact_manifolds`] for collider types with empty [`AnyCollider::Context`]
+    /// See [`SimpleCollider::contact_manifolds`] for collider types with an empty [`AnyCollider::Context`].
     fn contact_manifolds_with_context(
         &self,
         other: &Self,
@@ -254,7 +254,7 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         rotation2: impl Into<Rotation>,
         prediction_distance: Scalar,
         manifolds: &mut Vec<ContactManifold>,
-        context: ContactManifoldContext<Self::Context>,
+        context: ColliderPairContext<Self::Context>,
     );
 }
 
@@ -264,16 +264,16 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
     /// Computes the [Axis-Aligned Bounding Box](ColliderAabb) of the collider
     /// with the given position and rotation.
     ///
-    /// See [`AnyCollider::aabb_with_context`] for collider types with non-empty [`AnyCollider::Context`]
+    /// See [`AnyCollider::aabb_with_context`] for collider types with a non-empty [`AnyCollider::Context`].
     fn aabb(&self, position: Vector, rotation: impl Into<Rotation>) -> ColliderAabb {
-        self.aabb_with_context(position, rotation, AabbContext::fake())
+        self.aabb_with_context(position, rotation, ColliderContext::fake())
     }
 
     /// Computes the swept [Axis-Aligned Bounding Box](ColliderAabb) of the collider.
     /// This corresponds to the space the shape would occupy if it moved from the given
     /// start position to the given end position.
     ///
-    /// See [`AnyCollider::swept_aabb_with_context`] for collider types with non-empty [`AnyCollider::Context`]
+    /// See [`AnyCollider::swept_aabb_with_context`] for collider types with a non-empty [`AnyCollider::Context`].
     fn swept_aabb(
         &self,
         start_position: Vector,
@@ -286,7 +286,7 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
             start_rotation,
             end_position,
             end_rotation,
-            AabbContext::fake(),
+            ColliderContext::fake(),
         )
     }
 
@@ -295,7 +295,7 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
     /// `manifolds` is cleared if the colliders are separated by a distance greater than `prediction_distance`
     /// or if the given shapes are invalid.
     ///
-    /// See [`AnyCollider::contact_manifolds_with_context`] for collider types with non-empty [`AnyCollider::Context`]
+    /// See [`AnyCollider::contact_manifolds_with_context`] for collider types with a non-empty [`AnyCollider::Context`].
     fn contact_manifolds(
         &self,
         other: &Self,
@@ -314,7 +314,7 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
             rotation2,
             prediction_distance,
             manifolds,
-            ContactManifoldContext::fake(),
+            ColliderPairContext::fake(),
         )
     }
 }

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -257,11 +257,14 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         context: ColliderPairContext<Self::Context>,
     );
 
-    /// Returns the minimum thickness of the collider.
+    /// Returns a conservative minimum thickness used by [Continuous Collision Detection (CCD)][CCD]
+    /// to determine when the collider might tunnel through other geometry.
     ///
     /// Typically corresponds to the minimum distance from the centroid
     /// of any given shape to its surface.
-    fn min_thickness_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
+    ///
+    /// [CCD]: crate::dynamics::ccd
+    fn ccd_thickness_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
         let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
         aabb.size().min_element() * 0.5
     }
@@ -276,12 +279,13 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         point.distance(aabb.center()) + aabb.size().length() * 0.5
     }
 
-    /// Returns the maximum extent of the collider. This is the farthest distance
-    /// from the centroid of the shape to any point on its surface.
+    /// Returns the radius of the bounding sphere of the collider.
     ///
     /// This is used to compute a size-relative [`ColliderAabbMargin`] for the collider.
-    fn max_extent_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
-        let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
+    fn bounding_radius_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
+        // We don't have a bounding sphere method directly available here,
+        // so for now we settle for this approximation for the default implementation.
+        let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context.clone());
         aabb.size().length() * 0.5
     }
 }
@@ -346,28 +350,27 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
         )
     }
 
-    /// Returns the minimum thickness of the collider.
+    /// Returns a conservative minimum thickness used by [Continuous Collision Detection (CCD)][CCD]
+    /// to determine when the collider might tunnel through other geometry.
     ///
     /// Typically corresponds to the minimum distance from the centroid
     /// of any given shape to its surface.
-    fn min_thickness(&self) -> Scalar {
-        self.min_thickness_with_context(ColliderContext::fake())
+    ///
+    /// [CCD]: crate::dynamics::ccd
+    fn ccd_thickness(&self) -> Scalar {
+        self.ccd_thickness_with_context(ColliderContext::fake())
     }
 
     /// Returns the maximum distance from the collider to the given point.
-    ///
-    /// Typically corresponds to the radius of the sphere formed by sweeping
-    /// the shape about its centroid.
     fn max_distance_to_point(&self, point: Vector) -> Scalar {
         self.max_distance_to_point_with_context(point, ColliderContext::fake())
     }
 
-    /// Returns the maximum extent of the collider. This is the farthest distance
-    /// from the centroid of the shape to any point on its surface.
+    /// Returns the radius of the bounding sphere of the collider.
     ///
     /// This is used to compute a size-relative [`ColliderAabbMargin`] for the collider.
-    fn max_extent(&self) -> Scalar {
-        self.max_extent_with_context(ColliderContext::fake())
+    fn bounding_radius(&self) -> Scalar {
+        self.bounding_radius_with_context(ColliderContext::fake())
     }
 }
 
@@ -625,11 +628,12 @@ impl From<ColliderAabb> for obvhs::aabb::Aabb {
 
 /// An Axis-Aligned Bounding Box that contains the [`ColliderAabb`] with an additional margin.
 ///
-/// This is used to avoid updating the Bounding Volume Hierarchy acceleration structure
-/// every time a collider moves only a small amount.
+/// This is used to avoid updating the [`ColliderTree`] every time a collider moves only a small amount.
 ///
 /// The enlarged AABB is updated automatically whenever the [`ColliderAabb`]
 /// moves beyond the bounds of the current enlarged AABB.
+///
+/// [`ColliderTree`]: crate::collider_tree::ColliderTree
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
@@ -668,12 +672,13 @@ impl EnlargedAabb {
 /// The margin used to enlarge the [`ColliderAabb`] of a collider into its [`EnlargedAabb`].
 ///
 /// Enlarging the AABB allows the collider to move by a small amount without triggering
-/// an update of the Bounding Volume Hierarchy, which improves performance.
+/// an update of the [`ColliderTree`], which improves performance.
 ///
 /// The margin is computed automatically from the size of the collider, scaled relative to the
 /// [`PhysicsLengthUnit`]. Larger shapes get a larger margin (up to [`ColliderAabbMargin::MAX`]),
 /// while small shapes get a margin proportional to their size to avoid wastefully fat AABBs.
 ///
+/// [`ColliderTree`]: crate::collider_tree::ColliderTree
 /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
@@ -690,18 +695,18 @@ impl ColliderAabbMargin {
     /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
     pub const MAX: Scalar = 0.05;
 
-    /// For small shapes, the margin is limited to this fraction of the shape's maximum extent.
+    /// For small shapes, the margin is limited to this fraction of the shape's bounding radius.
     pub const FRACTION: Scalar = 0.125;
 
-    /// Computes the AABB margin for a collider with the given `max_extent` and [`PhysicsLengthUnit`].
+    /// Computes the AABB margin for a collider with the given `bounding_radius` and [`PhysicsLengthUnit`].
     ///
     /// The margin is clamped to at most [`ColliderAabbMargin::MAX`] scaled by the length unit,
-    /// and at most [`ColliderAabbMargin::FRACTION`] of the maximum extent for small shapes.
+    /// and at most [`ColliderAabbMargin::FRACTION`] of the bounding radius for small shapes.
     ///
     /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
     #[inline]
-    pub fn from_max_extent(max_extent: Scalar, length_unit: Scalar) -> Self {
-        Self((length_unit * Self::MAX).min(Self::FRACTION * max_extent))
+    pub fn from_bounding_radius(bounding_radius: Scalar, length_unit: Scalar) -> Self {
+        Self((length_unit * Self::MAX).min(Self::FRACTION * bounding_radius))
     }
 }
 

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -688,10 +688,10 @@ impl ColliderAabbMargin {
     /// to move by a small amount without triggering a tree adjustment.
     ///
     /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
-    pub const MAX: Scalar = 0.2;
+    pub const MAX: Scalar = 0.05;
 
     /// For small shapes, the margin is limited to this fraction of the shape's maximum extent.
-    pub const FRACTION: Scalar = 0.5;
+    pub const FRACTION: Scalar = 0.125;
 
     /// Computes the AABB margin for a collider with the given `max_extent` and [`PhysicsLengthUnit`].
     ///

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -257,8 +257,11 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         context: ColliderPairContext<Self::Context>,
     );
 
-    /// Returns the minimum extent of the collider relative to its centroid.
-    fn min_extent_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
+    /// Returns the minimum thickness of the collider.
+    ///
+    /// Typically corresponds to the minimum distance from the centroid
+    /// of any given shape to its surface.
+    fn min_thickness_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
         let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
         aabb.size().min_element() * 0.5
     }
@@ -334,12 +337,18 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
         )
     }
 
-    /// Returns the minimum extent of the collider relative to its centroid.
-    fn min_extent(&self) -> Scalar {
-        self.min_extent_with_context(ColliderContext::fake())
+    /// Returns the minimum thickness of the collider.
+    ///
+    /// Typically corresponds to the minimum distance from the centroid
+    /// of any given shape to its surface.
+    fn min_thickness(&self) -> Scalar {
+        self.min_thickness_with_context(ColliderContext::fake())
     }
 
     /// Returns the maximum distance from the collider to the given point.
+    ///
+    /// Typically corresponds to the radius of the sphere formed by sweeping
+    /// the shape about its centroid.
     fn max_distance_to_point(&self, point: Vector) -> Scalar {
         self.max_distance_to_point_with_context(point, ColliderContext::fake())
     }

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -256,6 +256,22 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         manifolds: &mut Vec<ContactManifold>,
         context: ColliderPairContext<Self::Context>,
     );
+
+    /// Returns the minimum extent of the collider relative to its centroid.
+    fn min_extent_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
+        let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
+        aabb.size().min_element() * 0.5
+    }
+
+    /// Returns the maximum distance from the collider to the given point.
+    fn max_distance_to_point_with_context(
+        &self,
+        point: Vector,
+        context: ColliderContext<Self::Context>,
+    ) -> Scalar {
+        let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
+        point.distance(aabb.center()) + aabb.size().length() * 0.5
+    }
 }
 
 /// A simplified wrapper around [`AnyCollider`] that doesn't require passing in the context for
@@ -316,6 +332,16 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
             manifolds,
             ColliderPairContext::fake(),
         )
+    }
+
+    /// Returns the minimum extent of the collider relative to its centroid.
+    fn min_extent(&self) -> Scalar {
+        self.min_extent_with_context(ColliderContext::fake())
+    }
+
+    /// Returns the maximum distance from the collider to the given point.
+    fn max_distance_to_point(&self, point: Vector) -> Scalar {
+        self.max_distance_to_point_with_context(point, ColliderContext::fake())
     }
 }
 
@@ -491,6 +517,12 @@ impl ColliderAabb {
     #[inline(always)]
     pub fn size(self) -> Vector {
         self.max - self.min
+    }
+
+    /// Computes the half-size of the AABB.
+    #[inline(always)]
+    pub fn half_size(self) -> Vector {
+        self.size() * 0.5
     }
 
     /// Merges this AABB with another one.

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -275,6 +275,15 @@ pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
         let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
         point.distance(aabb.center()) + aabb.size().length() * 0.5
     }
+
+    /// Returns the maximum extent of the collider. This is the farthest distance
+    /// from the centroid of the shape to any point on its surface.
+    ///
+    /// This is used to compute a size-relative [`ColliderAabbMargin`] for the collider.
+    fn max_extent_with_context(&self, context: ColliderContext<Self::Context>) -> Scalar {
+        let aabb = self.aabb_with_context(Vector::ZERO, Rotation::IDENTITY, context);
+        aabb.size().length() * 0.5
+    }
 }
 
 /// A simplified wrapper around [`AnyCollider`] that doesn't require passing in the context for
@@ -351,6 +360,14 @@ pub trait SimpleCollider: AnyCollider<Context = ()> {
     /// the shape about its centroid.
     fn max_distance_to_point(&self, point: Vector) -> Scalar {
         self.max_distance_to_point_with_context(point, ColliderContext::fake())
+    }
+
+    /// Returns the maximum extent of the collider. This is the farthest distance
+    /// from the centroid of the shape to any point on its surface.
+    ///
+    /// This is used to compute a size-relative [`ColliderAabbMargin`] for the collider.
+    fn max_extent(&self) -> Scalar {
+        self.max_extent_with_context(ColliderContext::fake())
     }
 }
 
@@ -645,6 +662,46 @@ impl EnlargedAabb {
     /// Gets the [`ColliderAabb`] of the enlarged AABB.
     pub fn get(&self) -> ColliderAabb {
         self.0
+    }
+}
+
+/// The margin used to enlarge the [`ColliderAabb`] of a collider into its [`EnlargedAabb`].
+///
+/// Enlarging the AABB allows the collider to move by a small amount without triggering
+/// an update of the Bounding Volume Hierarchy, which improves performance.
+///
+/// The margin is computed automatically from the size of the collider, scaled relative to the
+/// [`PhysicsLengthUnit`]. Larger shapes get a larger margin (up to [`ColliderAabbMargin::MAX`]),
+/// while small shapes get a margin proportional to their size to avoid wastefully fat AABBs.
+///
+/// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Component, Default, PartialEq)]
+pub struct ColliderAabbMargin(pub Scalar);
+
+impl ColliderAabbMargin {
+    /// The maximum AABB margin before being scaled by the [`PhysicsLengthUnit`].
+    ///
+    /// This is used to fatten AABBs in the broad phase acceleration structure. This allows proxies
+    /// to move by a small amount without triggering a tree adjustment.
+    ///
+    /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
+    pub const MAX: Scalar = 0.2;
+
+    /// For small shapes, the margin is limited to this fraction of the shape's maximum extent.
+    pub const FRACTION: Scalar = 0.5;
+
+    /// Computes the AABB margin for a collider with the given `max_extent` and [`PhysicsLengthUnit`].
+    ///
+    /// The margin is clamped to at most [`ColliderAabbMargin::MAX`] scaled by the length unit,
+    /// and at most [`ColliderAabbMargin::FRACTION`] of the maximum extent for small shapes.
+    ///
+    /// [`PhysicsLengthUnit`]: crate::dynamics::solver::PhysicsLengthUnit
+    #[inline]
+    pub fn from_max_extent(max_extent: Scalar, length_unit: Scalar) -> Self {
+        Self((length_unit * Self::MAX).min(Self::FRACTION * max_extent))
     }
 }
 

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -405,7 +405,7 @@ impl AnyCollider for Collider {
         &self,
         position: Vector,
         rotation: impl Into<Rotation>,
-        _: AabbContext<Self::Context>,
+        _: ColliderContext<Self::Context>,
     ) -> ColliderAabb {
         let aabb = self
             .shape_scaled()
@@ -425,7 +425,7 @@ impl AnyCollider for Collider {
         rotation2: impl Into<Rotation>,
         prediction_distance: Scalar,
         manifolds: &mut Vec<ContactManifold>,
-        _: ContactManifoldContext<Self::Context>,
+        _: ColliderPairContext<Self::Context>,
     ) {
         contact_query::contact_manifolds(
             self,

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -439,7 +439,7 @@ impl AnyCollider for Collider {
         )
     }
 
-    fn min_thickness_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
+    fn ccd_thickness_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
         self.shape_scaled().ccd_thickness()
     }
 
@@ -452,7 +452,7 @@ impl AnyCollider for Collider {
         point.distance(bounding_sphere.center) + bounding_sphere.radius
     }
 
-    fn max_extent_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
+    fn bounding_radius_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
         let center_of_mass = self.center_of_mass();
         self.max_distance_to_point(center_of_mass)
     }

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -438,6 +438,19 @@ impl AnyCollider for Collider {
             manifolds,
         )
     }
+
+    fn min_extent_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
+        self.shape_scaled().ccd_thickness()
+    }
+
+    fn max_distance_to_point_with_context(
+        &self,
+        point: Vector,
+        _context: ColliderContext<Self::Context>,
+    ) -> Scalar {
+        let bounding_sphere = self.shape_scaled().compute_local_bounding_sphere();
+        point.distance(bounding_sphere.center) + bounding_sphere.radius
+    }
 }
 
 // TODO: `bevy_heavy` supports computing the individual mass properties efficiently for Bevy's primitive shapes,

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -451,6 +451,11 @@ impl AnyCollider for Collider {
         let bounding_sphere = self.shape_scaled().compute_local_bounding_sphere();
         point.distance(bounding_sphere.center) + bounding_sphere.radius
     }
+
+    fn max_extent_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
+        let center_of_mass = self.center_of_mass();
+        self.max_distance_to_point(center_of_mass)
+    }
 }
 
 // TODO: `bevy_heavy` supports computing the individual mass properties efficiently for Bevy's primitive shapes,

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -453,7 +453,7 @@ impl AnyCollider for Collider {
     }
 
     fn bounding_radius_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
-        let center_of_mass = self.center_of_mass();
+        let center_of_mass = self.center_of_mass().adjust_precision();
         self.max_distance_to_point(center_of_mass)
     }
 }

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -439,7 +439,7 @@ impl AnyCollider for Collider {
         )
     }
 
-    fn min_extent_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
+    fn min_thickness_with_context(&self, _context: ColliderContext<Self::Context>) -> Scalar {
         self.shape_scaled().ccd_thickness()
     }
 

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -173,6 +173,13 @@ pub struct ContactPair {
     ///
     /// [`ConstraintGraph`]: crate::dynamics::solver::constraint_graph::ConstraintGraph
     pub(crate) manifold_count_change: i16,
+    /// An extra speculative contact distance requested by [Continuous Collision Detection](dynamics::ccd)
+    /// for a single timestep.
+    ///
+    /// When greater than zero, the narrow phase computes this pair's manifold even if the
+    /// [AABBs](ColliderAabb) no longer overlap. This ensures that all impacts found by CCD
+    /// are handled by the discrete solver. The distance is reset to zero each timestep.
+    pub(crate) ccd_speculative_distance: Scalar,
     /// Flag indicating the status and type of the contact pair.
     pub flags: ContactPairFlags,
 }
@@ -220,6 +227,7 @@ impl ContactPair {
             body2: None,
             manifolds: Vec::new(),
             manifold_count_change: 0,
+            ccd_speculative_distance: 0.0,
             flags: ContactPairFlags::empty(),
         }
     }

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -173,13 +173,15 @@ pub struct ContactPair {
     ///
     /// [`ConstraintGraph`]: crate::dynamics::solver::constraint_graph::ConstraintGraph
     pub(crate) manifold_count_change: i16,
-    /// An extra speculative contact distance requested by [Continuous Collision Detection](dynamics::ccd)
-    /// for a single timestep.
+    /// A speculative contact distance used to predict contacts before they happen.
+    /// Used for [Continuous Collision Detection (CCD)](dynamics::ccd).
     ///
-    /// When greater than zero, the narrow phase computes this pair's manifold even if the
-    /// [AABBs](ColliderAabb) no longer overlap. This ensures that all impacts found by CCD
-    /// are handled by the discrete solver. The distance is reset to zero each timestep.
-    pub(crate) ccd_speculative_distance: Scalar,
+    /// This is used by Avian to ensure that all impacts found by CCD
+    /// are handled by the discrete solver, but it can also be used
+    /// for speculative contacts in general.
+    ///
+    /// The speculative distance is reset to zero each timestep.
+    pub speculative_distance: Scalar,
     /// Flag indicating the status and type of the contact pair.
     pub flags: ContactPairFlags,
 }
@@ -227,7 +229,7 @@ impl ContactPair {
             body2: None,
             manifolds: Vec::new(),
             manifold_count_change: 0,
-            ccd_speculative_distance: 0.0,
+            speculative_distance: 0.0,
             flags: ContactPairFlags::empty(),
         }
     }

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -82,10 +82,9 @@ pub mod prelude {
     #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
     pub use super::collider::ColliderCachePlugin;
     pub use super::collider::{
-        AabbContext, AnyCollider, ColliderAabb, ColliderBackendPlugin, ColliderDisabled,
-        ColliderMarker, CollidingEntities, CollisionLayers, CollisionMargin,
-        ContactManifoldContext, IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor,
-        SimpleCollider,
+        AnyCollider, ColliderAabb, ColliderBackendPlugin, ColliderContext, ColliderDisabled,
+        ColliderMarker, ColliderPairContext, CollidingEntities, CollisionLayers, CollisionMargin,
+        IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor, SimpleCollider,
         collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
         collider_transform::{ColliderTransform, ColliderTransformPlugin},
     };

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -82,8 +82,9 @@ pub mod prelude {
     #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
     pub use super::collider::ColliderCachePlugin;
     pub use super::collider::{
-        AnyCollider, ColliderAabb, ColliderBackendPlugin, ColliderContext, ColliderDisabled,
-        ColliderMarker, ColliderPairContext, CollidingEntities, CollisionLayers, CollisionMargin,
+        AnyCollider, ColliderAabb, ColliderAabbMargin, ColliderBackendPlugin, ColliderContext,
+        ColliderDisabled, ColliderMarker, ColliderPairContext, CollidingEntities, CollisionLayers,
+        CollisionMargin,
         IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor, SimpleCollider,
         collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
         collider_transform::{ColliderTransform, ColliderTransformPlugin},

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -84,8 +84,8 @@ pub mod prelude {
     pub use super::collider::{
         AnyCollider, ColliderAabb, ColliderAabbMargin, ColliderBackendPlugin, ColliderContext,
         ColliderDisabled, ColliderMarker, ColliderPairContext, CollidingEntities, CollisionLayers,
-        CollisionMargin,
-        IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor, SimpleCollider,
+        CollisionMargin, IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor,
+        SimpleCollider,
         collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
         collider_transform::{ColliderTransform, ColliderTransformPlugin},
     };

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -203,37 +203,18 @@ pub struct CollisionEventSystems;
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Resource, PartialEq)]
 pub struct NarrowPhaseConfig {
-    /// The default maximum [speculative margin](SpeculativeMargin) used for
-    /// [speculative collisions](dynamics::ccd#speculative-collision). This can be overridden
-    /// for individual entities with the [`SpeculativeMargin`] component.
+    /// A small, fixed margin around colliders determining the distance
+    /// at which contacts are predicted before they happen.
     ///
-    /// By default, the maximum speculative margin is unbounded, so contacts can be predicted
-    /// from any distance, provided that the bodies are moving fast enough. As the prediction distance
-    /// grows, the contact data becomes more and more approximate, and in rare cases, it can even cause
-    /// [issues](dynamics::ccd#caveats-of-speculative-collision) such as ghost collisions.
-    ///
-    /// By limiting the maximum speculative margin, these issues can be mitigated, at the cost
-    /// of an increased risk of tunneling. Setting it to `0.0` disables speculative collision
-    /// altogether for entities without [`SpeculativeMargin`].
+    /// This is used for speculative contacts during [Continuous Collision Detection (CCD)](dynamics::ccd)
+    /// to help prevent fast-moving objects from tunneling through geometry.
+    /// It can also help ensure that contacts are not missed due to numerical issues
+    /// or solver jitter for objects that are in continuous contact.
     ///
     /// This is implicitly scaled by the [`PhysicsLengthUnit`].
     ///
-    /// Default: `MAX` (unbounded)
-    pub default_speculative_margin: Scalar,
-
-    /// A contact tolerance that acts as a minimum bound for the [speculative margin](dynamics::ccd#speculative-collision).
-    ///
-    /// A small, positive contact tolerance helps ensure that contacts are not missed
-    /// due to numerical issues or solver jitter for objects that are in continuous
-    /// contact, such as pushing against each other.
-    ///
-    /// Making the contact tolerance too large will have a negative impact on performance,
-    /// as contacts will be computed even for objects that are not in close proximity.
-    ///
-    /// This is implicitly scaled by the [`PhysicsLengthUnit`].
-    ///
-    /// Default: `0.005`
-    pub contact_tolerance: Scalar,
+    /// Default: `0.02`
+    pub speculative_margin: Scalar,
 
     /// If `true`, the current contacts will be matched with the previous contacts
     /// based on feature IDs or contact positions, and the contact impulses from
@@ -249,8 +230,7 @@ pub struct NarrowPhaseConfig {
 impl Default for NarrowPhaseConfig {
     fn default() -> Self {
         Self {
-            default_speculative_margin: Scalar::MAX,
-            contact_tolerance: 0.005,
+            speculative_margin: 0.02,
             match_contacts: true,
         }
     }

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -203,18 +203,14 @@ pub struct CollisionEventSystems;
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Resource, PartialEq)]
 pub struct NarrowPhaseConfig {
-    /// A small, fixed margin around colliders determining the distance
-    /// at which contacts are predicted before they happen.
-    ///
-    /// This is used for speculative contacts during [Continuous Collision Detection (CCD)](dynamics::ccd)
-    /// to help prevent fast-moving objects from tunneling through geometry.
-    /// It can also help ensure that contacts are not missed due to numerical issues
-    /// or solver jitter for objects that are in continuous contact.
+    /// A small, positive contact tolerance to help ensure that contacts are not missed
+    /// due to numerical issues or solver jitter for objects that are in continuous
+    /// contact, such as pushing against each other.
     ///
     /// This is implicitly scaled by the [`PhysicsLengthUnit`].
     ///
     /// Default: `0.02`
-    pub speculative_margin: Scalar,
+    pub contact_tolerance: Scalar,
 
     /// If `true`, the current contacts will be matched with the previous contacts
     /// based on feature IDs or contact positions, and the contact impulses from
@@ -230,7 +226,8 @@ pub struct NarrowPhaseConfig {
 impl Default for NarrowPhaseConfig {
     fn default() -> Self {
         Self {
-            speculative_margin: 0.02,
+            // TODO: Investigate if this could be smaller
+            contact_tolerance: 0.02,
             match_contacts: true,
         }
     }

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -698,11 +698,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // TODO: It'd be good to persist the manifolds and let Parry match contacts.
                 //       This isn't currently done because it requires using Parry's contact manifold type.
                 // Compute the contact manifolds using the effective speculative margin.
-                let context = ContactManifoldContext::new(
-                    collider1.entity,
-                    collider2.entity,
-                    collider_context,
-                );
+                let context =
+                    ColliderPairContext::new(collider1.entity, collider2.entity, collider_context);
                 collider1.shape.contact_manifolds_with_context(
                     collider2.shape,
                     collider1.position.0,

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -54,6 +54,7 @@ struct RigidBodyQuery {
     friction: Option<Read<Friction>>,
     restitution: Option<Read<Restitution>>,
     collision_margin: Option<Read<CollisionMargin>>,
+    speculative_ccd: Option<Read<SpeculativeCcd>>,
 }
 
 /// A system parameter for managing the narrow phase.
@@ -434,7 +435,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     ) where
         for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
     {
-        let contact_tolerance = self.length_unit.0 * self.config.contact_tolerance;
+        let length_unit = self.length_unit.0;
+        let contact_tolerance = length_unit * self.config.contact_tolerance;
+        let inv_delta_secs = delta_secs.recip();
 
         // Contact bit vecs must be sized based on the full contact capacity,
         // not the number of active contact pairs, because pair indices
@@ -500,7 +503,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
             // An extra speculative distance requested for this timestep.
             // This can be used to ensure that TOI impacts are handled by the discrete solver,
             // or more generally for speculative contacts.
-            let speculative_distance = core::mem::take(&mut contacts.speculative_distance);
+            let mut speculative_distance = core::mem::take(&mut contacts.speculative_distance);
 
             // Check if the AABBs of the colliders still overlap and the contact pair is valid.
             let overlap = collider1.enlarged_aabb.intersects(
@@ -536,6 +539,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     ang_vel1,
                     rb_friction1,
                     rb_collision_margin1,
+                    speculative_ccd1,
                 ) = body1_bundle
                     .as_ref()
                     .map(|body| {
@@ -547,6 +551,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
+                            body.speculative_ccd.copied(),
                         )
                     })
                     .unwrap_or_default();
@@ -558,6 +563,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     ang_vel2,
                     rb_friction2,
                     rb_collision_margin2,
+                    speculative_ccd2,
                 ) = body2_bundle
                     .as_ref()
                     .map(|body| {
@@ -569,6 +575,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
+                            body.speculative_ccd.copied(),
                         )
                     })
                     .unwrap_or_default();
@@ -642,10 +649,31 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // at each contact point for restitution and speculative contact pruning.
                 let relative_linear_velocity = lin_vel2 - lin_vel1;
 
+                // Compute the effective speculative margin from the opt-in `SpeculativeCcd` component.
+                let max_distance1 = speculative_ccd1.map_or(0.0, |s| s.max_distance);
+                let max_distance2 = speculative_ccd2.map_or(0.0, |s| s.max_distance);
+
+                if max_distance1 != 0.0 || max_distance2 != 0.0 {
+                    // Clamp each body's contribution to its maximum speculative distance.
+                    let clamped_vel1 = if max_distance1 < Scalar::MAX {
+                        lin_vel1.clamp_length_max(max_distance1 * inv_delta_secs)
+                    } else {
+                        lin_vel1
+                    };
+                    let clamped_vel2 = if max_distance2 < Scalar::MAX {
+                        lin_vel2.clamp_length_max(max_distance2 * inv_delta_secs)
+                    } else {
+                        lin_vel2
+                    };
+
+                    // The margin is how far the bodies are expected to move relative to each other.
+                    let margin = (clamped_vel2 - clamped_vel1).length() * delta_secs;
+                    speculative_distance = margin.max(speculative_distance).max(contact_tolerance);
+                }
+
                 // The maximum distance at which contacts are detected.
-                // At least as large as the contact tolerance.
-                let max_contact_distance =
-                    contact_tolerance + collision_margin_sum + speculative_distance;
+                // This is at least as large as the contact tolerance.
+                let max_contact_distance = collision_margin_sum + speculative_distance;
 
                 let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
 
@@ -707,9 +735,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                         // Keep the contact if (1) the separation distance is below the required threshold,
                         // or if (2) the bodies are expected to come into contact within the next time step.
-                        -point.penetration < contact_tolerance || {
+                        -point.penetration < speculative_distance || {
                             let delta_distance = normal_speed * delta_secs;
-                            delta_distance - point.penetration < contact_tolerance
+                            delta_distance - point.penetration < speculative_distance
                         }
                     });
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -497,8 +497,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 return;
             };
 
+            // An extra speculative distance requested by CCD for this timestep
+            // to ensure that the impact is handled by the discrete solver.
+            let ccd_speculative_distance = core::mem::take(&mut contacts.ccd_speculative_distance);
+
             // Check if the AABBs of the colliders still overlap and the contact pair is valid.
-            let overlap = collider1.enlarged_aabb.intersects(collider2.enlarged_aabb);
+            let overlap = collider1.enlarged_aabb.intersects(collider2.enlarged_aabb)
+                || ccd_speculative_distance > 0.0;
 
             // Also check if the collision layers are still compatible and the contact pair is valid.
             // TODO: Ideally, we would have fine-grained change detection for `CollisionLayers`
@@ -635,7 +640,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                 // The maximum distance at which contacts are detected.
                 // At least as large as the speculative margin.
-                let max_contact_distance = speculative_margin + collision_margin_sum;
+                let max_contact_distance =
+                    speculative_margin + collision_margin_sum + ccd_speculative_distance;
 
                 let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -434,7 +434,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     ) where
         for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
     {
-        let speculative_margin = self.length_unit.0 * self.config.speculative_margin;
+        let contact_tolerance = self.length_unit.0 * self.config.contact_tolerance;
 
         // Contact bit vecs must be sized based on the full contact capacity,
         // not the number of active contact pairs, because pair indices
@@ -497,13 +497,17 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 return;
             };
 
-            // An extra speculative distance requested by CCD for this timestep
-            // to ensure that the impact is handled by the discrete solver.
-            let ccd_speculative_distance = core::mem::take(&mut contacts.ccd_speculative_distance);
+            // An extra speculative distance requested for this timestep.
+            // This can be used to ensure that TOI impacts are handled by the discrete solver,
+            // or more generally for speculative contacts.
+            let speculative_distance = core::mem::take(&mut contacts.speculative_distance);
 
             // Check if the AABBs of the colliders still overlap and the contact pair is valid.
-            let overlap = collider1.enlarged_aabb.intersects(collider2.enlarged_aabb)
-                || ccd_speculative_distance > 0.0;
+            let overlap = collider1.enlarged_aabb.intersects(
+                &collider2
+                    .enlarged_aabb
+                    .grow(Vector::splat(speculative_distance)),
+            );
 
             // Also check if the collision layers are still compatible and the contact pair is valid.
             // TODO: Ideally, we would have fine-grained change detection for `CollisionLayers`
@@ -639,9 +643,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 let relative_linear_velocity = lin_vel2 - lin_vel1;
 
                 // The maximum distance at which contacts are detected.
-                // At least as large as the speculative margin.
+                // At least as large as the contact tolerance.
                 let max_contact_distance =
-                    speculative_margin + collision_margin_sum + ccd_speculative_distance;
+                    contact_tolerance + collision_margin_sum + speculative_distance;
 
                 let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
 
@@ -650,7 +654,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                 // TODO: It'd be good to persist the manifolds and let Parry match contacts.
                 //       This isn't currently done because it requires using Parry's contact manifold type.
-                // Compute the contact manifolds using the effective speculative margin.
+                // Compute the contact manifolds.
                 let context =
                     ColliderPairContext::new(collider1.entity, collider2.entity, collider_context);
                 collider1.shape.contact_manifolds_with_context(
@@ -703,9 +707,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                         // Keep the contact if (1) the separation distance is below the required threshold,
                         // or if (2) the bodies are expected to come into contact within the next time step.
-                        -point.penetration < speculative_margin || {
+                        -point.penetration < contact_tolerance || {
                             let delta_distance = normal_speed * delta_secs;
-                            delta_distance - point.penetration < speculative_margin
+                            delta_distance - point.penetration < contact_tolerance
                         }
                     });
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -38,7 +38,6 @@ struct ColliderQuery<C: AnyCollider> {
     friction: Option<Read<Friction>>,
     restitution: Option<Read<Restitution>>,
     collision_margin: Option<Read<CollisionMargin>>,
-    speculative_margin: Option<Read<SpeculativeMargin>>,
     is_sensor: Has<Sensor>,
 }
 
@@ -55,7 +54,6 @@ struct RigidBodyQuery {
     friction: Option<Read<Friction>>,
     restitution: Option<Read<Restitution>>,
     collision_margin: Option<Read<CollisionMargin>>,
-    speculative_margin: Option<Read<SpeculativeMargin>>,
 }
 
 /// A system parameter for managing the narrow phase.
@@ -86,9 +84,6 @@ pub struct NarrowPhase<'w, 's, C: AnyCollider> {
     default_friction: Res<'w, DefaultFriction>,
     default_restitution: Res<'w, DefaultRestitution>,
     length_unit: Res<'w, PhysicsLengthUnit>,
-    // These are scaled by the length unit.
-    default_speculative_margin: Local<'s, Scalar>,
-    contact_tolerance: Local<'s, Scalar>,
 }
 
 /// A bit vector for tracking contact status changes.
@@ -125,13 +120,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     ) where
         for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
     {
-        // Cache default margins scaled by the length unit.
-        if self.config.is_changed() {
-            *self.default_speculative_margin =
-                self.length_unit.0 * self.config.default_speculative_margin;
-            *self.contact_tolerance = self.length_unit.0 * self.config.contact_tolerance;
-        }
-
         // Update contacts for all contact pairs.
         self.update_contacts::<H>(delta_secs, hooks, context, commands);
 
@@ -446,6 +434,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     ) where
         for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
     {
+        let speculative_margin = self.length_unit.0 * self.config.speculative_margin;
+
         // Contact bit vecs must be sized based on the full contact capacity,
         // not the number of active contact pairs, because pair indices
         // are unstable and can be invalidated when pairs are removed.
@@ -527,17 +517,16 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     .of
                     .and_then(|&ColliderOf { body }| self.body_query.get(body).ok());
 
-                // The rigid body's friction, restitution, collision margin, and speculative margin
+                // The rigid body's friction, restitution, and collision margin
                 // will be used if the collider doesn't have them specified.
                 let (
                     is_static1,
                     collider_offset1,
                     world_com1,
-                    mut lin_vel1,
+                    lin_vel1,
                     ang_vel1,
                     rb_friction1,
                     rb_collision_margin1,
-                    rb_speculative_margin1,
                 ) = body1_bundle
                     .as_ref()
                     .map(|body| {
@@ -549,7 +538,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
-                            body.speculative_margin,
                         )
                     })
                     .unwrap_or_default();
@@ -557,11 +545,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     is_static2,
                     collider_offset2,
                     world_com2,
-                    mut lin_vel2,
+                    lin_vel2,
                     ang_vel2,
                     rb_friction2,
                     rb_collision_margin2,
-                    rb_speculative_margin2,
                 ) = body2_bundle
                     .as_ref()
                     .map(|body| {
@@ -573,7 +560,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
-                            body.speculative_margin,
                         )
                     })
                     .unwrap_or_default();
@@ -643,52 +629,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     .map_or(0.0, |margin| margin.0);
                 let collision_margin_sum = collision_margin1 + collision_margin2;
 
-                // Use the collider's own speculative margin if specified, and fall back to the body's
-                // speculative margin.
-                //
-                // The speculative margin is used to predict contacts that might happen during the frame.
-                // This is used for speculative collision. See the CCD and `SpeculativeMargin` documentation
-                // for more details.
-                let speculative_margin1 = collider1
-                    .speculative_margin
-                    .map_or(rb_speculative_margin1.map(|margin| margin.0), |margin| {
-                        Some(margin.0)
-                    });
-                let speculative_margin2 = collider2
-                    .speculative_margin
-                    .map_or(rb_speculative_margin2.map(|margin| margin.0), |margin| {
-                        Some(margin.0)
-                    });
-
-                let relative_linear_velocity: Vector;
-
-                // Compute the effective speculative margin, clamping it based on velocities and the maximum bound.
-                let effective_speculative_margin = {
-                    let speculative_margin1 =
-                        speculative_margin1.unwrap_or(*self.default_speculative_margin);
-                    let speculative_margin2 =
-                        speculative_margin2.unwrap_or(*self.default_speculative_margin);
-                    let inv_delta_secs = delta_secs.recip();
-
-                    // Clamp velocities to the maximum speculative margins.
-                    if speculative_margin1 < Scalar::MAX {
-                        lin_vel1 = lin_vel1.clamp_length_max(speculative_margin1 * inv_delta_secs);
-                    }
-                    if speculative_margin2 < Scalar::MAX {
-                        lin_vel2 = lin_vel2.clamp_length_max(speculative_margin2 * inv_delta_secs);
-                    }
-
-                    // Compute the effective margin based on how much the bodies
-                    // are expected to move relative to each other.
-                    relative_linear_velocity = lin_vel2 - lin_vel1;
-                    delta_secs * relative_linear_velocity.length()
-                };
+                // The relative linear velocity is used below to compute the normal speed
+                // at each contact point for restitution and speculative contact pruning.
+                let relative_linear_velocity = lin_vel2 - lin_vel1;
 
                 // The maximum distance at which contacts are detected.
-                // At least as large as the contact tolerance.
-                let max_contact_distance = effective_speculative_margin
-                    .max(*self.contact_tolerance)
-                    + collision_margin_sum;
+                // At least as large as the speculative margin.
+                let max_contact_distance = speculative_margin + collision_margin_sum;
 
                 let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
 
@@ -750,9 +697,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                         // Keep the contact if (1) the separation distance is below the required threshold,
                         // or if (2) the bodies are expected to come into contact within the next time step.
-                        -point.penetration < effective_speculative_margin || {
+                        -point.penetration < speculative_margin || {
                             let delta_distance = normal_speed * delta_secs;
-                            delta_distance - point.penetration < effective_speculative_margin
+                            delta_distance - point.penetration < speculative_margin
                         }
                     });
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -668,11 +668,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                     // The margin is how far the bodies are expected to move relative to each other.
                     let margin = (clamped_vel2 - clamped_vel1).length() * delta_secs;
-                    speculative_distance = margin.max(speculative_distance).max(contact_tolerance);
+                    speculative_distance = margin.max(speculative_distance);
                 }
 
+                // Ensure that the speculative distance is at least as large as the contact tolerance.
+                speculative_distance = speculative_distance.max(contact_tolerance);
+
                 // The maximum distance at which contacts are detected.
-                // This is at least as large as the contact tolerance.
                 let max_contact_distance = collision_margin_sum + speculative_distance;
 
                 let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -59,6 +59,15 @@ pub struct PhysicsGizmos {
     /// The colors (in HSLA) for [sleeping](Sleeping) bodies will be multiplied by this array.
     /// If `None`, sleeping will have no effect on the colors.
     pub sleeping_color_multiplier: Option<[f32; 4]>,
+    /// The color used for the [collider](Collider) wireframes of bodies that were treated as
+    /// fast-moving and swept by [Continuous Collision Detection](crate::dynamics::ccd) during the
+    /// last physics step. If `None`, fast bodies use the normal [`collider_color`](Self::collider_color).
+    pub fast_body_color: Option<Color>,
+    /// The color used for the [collider](Collider) wireframes of bodies whose motion was stopped at
+    /// a time of impact by [Continuous Collision Detection](crate::dynamics::ccd) during the last
+    /// physics step. Takes priority over [`fast_body_color`](Self::fast_body_color). If `None`,
+    /// these bodies use the normal [`collider_color`](Self::collider_color).
+    pub time_of_impact_color: Option<Color>,
     /// The color of the contact points. If `None`, the contact points will not be rendered.
     pub contact_point_color: Option<Color>,
     /// The color of the contact normals. If `None`, the contact normals will not be rendered.
@@ -99,6 +108,8 @@ impl Default for PhysicsGizmos {
             aabb_color: None,
             collider_color: Some(ORANGE.into()),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
+            fast_body_color: Some(SALMON.into()),
+            time_of_impact_color: Some(Color::srgb(0.0, 1.0, 0.0)),
             contact_point_color: None,
             contact_normal_color: None,
             contact_normal_scale: ContactGizmoScale::default(),
@@ -144,6 +155,8 @@ impl PhysicsGizmos {
             aabb_color: Some(Color::srgb(0.8, 0.8, 0.8)),
             collider_color: Some(ORANGE.into()),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
+            fast_body_color: Some(SALMON.into()),
+            time_of_impact_color: Some(Color::srgb(0.0, 1.0, 0.0)),
             contact_point_color: Some(LIGHT_CYAN.into()),
             contact_normal_color: Some(RED.into()),
             contact_normal_scale: ContactGizmoScale::default(),
@@ -171,6 +184,8 @@ impl PhysicsGizmos {
             aabb_color: None,
             collider_color: None,
             sleeping_color_multiplier: None,
+            fast_body_color: None,
+            time_of_impact_color: None,
             contact_point_color: None,
             contact_normal_color: None,
             contact_normal_scale: ContactGizmoScale::default(),

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -15,7 +15,10 @@ use crate::{
     collider_tree::ColliderTrees,
     dynamics::{
         joints::EntityConstraint,
-        solver::islands::{BodyIslandNode, PhysicsIslands},
+        solver::{
+            islands::{BodyIslandNode, PhysicsIslands},
+            solver_body::{SolverBody, SolverBodyFlags},
+        },
     },
     prelude::*,
 };
@@ -289,6 +292,7 @@ fn debug_render_colliders(
         Option<&DebugRender>,
     )>,
     sleeping: Query<(), With<Sleeping>>,
+    solver_bodies: Query<&SolverBody>,
     mut gizmos: Gizmos<PhysicsGizmos>,
     store: Res<GizmoConfigStore>,
 ) {
@@ -299,8 +303,26 @@ fn debug_render_colliders(
         if let Some(mut color) = render_config.map_or(config.collider_color, |c| c.collider_color) {
             let collider_rb = collider_rb.map_or(entity, |c| c.body);
 
-            // If the body is sleeping, multiply the color by the sleeping color multiplier
-            if sleeping.contains(collider_rb) {
+            let ccd_color = (render_config.is_none())
+                .then(|| solver_bodies.get(collider_rb).ok())
+                .flatten()
+                .and_then(|solver_body| {
+                    if solver_body
+                        .flags
+                        .contains(SolverBodyFlags::HAD_TIME_OF_IMPACT)
+                    {
+                        config.time_of_impact_color
+                    } else if solver_body.flags.contains(SolverBodyFlags::IS_FAST) {
+                        config.fast_body_color
+                    } else {
+                        None
+                    }
+                });
+
+            if let Some(ccd_color) = ccd_color {
+                color = ccd_color;
+            } else if sleeping.contains(collider_rb) {
+                // If the body is sleeping, multiply the color by the sleeping color multiplier.
                 let hsla = Hsla::from(color).to_vec4();
                 if let Some(mul) = render_config.map_or(config.sleeping_color_multiplier, |c| {
                     c.sleeping_color_multiplier
@@ -308,6 +330,7 @@ fn debug_render_colliders(
                     color = Hsla::from_vec4(hsla * Vec4::from_array(mul)).into();
                 }
             }
+
             gizmos.draw_collider(collider, position, rotation, color);
         }
     }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -231,18 +231,24 @@
 //! However, this comes at the cost of worse performance for the entire simulation.
 
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-use super::solver::solver_body::SolverBody;
+use super::solver::solver_body::{SolverBody, SolverBodyFlags};
 use crate::prelude::*;
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
+use crate::{
+    collider_tree::{ColliderTree, ColliderTreeProxyFlags, ColliderTrees},
+    math::make_pose,
+};
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use bevy::ecs::query::QueryData;
 use bevy::prelude::*;
-use derive_more::From;
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
+use core::cell::RefCell;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use dynamics::solver::SolverDiagnostics;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-use parry::query::{
-    NonlinearRigidMotion, ShapeCastHit, ShapeCastOptions, cast_shapes, cast_shapes_nonlinear,
-};
+use parry::query::{NonlinearRigidMotion, ShapeCastOptions, cast_shapes, cast_shapes_nonlinear};
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
+use thread_local::ThreadLocal;
 
 /// A plugin for [Continuous Collision Detection](self).
 pub struct CcdPlugin;
@@ -254,77 +260,26 @@ impl Plugin for CcdPlugin {
             .get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first");
 
-        physics.configure_sets(
-            SweptCcdSystems
-                .after(SolverSystems::PostSubstep)
-                .before(SolverSystems::Restitution),
-        );
-
         #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-        physics.add_systems(solve_swept_ccd.in_set(SweptCcdSystems));
+        physics.add_systems(solve_continuous.in_set(SolverSystems::ContinuousCollision));
     }
 }
 
-/// A system set for [Continuous Collision Detection](self) systems.
-#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct SweptCcdSystems;
-
-/// A deprecated alias for [`SweptCcdSystems`].
-#[deprecated(since = "0.4.0", note = "Renamed to `SweptCcdSystems`")]
-pub type SweptCcdSet = SweptCcdSystems;
-
-/// The maximum distance at which [speculative contacts](self#speculative-collision)
-/// are generated for this entity. A value greater than zero helps prevent missing
-/// contacts for moderately fast-moving and thin objects.
+/// A component that configures [Continuous Collision Detection](self) (CCD)
+/// for a [dynamic](RigidBody::Dynamic) [`RigidBody`].
 ///
-/// In general, this component should not be needed. The default speculative margin
-/// for all objects is defined in the [`NarrowPhaseConfig`] resource, and it is unbounded
-/// by default, meaning that the margin can extend infinitely. The margin can be bounded
-/// for individual entities using this component in case speculative contacts are causing
-/// issues like the ones outlined [here](self#caveats-of-speculative-collision).
+/// Only dynamic bodies support CCD. Fast-moving dynamic bodies are swept against static and
+/// kinematic bodies automatically, even without this component (see the
+/// [module-level documentation](self)). Add `CcdSettings` to:
 ///
-/// See the [module-level documentation](self) for information about
-/// Speculative Conllision and Continuous Collision Detection in general.
+/// - also sweep the body against other **dynamic** bodies (via [`include_dynamic`](Self::include_dynamic))
+/// - choose the [sweep mode](SweepMode) (via [`mode`](Self::mode))
+/// - disable CCD for the body (via [`enabled`](Self::enabled))
 ///
-/// # Example
+/// The component has no effect on static or kinematic bodies.
 ///
-/// ```
-#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
-#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
-/// use bevy::prelude::*;
-///
-/// fn setup(mut commands: Commands) {
-///     // Spawn a rigid body with an unbounded speculative margin.
-///     commands.spawn((
-///         RigidBody::Dynamic,
-///         Collider::capsule(0.5, 2.0),
-///         SpeculativeMargin::MAX,
-///     ));
-/// }
-/// ```
-#[derive(Component, Clone, Copy, Debug, Deref, DerefMut, PartialEq, Reflect, From)]
-#[reflect(Component)]
-#[doc(alias = "SweptCcdPredictionDistance")]
-pub struct SpeculativeMargin(pub Scalar);
-
-impl SpeculativeMargin {
-    /// A zero speculative margin. Disables speculative collision for this entity.
-    pub const ZERO: Self = Self(0.0);
-
-    /// An unbounded speculative margin.
-    pub const MAX: Self = Self(Scalar::MAX);
-}
-
-/// A component that enables sweep-based [Continuous Collision Detection](self) (CCD)
-/// for a [`RigidBody`]. This helps prevent missed collisions for small and fast-moving objects.
-///
-/// By default, swept CCD considers both translational and rotational motion, and is used
-/// against all types of rigid bodies and colliders. This behavior can be modified
-/// by changing [`SweptCcd::mode`] and other properties.
-///
-/// CCD is generally not useful for large or slow objects, as they are less likely
-/// to miss collisions. It is recommended to only use swept CCD when necessary,
-/// as it is more expensive than [speculative collision](self#speculative-collision) and discrete collision detection.
+/// By default, CCD considers both translational and rotational motion, and sweeps against
+/// static and kinematic bodies but not other dynamic bodies.
 ///
 /// Read the [module-level documentation](self) for more information about what CCD is,
 /// what it is used for, and what limitations and tradeoffs it can have.
@@ -338,11 +293,10 @@ impl SpeculativeMargin {
 ///
 /// # #[cfg(feature = "f32")]
 /// fn setup(mut commands: Commands) {
-///     // Spawn a dynamic rigid body with swept CCD, travelling towards the right at a high speed.
-///     // The default CCD configuration considers both translational and rotational motion.
+///     // A fast dynamic body is swept against static and kinematic bodies automatically,
+///     // so it needs no extra components.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         SweptCcd::default(),
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
@@ -350,145 +304,114 @@ impl SpeculativeMargin {
 ///         Transform::from_xyz(-10.0, 3.0, 0.0),
 ///     ));
 ///
-///     // Spawn another dynamic rigid body with swept CCD, but this time only considering
-///     // linear motion and not rotation.
+///     // Spawn another body that only considers linear motion and not rotation,
+///     // and is additionally swept against other dynamic bodies.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         SweptCcd::LINEAR, // or `SweptCcd::new_with_mode(SweepMode::Linear)`
+///         CcdSettings::default()
+///             .with_mode(SweepMode::Linear)
+///             .with_include_dynamic(true),
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
 #[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
 ///         Transform::from_xyz(-10.0, -3.0, 0.0),
 ///     ));
-///
-///     // Spawn a thin, long object rotating at a high speed.
-///     // The first ball should hit it, but the second one does not consider
-///     // rotational motion, and most likely passes through.
-///     commands.spawn((
-///         RigidBody::Dynamic,
-///         LockedAxes::TRANSLATION_LOCKED,
-#[cfg_attr(feature = "2d", doc = "        AngularVelocity(100.0),")]
-#[cfg_attr(feature = "3d", doc = "        AngularVelocity(Vec3::Z * 100.0),")]
-#[cfg_attr(feature = "2d", doc = "        Collider::rectangle(0.2, 10.0),")]
-#[cfg_attr(feature = "3d", doc = "        Collider::cuboid(0.2, 10.0, 10.0),")]
-///     ));
-///
-///     // Spawn another thin, long object, this time not rotating.
-///     // The second ball should now hit this.
-///     commands.spawn((
-///         RigidBody::Static,
-#[cfg_attr(feature = "2d", doc = "        Collider::rectangle(0.2, 10.0),")]
-#[cfg_attr(feature = "3d", doc = "        Collider::cuboid(0.2, 10.0, 10.0),")]
-///         Transform::from_xyz(15.0, 0.0, 0.0),
-///     ));
 /// }
 /// ```
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
-#[reflect(Component)]
-pub struct SweptCcd {
-    /// The type of sweep used for swept CCD.
+#[reflect(Component, Debug, Default, PartialEq)]
+pub struct CcdSettings {
+    /// Whether CCD is enabled for this body.
     ///
-    /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
-    /// is preferred.
+    /// Setting this to `false` disables CCD for the body entirely.
+    /// This can improve performance but can lead to tunneling.
     ///
-    /// The default is [`SweepMode::NonLinear`], which considers both translational
-    /// and rotational motion.
+    /// Disabling CCD should rarely be necessary, as it is only performed
+    /// for fast-moving bodies, and should have a minimal performance impact
+    /// for most applications.
+    ///
+    /// **Default**: `true`
+    pub enabled: bool,
+
+    /// The [sweep mode](SweepMode) used for this body.
+    ///
+    /// The [`Linear`](SweepMode::Linear) mode is cheaper but only considers translational motion,
+    /// so it can lead to tunneling against thin, fast-spinning objects, while the [`NonLinear`](SweepMode::NonLinear)
+    /// mode is more expensive but also considers rotational motion.
+    ///
+    /// If two bodies with different sweep modes collide, [`SweepMode::NonLinear`] is preferred.
+    ///
+    /// **Default**: [`SweepMode::NonLinear`]
     pub mode: SweepMode,
-    /// If `true`, swept CCD is performed against dynamic rigid bodies.
-    /// Otherwise, it is only performed against static geometry and kinematic bodies.
+
+    /// Whether the body is additionally swept against other dynamic bodies.
     ///
-    /// The default is `true`.
+    /// Dynamic bodies are always swept against static and kinematic bodies;
+    /// this only controls whether they are also swept against each other.
+    ///
+    /// **Default**: `false`
     pub include_dynamic: bool,
-    /// Determines how fast two bodies must be moving relative to each other
-    /// for swept CCD to be activated for them.
-    ///
-    /// If the linear velocity is below this threshold, CCD is skipped,
-    /// unless the angular velocity exceeds the `angular_threshold`.
-    ///
-    /// The default is `0.0`, meaning that CCD is performed regardless of the relative velocity.
-    pub linear_threshold: Scalar,
-    /// Determines how fast two bodies must be rotating relative to each other
-    /// for swept CCD to be activated for them.
-    ///
-    /// If the angular velocity is below this threshold, CCD is skipped,
-    /// unless the linear velocity exceeds the `linear_threshold`.
-    ///
-    /// The default is `0.0`, meaning that CCD is performed regardless of the relative velocity.
-    pub angular_threshold: Scalar,
 }
 
-impl Default for SweptCcd {
+impl Default for CcdSettings {
     fn default() -> Self {
-        Self::NON_LINEAR
+        Self::new()
     }
 }
 
-impl SweptCcd {
-    /// Continuous Collision Detection with [`SweepMode::Linear`].
-    ///
-    /// This only takes into account translational motion, and can lead to tunneling
-    /// against thin, fast-spinning objects.
-    pub const LINEAR: Self = Self::new_with_mode(SweepMode::Linear);
-
-    /// Continuous Collision Detection with [`SweepMode::NonLinear`].
-    ///
-    /// This takes into account both translational and rotational motion.
-    pub const NON_LINEAR: Self = Self::new_with_mode(SweepMode::NonLinear);
-
-    /// Creates a new [`SweptCcd`] configuration with the given [`SweepMode`].
+impl CcdSettings {
+    /// Creates a [`CcdSettings`] configuration with default settings: CCD enabled,
+    /// [`SweepMode::NonLinear`], swept against static and kinematic bodies but not dynamic bodies.
     #[inline]
-    pub const fn new_with_mode(mode: SweepMode) -> Self {
+    pub const fn new() -> Self {
         Self {
-            mode,
-            include_dynamic: true,
-            linear_threshold: 0.0,
-            angular_threshold: 0.0,
+            enabled: true,
+            mode: SweepMode::NonLinear,
+            include_dynamic: false,
         }
     }
 
-    /// Sets the linear and angular velocity thresholds in `self`,
-    /// determining how fast two bodies must be moving relative to each other
-    /// for swept CCD to be activated for them.
-    ///
-    /// CCD will be active if either of the two thresholds is exceeded.
+    /// Sets whether CCD is enabled for this body.
     #[inline]
-    pub const fn with_velocity_threshold(mut self, linear: Scalar, angular: Scalar) -> Self {
-        self.linear_threshold = linear;
-        self.angular_threshold = angular;
+    pub const fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
         self
     }
 
-    /// Sets whether swept CCD is performed against dynamic rigid bodies.
-    /// If `false`, it is only performed against static geometry and kinematic bodies.
+    /// Sets the [sweep mode](SweepMode) used for this body.
     #[inline]
-    pub const fn include_dynamic(mut self, should_include: bool) -> Self {
-        self.include_dynamic = should_include;
+    pub const fn with_mode(mut self, mode: SweepMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Sets whether the body is additionally swept against other dynamic bodies.
+    #[inline]
+    pub const fn with_include_dynamic(mut self, include_dynamic: bool) -> Self {
+        self.include_dynamic = include_dynamic;
         self
     }
 }
 
-/// The algorithm used for [Swept Continuous Collision Detection](self#swept-ccd).
+/// The algorithm used for sweepds during [Continuous Collision Detection](self#swept-ccd).
 ///
-/// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
-/// is preferred.
+/// If two entities with different sweep modes collide, [`SweepMode::NonLinear`] is preferred.
 ///
 /// The default is [`SweepMode::NonLinear`], which considers both translational
 /// and rotational motion.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
 pub enum SweepMode {
-    /// [Swept CCD](self#swept-ccd) is performed using linear time-of-impact queries
-    /// from the previous positions of [`SweptCcd`] bodies to their current positions,
-    /// stopping the bodies at the first time of impact.
+    /// Sweeps are performed using linear time-of-impact queries from the previous positions
+    /// of fast bodies to their current positions, stopping the bodies at the first time of impact.
     ///
     /// This mode only considers translational motion, and can lead to tunneling
     /// against thin, fast-spinning objects. For the more expensive version
     /// that also considers rotational motion, consider using [`SweepMode::NonLinear`].
     Linear,
 
-    /// [Swept CCD](self#swept-ccd) is performed using non-linear time-of-impact queries
-    /// from the previous positions of [`SweptCcd`] bodies to their current positions,
-    /// stopping the bodies at the first time of impact.
+    /// Sweeps are performed using non-linear time-of-impact queries from the previous positions
+    /// of fast bodies to their current positions, stopping the bodies at the first time of impact.
     ///
     /// This mode considers both translational and rotational motion.
     /// For the cheaper version that only considers translational motion,
@@ -497,188 +420,276 @@ pub enum SweepMode {
     NonLinear,
 }
 
+/// Read-only [`SolverBody`] motion data used to reconstruct a body's per-frame sweep.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 #[derive(QueryData)]
-#[query_data(mutable)]
-struct SweptCcdBodyQuery {
+struct CcdBodyQuery {
     entity: Entity,
-    solver_body: Option<&'static mut SolverBody>,
-    rb: &'static RigidBody,
-    pos: &'static Position,
-    rot: &'static Rotation,
-    ccd: Option<&'static SweptCcd>,
-    collider: &'static Collider,
+    body: &'static SolverBody,
+    position: &'static Position,
+    rotation: &'static Rotation,
     com: &'static ComputedCenterOfMass,
+    colliders: &'static RigidBodyColliders,
+    body_radii: &'static BodyRadii,
+    ccd: Option<&'static CcdSettings>,
 }
 
-/// Performs [sweep-based mContinuous Collision Detection](self#swept-ccd)
-/// by performing time-of-impact queries from the previous positions of [`SweptCcd`] bodies
-/// to their current positions, stopping the bodies at the first time of impact.
+/// A time-of-impact result for a single fast body.
+struct CcdResult {
+    /// The fast body that was swept.
+    entity: Entity,
+    /// The time of impact fraction in `[0, 1]`,
+    fraction: Scalar,
+}
+
+/// Performs [Continuous Collision Detection](self).
 ///
-/// This approach can lead to "time loss" or "time stealing", because the bodies
-/// are essentially moved back in time, making them appear to momentarily move slower.
-/// Secondary contacts are also not accounted for.
-#[allow(clippy::useless_conversion)]
+/// Every dynamic body whose per-frame motion is large relative to its thickness is treated
+/// as a "fast body" and swept against static and kinematic (and optionally dynamic) bodies.
+///
+/// If a time of impact is found, the body's accumulated motion is scaled down so it stops
+/// at the first impact, leaving the next frame's collision detection to resolve the contact.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-fn solve_swept_ccd(
-    ccd_query: Query<Entity, With<SweptCcd>>,
-    bodies: Query<SweptCcdBodyQuery>,
-    colliders: Query<(&Collider, &ColliderOf)>,
-    time: Res<Time>,
+fn solve_continuous(
+    colliders: Query<(&Collider, &Position, &Rotation)>,
+    mut bodies: ParamSet<(Query<CcdBodyQuery>, Query<&mut SolverBody>)>,
+    trees: Res<ColliderTrees>,
     contact_graph: Res<ContactGraph>,
-    narrow_phase_config: Res<NarrowPhaseConfig>,
+    time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
+    /// The fraction of a body's minimum thickness it may travel in a frame before being
+    /// treated as a fast body.
+    const FAST_BODY_SAFETY_FACTOR: Scalar = 0.5;
+
     let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
+    if delta_secs <= 0.0 {
+        return;
+    }
+    let inv_dt = 1.0 / delta_secs;
 
-    let mut dummy_body = SolverBody::default();
+    // Per-thread time-of-impact fractions (in `[0, 1]`) for each fast body. A fraction of `1.0`
+    // means the body is fast but no impact was found.
+    let thread_local_results: ThreadLocal<RefCell<Vec<CcdResult>>> = ThreadLocal::new();
 
-    // TODO: Parallelize.
-    for entity in &ccd_query {
-        // Get the CCD body.
-        let Ok(SweptCcdBodyQueryItem {
-            solver_body: Some(mut solver_body1),
-            pos: &prev_pos1,
-            rot: &prev_rot1,
-            ccd: Some(ccd1),
-            collider: collider1,
-            com: com1,
-            ..
-        }) = (
-            // Safety: `get_unchecked` is only unsafe if there are multiple mutable references
-            //         to the same component, and this is ensured not to happen when iterating
-            //         over the AABB intersections below.
-            unsafe { bodies.get_unchecked(entity) }
-        )
+    // First, detect fast bodies and compute their time of impact,
+    // collecting the results into `thread_local_results`.
+    //
+    // This runs in parallel over solver bodies. The order of TOI sweeps does not matter,
+    // as each fast body only reads the trees and produces its own deterministic result.
+    // This combines parts of `b2FinalizeBodiesTask` and `b2SolveContinuous` from Box2D.
+    let ccd_query = bodies.p0();
+    ccd_query.par_iter().for_each(|fast| {
+        // Only dynamic bodies support CCD.
+        if !fast.body.flags.is_dynamic() {
+            return;
+        }
+
+        let ccd = fast.ccd.copied().unwrap_or_default();
+
+        if !ccd.enabled {
+            return;
+        }
+
+        let body = fast.body;
+        let min_thickness = fast.body_radii.min_thickness;
+        let sweep_radius = fast.body_radii.sweep_radius;
+
+        // Compute the speed and displacement to determine whether the body moved
+        // enough to be considered a fast body that requires CCD.
+
+        // Linear and angular speed
+        let lin_speed = body.linear_velocity.length();
+        #[cfg(feature = "2d")]
+        let ang_speed = body.angular_velocity.abs();
+        #[cfg(feature = "3d")]
+        let ang_speed = body.angular_velocity.length();
+
+        // Displacement of the center of mass
+        let delta_pos_len = body.delta_position.length();
+
+        // The chord length of the rotation. This is a straight-line approximation
+        // of the displacement of the farthest point (per unit sweep radius).
+        let delta_rot_chord = body.delta_rotation.chord_length();
+
+        // The velocity of the farthest point on the body
+        let max_velocity = lin_speed + ang_speed * sweep_radius;
+
+        // The maximum distance the farthest point on the body travels during the timestep
+        let max_delta_position = delta_pos_len + delta_rot_chord * sweep_radius;
+
+        // The maximum of the two, which is an upper bound on how far any point on the body travels
+        let max_motion = max_delta_position.max(max_velocity * delta_secs);
+
+        // Check if the body moved more than the threshold fraction of its minimum thickness.
+        // This way, CCD is only performed for bodies that are actually at risk of tunneling.
+        if max_motion <= FAST_BODY_SAFETY_FACTOR * min_thickness {
+            // Not a fast body, so no CCD is needed.
+            return;
+        }
+
+        // Records a fast body's time-of-impact fraction on the current thread.
+        let record = |fraction| {
+            thread_local_results
+                .get_or(|| RefCell::new(Vec::new()))
+                .borrow_mut()
+                .push(CcdResult {
+                    entity: fast.entity,
+                    fraction,
+                });
+        };
+
+        let mode1 = ccd.mode;
+        let body_com_world = fast.position.0 + fast.rotation * fast.com.0;
+
+        // Determine which trees to sweep against.
+        let trees_to_query: [Option<&ColliderTree>; 4] = [
+            Some(&trees.static_tree),
+            Some(&trees.standalone_tree),
+            Some(&trees.kinematic_tree),
+            ccd.include_dynamic.then_some(&trees.dynamic_tree),
+        ];
+
+        // The smallest time of impact found across all of the body's colliders.
+        // Starts at the full timestep duration.
+        let mut min_toi = delta_secs;
+
+        // Sweep each collider attached to the body.
+        for collider_entity in fast.colliders {
+            let Ok((collider1, &collider_pos1, &collider_rot1)) = colliders.get(collider_entity)
         else {
             continue;
         };
 
-        let lin_vel1 = solver_body1.linear_velocity;
-        let ang_vel1 = solver_body1.angular_velocity;
+            let motion1 =
+                collider_sweep_motion(collider_pos1, collider_rot1, body_com_world, body, inv_dt);
 
-        // The smallest time of impact found. Starts at the largest value,
-        // how long a body moves during a single frame due to position integration.
-        let (mut min_toi, mut min_toi_entity) = (delta_secs, None);
+            // Compute the collider's end-of-frame pose to build the swept AABB.
+            let collider_rot2 = (body.delta_rotation * collider_rot1).fast_renormalize();
+            let collider_pos2 = body_com_world
+                + body.delta_position
+                + body.delta_rotation * (collider_pos1.0 - body_com_world);
+            let swept_aabb =
+                collider1.swept_aabb(collider_pos1.0, collider_rot1, collider_pos2, collider_rot2);
+            let query_aabb = obvhs::aabb::Aabb::from(swept_aabb);
 
-        // Iterate through colliders intersecting the AABB of the CCD body.
-        let intersecting_entities = contact_graph.entities_colliding_with(entity);
-        for (collider2, &ColliderOf { body: entity2 }) in colliders.iter_many(intersecting_entities)
-        {
-            debug_assert_ne!(entity, entity2, "collider AABB cannot intersect itself");
+            // Sweep the collider against the relevant trees.
+            for tree in trees_to_query.into_iter().flatten() {
+                tree.aabb_traverse(query_aabb, |proxy_id| {
+                    let Some(proxy) = tree.get_proxy(proxy_id) else {
+                        return true;
+                    };
 
-            // Get the body associated with the collider.
-            // Safety: `AabbIntersections` should never contain the entity of a collider
-            //         attached to the first body, and the entities are also ensured to be different above.
-            if let Ok(body2) = unsafe { bodies.get_unchecked(entity2) } {
-                if !ccd1.include_dynamic && body2.rb.is_dynamic() {
-                    continue;
-                }
+                    // Skip self-collisions within the same body.
+                    if proxy.body == Some(fast.entity) {
+                        return true;
+                    }
 
-                // Get the solver body associated with the second body.
-                let solver_body2 = body2
-                    .solver_body
-                    .map_or(&dummy_body, |body| body.into_inner());
+                    // Skip sensors and disabled bodies.
+                    if proxy.is_sensor()
+                        || proxy.flags.contains(ColliderTreeProxyFlags::BODY_DISABLED)
+                    {
+                        return true;
+                    }
 
-                let prev_pos2 = *body2.pos;
-                let prev_rot2 = *body2.rot;
-                let lin_vel2 = solver_body2.linear_velocity;
-                let ang_vel2 = solver_body2.angular_velocity;
+                    let collider_entity2 = proxy.collider;
 
-                #[cfg(feature = "2d")]
-                let ang_vel_below_threshold = (ang_vel1 - ang_vel2).abs() < ccd1.angular_threshold;
-                #[cfg(feature = "3d")]
-                let ang_vel_below_threshold =
-                    (ang_vel1 - ang_vel2).length_squared() < ccd1.angular_threshold.powi(2);
+                    // If the narrow phase already has a touching contact for this pair,
+                    // the discrete contact solver is responsible for it.
+                    //
+                    // Skipping it here is important because clamping the body at the time of impact
+                    // would overwrite the already computed correction from the contact solver,
+                    // which could lead to the bodies getting frozen. This is not a problem in Box2D
+                    // because it runs CCD after updating body poses (but needs to store old poses).
+                    if contact_graph
+                        .get(collider_entity, collider_entity2)
+                        .is_some_and(|(_, pair)| pair.is_touching())
+                    {
+                        return true;
+                    }
 
-                // If both the relative linear and relative angular velocity
-                // are below the defined thresholds, skip this body.
-                if ang_vel_below_threshold
-                    && (lin_vel1 - lin_vel2).length_squared() < ccd1.linear_threshold.powi(2)
-                {
-                    continue;
-                }
+                    // Fetch the target collider and its start-of-frame pose.
+                    let Ok((collider2, &target_pos, &target_rot)) = colliders.get(collider_entity2)
+                    else {
+                        return true;
+                    };
 
-                let iso1 = make_pose(prev_pos1, prev_rot1);
-                let iso2 = make_pose(prev_pos2, prev_rot2);
+                    // Reconstruct the target's motion over the timestep.
+                    // Bodies with a solver body are awake and moving, everything else is stationary.
+                    let (motion2, mode2) = match proxy.body {
+                        Some(body2_entity) => match ccd_query.get(body2_entity) {
+                            Ok(body2) => {
+                                let target_com_world =
+                                    body2.position.0 + body2.rotation * body2.com.0;
+                                (
+                                    collider_sweep_motion(
+                                        target_pos,
+                                        target_rot,
+                                        target_com_world,
+                                        body2.body,
+                                        inv_dt,
+                                    ),
+                                    body2.ccd.map_or(SweepMode::NonLinear, |ccd| ccd.mode),
+                                )
+                            }
+                            Err(_) => (static_motion(target_pos, target_rot), SweepMode::Linear),
+                        },
+                        None => (static_motion(target_pos, target_rot), SweepMode::Linear),
+                    };
 
-                // TODO: Support child colliders
-                let motion1 = NonlinearRigidMotion::new(
-                    iso1,
-                    com1.0.into(),
-                    lin_vel1.into(),
-                    ang_vel1.into(),
-                );
-                let motion2 = NonlinearRigidMotion::new(
-                    iso2,
-                    body2.com.0.into(),
-                    lin_vel2.into(),
-                    ang_vel2.into(),
-                );
-
-                let sweep_mode = if ccd1.mode == SweepMode::Linear
-                    && body2.ccd.is_none_or(|ccd| ccd.mode == SweepMode::Linear)
-                {
+                    // Use a non-linear sweep unless both bodies opt into linear sweeps.
+                    let sweep_mode = if mode1 == SweepMode::Linear && mode2 == SweepMode::Linear {
                     SweepMode::Linear
                 } else {
                     SweepMode::NonLinear
                 };
 
+                    // Compute the time of impact for this pair of colliders,
+                    // and update the minimum if it's the earliest one so far.
                 if let Some(toi) = compute_ccd_toi(
-                    sweep_mode,
-                    &motion1,
-                    collider1,
-                    &motion2,
-                    collider2,
-                    min_toi,
-                    narrow_phase_config.default_speculative_margin,
+                        sweep_mode, &motion1, collider1, &motion2, collider2, min_toi,
                 ) {
                     min_toi = toi;
-                    min_toi_entity = Some(entity2);
-                }
+                    }
+
+                    true
+                });
             }
         }
 
-        // Advance the bodies from the previous poses to the first time of impact.
-        if let Some(Ok(body2)) =
-            min_toi_entity.map(|entity| unsafe { bodies.get_unchecked(entity) })
-        {
-            // Get the solver body for the entity that was hit.
-            let solver_body2 = body2
-                .solver_body
-                .map_or(&mut dummy_body, |body| body.into_inner());
+        // Record the minimum time of impact as a fraction of the timestep.
+        record(min_toi * inv_dt);
+    });
 
-            let lin_vel2 = solver_body2.linear_velocity;
-            let ang_vel2 = solver_body2.angular_velocity;
+    // Collect the per-thread results.
+    let results: Vec<CcdResult> = thread_local_results
+        .into_iter()
+        .flat_map(|cell| cell.into_inner())
+        .collect();
 
-            // Overshoot slightly to make sure the bodies advance and don't get stuck.
-            let min_toi = min_toi * 1.0001;
+    // Finally, apply the time-of-impact corrections by scaling the pose deltas of each solver body.
+    if !results.is_empty() {
+        let mut apply = bodies.p1();
+        for CcdResult { entity, fraction } in results {
+            let Ok(mut solver_body) = apply.get_mut(entity) else {
+                continue;
+            };
 
-            solver_body1.delta_position = min_toi * lin_vel1;
+            // Note: This flag is only retained for debug rendering.
+            solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 
-            // TODO: Abstract the integration logic to reuse it here
-            #[cfg(feature = "2d")]
-            {
-                solver_body1.delta_rotation = Rotation::radians(ang_vel1 * min_toi);
-            }
-            #[cfg(feature = "3d")]
-            {
-                let delta_rot = Quaternion::from_scaled_axis(ang_vel1 * min_toi);
-                solver_body1.delta_rotation.0 = delta_rot * solver_body1.delta_rotation.0;
-            }
+            if fraction < 1.0 {
+                // Note: This flag is only retained for debug rendering.
+                solver_body
+                    .flags
+                    .insert(SolverBodyFlags::HAD_TIME_OF_IMPACT);
 
-            solver_body2.delta_position = min_toi * lin_vel2;
-
-            #[cfg(feature = "2d")]
-            {
-                solver_body2.delta_rotation = Rotation::radians(ang_vel2 * min_toi);
-            }
-            #[cfg(feature = "3d")]
-            {
-                let delta_rot = Quaternion::from_scaled_axis(ang_vel2 * min_toi);
-                solver_body2.delta_rotation.0 = delta_rot * solver_body2.delta_rotation.0;
+                let t = fraction.min(1.0);
+                solver_body.delta_position *= t;
+                solver_body.delta_rotation =
+                    Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
             }
         }
     }
@@ -686,8 +697,45 @@ fn solve_swept_ccd(
     diagnostics.swept_ccd += start.elapsed();
 }
 
-/// Computes the time of impact for the motion of two objects for Continuous Collision Detection.
-/// If the TOI is larger than `min_toi` or the shapes never touch, `None` is returned.
+/// Reconstructs the sweep of a single collider for the timestep from its [`SolverBody`] deltas,
+/// as a Parry [`NonlinearRigidMotion`] with per-second velocities.
+///
+/// `collider_pos`/`collider_rot` are the collider's world pose at the start of the frame, and
+/// `com_world` is its body's center of mass in world space. The body rotates about its center of
+/// mass, so this supports colliders offset from the body origin (i.e. child colliders).
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
+fn collider_sweep_motion(
+    collider_pos: Position,
+    collider_rot: Rotation,
+    com_world: Vector,
+    solver_body: &SolverBody,
+    inv_dt: Scalar,
+) -> NonlinearRigidMotion {
+    let lin_vel = solver_body.delta_position * inv_dt;
+    #[cfg(feature = "2d")]
+    let ang_vel = solver_body.delta_rotation.as_radians() * inv_dt;
+    #[cfg(feature = "3d")]
+    let ang_vel = solver_body.delta_rotation.0.to_scaled_axis() * inv_dt;
+    // The body's center of mass expressed in the collider's local frame
+    let local_center = collider_rot.inverse() * (com_world - collider_pos.0);
+    NonlinearRigidMotion::new(
+        make_pose(collider_pos, collider_rot),
+        local_center,
+        lin_vel,
+        ang_vel,
+    )
+}
+
+/// A constant (non-moving) [`NonlinearRigidMotion`] at the given pose, for static targets.
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
+fn static_motion(pos: Position, rot: Rotation) -> NonlinearRigidMotion {
+    NonlinearRigidMotion::constant_position(make_pose(pos, rot))
+}
+
+/// Computes the time of impact at which `motion1` (sweeping `collider1`) first touches
+/// `motion2` (sweeping `collider2`), if any, using the specified `mode`.
+///
+/// Returns `None` if no impact is found within `min_toi`.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 fn compute_ccd_toi(
     mode: SweepMode,
@@ -696,85 +744,39 @@ fn compute_ccd_toi(
     motion2: &NonlinearRigidMotion,
     collider2: &Collider,
     min_toi: Scalar,
-    prediction_distance: Scalar,
 ) -> Option<Scalar> {
-    if mode == SweepMode::Linear {
-        let hit = cast_shapes(
+    let shape1 = collider1.shape_scaled();
+    let shape2 = collider2.shape_scaled();
+
+    let toi = if mode == SweepMode::Linear {
+        cast_shapes(
             &motion1.start,
             motion1.linvel,
-            collider1.shape_scaled().as_ref(),
+            shape1.as_ref(),
             &motion2.start,
             motion2.linvel,
-            collider2.shape_scaled().as_ref(),
+            shape2.as_ref(),
             ShapeCastOptions {
                 max_time_of_impact: min_toi,
                 stop_at_penetration: false,
                 ..default()
             },
         )
-        .ok()??;
-        let toi = hit.time_of_impact;
-        if toi > 0.0 && toi < min_toi {
-            // New smaller time of impact found
-            return Some(toi);
-        } else if toi == 0.0 {
-            // If the time of impact is zero, fall back to computing the TOI of a small circle
-            // around the centroid of the first body.
-            let hit = cast_shapes(
-                &motion1.start,
-                motion1.linvel,
-                collider1.shape_scaled().as_ref(),
-                &motion2.start,
-                motion2.linvel,
-                &parry::shape::Ball::new(prediction_distance),
-                ShapeCastOptions {
-                    max_time_of_impact: min_toi,
-                    stop_at_penetration: false,
-                    ..default()
-                },
-            )
-            .ok()??;
-            let toi = hit.time_of_impact;
-            if toi > 0.0 && toi < min_toi {
-                // New smaller time of impact found
-                return Some(toi);
-            }
-        }
-    } else if let Ok(Some(ShapeCastHit {
-        time_of_impact: toi,
-        ..
-    })) = cast_shapes_nonlinear(
+        .ok()??
+        .time_of_impact
+    } else {
+        cast_shapes_nonlinear(
         motion1,
-        collider1.shape_scaled().as_ref(),
+            shape1.as_ref(),
         motion2,
-        collider2.shape_scaled().as_ref(),
-        0.0,
-        min_toi,
-        false,
-    ) {
-        if toi > 0.0 && toi < min_toi {
-            // New smaller time of impact found
-            return Some(toi);
-        } else if toi == 0.0 {
-            // If the time of impact is zero, fall back to computing the TOI of a small circle
-            // around the centroid of the first body.
-            let hit = cast_shapes_nonlinear(
-                motion1,
-                collider1.shape_scaled().as_ref(),
-                motion2,
-                &parry::shape::Ball::new(prediction_distance),
+            shape2.as_ref(),
                 0.0,
                 min_toi,
                 false,
             )
-            .ok()??;
-            let toi = hit.time_of_impact;
-            if toi > 0.0 && toi < min_toi {
-                // New smaller time of impact found
-                return Some(toi);
-            }
-        }
-    }
+        .ok()??
+        .time_of_impact
+    };
 
-    None
+    (toi > 0.0 && toi < min_toi).then_some(toi)
 }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -333,8 +333,8 @@ pub struct SweptCcd {
     /// **Default**: [`SweepMode::NonLinear`]
     pub mode: SweepMode,
 
-    /// The fraction of a body's minimum CCD thickness it may travel in a timestep before being
-    /// treated as a fast-moving body.
+    /// The fraction of a body's minimum [`ccd_thickness`](BodySizeMetrics::ccd_thickness)
+    /// it may travel in a timestep before being treated as a fast-moving body.
     ///
     /// This should typically be in the range `[0.0, 1.0]` to prevent tunneling.
     /// Smaller values trigger CCD more easily, which can help prevent overlap,
@@ -544,7 +544,7 @@ struct CcdBodyQuery {
     rotation: &'static Rotation,
     com: &'static ComputedCenterOfMass,
     colliders: &'static RigidBodyColliders,
-    body_radii: &'static BodyRadii,
+    size_metrics: &'static BodySizeMetrics,
     ccd: Option<&'static SweptCcd>,
 }
 
@@ -636,8 +636,8 @@ fn solve_continuous(
         }
 
         let body = fast.body;
-        let min_thickness = fast.body_radii.min_thickness;
-        let sweep_radius = fast.body_radii.sweep_radius;
+        let ccd_thickness = fast.size_metrics.ccd_thickness;
+        let sweep_radius = fast.size_metrics.sweep_radius;
 
         // Compute the speed and displacement to determine whether the body moved
         // enough to be considered a fast body that requires CCD.
@@ -665,9 +665,9 @@ fn solve_continuous(
         // The maximum of the two, which is an upper bound on how far any point on the body travels
         let max_motion = max_delta_position.max(max_velocity * delta_secs);
 
-        // Check if the body moved more than the threshold fraction of its minimum thickness.
+        // Check if the body moved more than the threshold fraction of its CCD thickness.
         // CCD is only performed for bodies that are actually at risk of tunneling or deep overlap.
-        if max_motion <= ccd.threshold * min_thickness {
+        if max_motion <= ccd.threshold * ccd_thickness {
             // Not a fast body, so no CCD is needed.
             return;
         }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -347,7 +347,7 @@ pub struct CcdSettings {
     /// **Default**: [`SweepMode::NonLinear`]
     pub mode: SweepMode,
 
-    /// The fraction of a body's minimum CCD thickness it may travel in a frame before being
+    /// The fraction of a body's minimum CCD thickness it may travel in a timestep before being
     /// treated as a fast-moving body.
     ///
     /// This should typically be in the range `[0.0, 1.0]` to prevent tunneling.
@@ -355,7 +355,7 @@ pub struct CcdSettings {
     /// at the cost of more overhead as sweeps are performed even at lower speeds.
     ///
     /// **Default**: `0.5`
-    pub safety_factor: Scalar,
+    pub fast_threshold: Scalar,
 
     /// Whether the body is additionally swept against other dynamic bodies.
     ///
@@ -380,7 +380,7 @@ impl CcdSettings {
         Self {
             enabled: true,
             mode: SweepMode::NonLinear,
-            safety_factor: 0.5,
+            fast_threshold: 0.5,
             include_dynamic: false,
         }
     }
@@ -433,19 +433,21 @@ pub enum SweepMode {
     NonLinear,
 }
 
-/// A marker component that expands a body's [`ColliderAabb`] based on
-/// its velocity each timestep.
+/// A component that enables [speculative collision](self#speculative-collision)
+/// and velocity-expanded [AABBs](ColliderAabb) for a [dynamic](RigidBody::Dynamic) [`RigidBody`],
+/// allowing it to predict and react to contacts before they happen.
 ///
-/// By default, AABBs are kept tight, only expanded by a small fixed margin.
-/// The downside is that a fast body's AABB does not reach ahead along its path,
-/// so two fast-moving bodies approacing each other from different directions
-/// might not collide even with [CCD](self), because their swept shapes would not
-/// find each other. Adding this component works around the issue, at the cost of
-/// more broad phase collision tests due to the larger AABB.
+/// Without this component, a body still receives a small, fixed [`contact_tolerance`]
+/// and automatic [swept CCD](self#swept-ccd), but no velocity-based speculative margin
+/// or AABB expansion.
 ///
-/// It is only recommended to add this component to fast-moving bodies
-/// that should reliably collide with other fast-moving bodies.
-/// Oftentimes these entities also have [`CcdSettings::include_dynamic`] enabled.
+/// Speculative collision can be cheaper than swept CCD, but speculative contacts are approximations,
+/// and large margins can cause [ghost collisions](self#caveats-of-speculative-collision).
+/// The [`max_distance`](Self::max_distance) property bounds the margin to mitigate this.
+///
+/// Bodies with this component oftentimes also enable [`CcdSettings::include_dynamic`].
+///
+/// [`contact_tolerance`]: NarrowPhaseConfig::contact_tolerance
 ///
 /// # Example
 ///
@@ -455,22 +457,58 @@ pub enum SweepMode {
 /// use bevy::prelude::*;
 ///
 /// fn setup(mut commands: Commands) {
-///     // A fast body whose AABB is expanded by its velocity
-///     // and is also swept against other dynamic bodies for CCD.
+///     // A fast body that predicts contacts up to 2 units ahead based on its velocity,
+///     // expands its AABB accordingly, and is also swept against other dynamic bodies.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
 #[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
-///         SpeculativeAabb,
+///         SpeculativeCcd::new(2.0),
 ///         CcdSettings::default().with_include_dynamic(true),
 ///     ));
 /// }
 /// ```
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default, PartialEq)]
-pub struct SpeculativeAabb;
+#[doc(alias = "SpeculativeMargin")]
+pub struct SpeculativeCcd {
+    /// The maximum distance at which [speculative contacts](self#speculative-collision)
+    /// are generated for this body, and the maximum distance its [`ColliderAabb`] is
+    /// expanded along its velocity each timestep.
+    ///
+    /// Larger values predict contacts further ahead, at the cost of more broad phase work
+    /// and a higher risk of [ghost collisions](self#caveats-of-speculative-collision).
+    /// A value of `0.0` effectively disables speculative collision for this body.
+    ///
+    /// **Default**: [`Scalar::MAX`] (unbounded)
+    pub max_distance: Scalar,
+}
 
-/// Read-only [`SolverBody`] motion data used to reconstruct a body's per-frame sweep.
+impl Default for SpeculativeCcd {
+    fn default() -> Self {
+        Self::MAX
+    }
+}
+
+impl SpeculativeCcd {
+    /// An unbounded speculative margin. Speculative contacts are generated as far ahead
+    /// as the body's velocity reaches, and the AABB is expanded by the full per-timestep motion.
+    pub const MAX: Self = Self {
+        max_distance: Scalar::MAX,
+    };
+
+    /// A zero speculative margin. Disables speculative collision and velocity-based
+    /// AABB expansion for this body.
+    pub const ZERO: Self = Self { max_distance: 0.0 };
+
+    /// Creates a [`SpeculativeCcd`] configuration with the given maximum speculative distance.
+    #[inline]
+    pub const fn new(max_distance: Scalar) -> Self {
+        Self { max_distance }
+    }
+}
+
+/// Read-only [`SolverBody`] motion data used to reconstruct a body's per-timestep sweep.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 #[derive(QueryData)]
 struct CcdBodyQuery {
@@ -588,8 +626,8 @@ fn solve_continuous(
         let max_motion = max_delta_position.max(max_velocity * delta_secs);
 
         // Check if the body moved more than the threshold fraction of its minimum thickness.
-        // This way, CCD is only performed for bodies that are actually at risk of tunneling.
-        if max_motion <= ccd.safety_factor * min_thickness {
+        // CCD is only performed for bodies that are actually at risk of tunneling or deep overlap.
+        if max_motion <= ccd.fast_threshold * min_thickness {
             // Not a fast body, so no CCD is needed.
             return;
         }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -272,7 +272,7 @@ impl Plugin for CcdPlugin {
 ///
 /// Only dynamic bodies support CCD. Fast-moving dynamic bodies are swept against static and
 /// kinematic bodies automatically, even without this component (see the
-/// [module-level documentation](self)). Add `CcdSettings` to:
+/// [module-level documentation](self)). Add `SweptCcd` to:
 ///
 /// - also sweep the body against other **dynamic** bodies (via [`include_dynamic`](Self::include_dynamic))
 /// - choose the [sweep mode](SweepMode) (via [`mode`](Self::mode))
@@ -310,7 +310,7 @@ impl Plugin for CcdPlugin {
 ///     // and is additionally swept against other dynamic bodies.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         CcdSettings::default()
+///         SweptCcd::default()
 ///             .with_mode(SweepMode::Linear)
 ///             .with_include_dynamic(true),
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
@@ -323,7 +323,7 @@ impl Plugin for CcdPlugin {
 /// ```
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default, PartialEq)]
-pub struct CcdSettings {
+pub struct SweptCcd {
     /// Whether CCD is enabled for this body.
     ///
     /// Setting this to `false` disables CCD for the body entirely.
@@ -366,14 +366,14 @@ pub struct CcdSettings {
     pub include_dynamic: bool,
 }
 
-impl Default for CcdSettings {
+impl Default for SweptCcd {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl CcdSettings {
-    /// Creates a [`CcdSettings`] configuration with default settings: CCD enabled,
+impl SweptCcd {
+    /// Creates a [`SweptCcd`] configuration with default settings: CCD enabled,
     /// [`SweepMode::NonLinear`], swept against static and kinematic bodies but not dynamic bodies.
     #[inline]
     pub const fn new() -> Self {
@@ -445,7 +445,7 @@ pub enum SweepMode {
 /// and large margins can cause [ghost collisions](self#caveats-of-speculative-collision).
 /// The [`max_distance`](Self::max_distance) property bounds the margin to mitigate this.
 ///
-/// Bodies with this component oftentimes also enable [`CcdSettings::include_dynamic`].
+/// Bodies with this component oftentimes also enable [`SweptCcd::include_dynamic`].
 ///
 /// [`contact_tolerance`]: NarrowPhaseConfig::contact_tolerance
 ///
@@ -464,7 +464,7 @@ pub enum SweepMode {
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
 #[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
 ///         SpeculativeCcd::new(2.0),
-///         CcdSettings::default().with_include_dynamic(true),
+///         SweptCcd::default().with_include_dynamic(true),
 ///     ));
 /// }
 /// ```
@@ -519,7 +519,7 @@ struct CcdBodyQuery {
     com: &'static ComputedCenterOfMass,
     colliders: &'static RigidBodyColliders,
     body_radii: &'static BodyRadii,
-    ccd: Option<&'static CcdSettings>,
+    ccd: Option<&'static SweptCcd>,
 }
 
 /// A time-of-impact result for a single fast body.

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -347,6 +347,16 @@ pub struct CcdSettings {
     /// **Default**: [`SweepMode::NonLinear`]
     pub mode: SweepMode,
 
+    /// The fraction of a body's minimum CCD thickness it may travel in a frame before being
+    /// treated as a fast-moving body.
+    ///
+    /// This should typically be in the range `[0.0, 1.0]` to prevent tunneling.
+    /// Smaller values trigger CCD more easily, which can help prevent overlap,
+    /// at the cost of more overhead as sweeps are performed even at lower speeds.
+    ///
+    /// **Default**: `0.5`
+    pub safety_factor: Scalar,
+
     /// Whether the body is additionally swept against other dynamic bodies.
     ///
     /// Dynamic bodies are always swept against static and kinematic bodies;
@@ -370,6 +380,7 @@ impl CcdSettings {
         Self {
             enabled: true,
             mode: SweepMode::NonLinear,
+            safety_factor: 0.5,
             include_dynamic: false,
         }
     }
@@ -518,10 +529,6 @@ fn solve_continuous(
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    /// The fraction of a body's minimum thickness it may travel in a frame before being
-    /// treated as a fast body.
-    const FAST_BODY_SAFETY_FACTOR: Scalar = 0.5;
-
     let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
@@ -585,7 +592,7 @@ fn solve_continuous(
 
         // Check if the body moved more than the threshold fraction of its minimum thickness.
         // This way, CCD is only performed for bodies that are actually at risk of tunneling.
-        if max_motion <= FAST_BODY_SAFETY_FACTOR * min_thickness {
+        if max_motion <= ccd.safety_factor * min_thickness {
             // Not a fast body, so no CCD is needed.
             return;
         }
@@ -812,8 +819,7 @@ fn solve_continuous(
                 if let Some((_edge, pair)) =
                     contact_graph.get_mut(impact.collider1, impact.collider2)
                 {
-                    pair.ccd_speculative_distance =
-                        pair.ccd_speculative_distance.max(impact.distance);
+                    pair.speculative_distance = pair.speculative_distance.max(impact.distance);
                 } else {
                     let mut edge = ContactEdge::new(impact.collider1, impact.collider2);
                     edge.body1 = Some(entity);
@@ -824,7 +830,7 @@ fn solve_continuous(
                     contact_graph.add_edge_with(edge, |pair| {
                         pair.body1 = body1;
                         pair.body2 = body2;
-                        pair.ccd_speculative_distance = distance;
+                        pair.speculative_distance = distance;
                     });
                 }
             }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -19,9 +19,9 @@
 //!     <text x="150" y="325" style="fill: #b4b4b4; font: 18px monospace; text-anchor: middle;">Discrete</text>
 //! </svg>
 //!
-//! **Continuous Collision Detection** (CCD) aims to prevent tunneling and deep overlap.
-//! Currently, two approaches are supported: [Swept CCD](#swept-ccd) and
-//! [Speculative Collision](#speculative-collision). Swept CCD is performed for fast-moving
+//! **Continuous Collision Detection (CCD)** aims to prevent tunneling and deep overlap.
+//! Currently, two approaches are supported: [swept CCD](#swept-ccd) and
+//! [speculative collision](#speculative-collision). Swept CCD is performed for fast-moving
 //! dynamic bodies *by default*, and can be configured using the [`SweptCcd`] component,
 //! while speculative collision is fully opt-in via the [`SpeculativeCcd`] component.
 //!
@@ -236,7 +236,7 @@ use parry::query::{
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use thread_local::ThreadLocal;
 
-/// A plugin for [Continuous Collision Detection](self).
+/// A plugin for [Continuous Collision Detection (CCD)](self).
 pub struct CcdPlugin;
 
 impl Plugin for CcdPlugin {
@@ -251,7 +251,7 @@ impl Plugin for CcdPlugin {
     }
 }
 
-/// A component that configures [Swept Continuous Collision Detection (CCD)](self#swept-ccd)
+/// A component that configures [swept Continuous Collision Detection (CCD)](self#swept-ccd)
 /// for a [dynamic](RigidBody::Dynamic) [`RigidBody`].
 ///
 /// By default, swept CCD is performed automatically for fast-moving dynamic bodies,
@@ -391,7 +391,7 @@ impl SweptCcd {
 }
 
 /// A bitmask determining which [`RigidBody`] types a [`SweptCcd`] body is swept against
-/// during [Continuous Collision Detection](self).
+/// during [Continuous Collision Detection (CCD)](self).
 ///
 /// If [empty](Self::EMPTY), CCD is disabled for the body entirely.
 #[repr(transparent)]
@@ -431,7 +431,7 @@ impl Default for CcdFilter {
     }
 }
 
-/// The algorithm used for sweeps during [Continuous Collision Detection](self#swept-ccd).
+/// The algorithm used for sweeps during [Continuous Collision Detection (CCD)](self#swept-ccd).
 ///
 /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`] is preferred.
 ///
@@ -594,6 +594,20 @@ fn solve_continuous(
         return;
     }
     let inv_dt = 1.0 / delta_secs;
+
+    // Avian's approach to CCD is heavily inspired by Box2D by Erin Catto,
+    // with some notable differences (as of Box2D 3.1.0):
+    //
+    // - We perform sweeps against both static *and* kinematic bodies by default.
+    // - We support sweeps between two dynamic bodies (CCD between "bullets").
+    // - We use a bitmask to configure which body types fast bodies are swept against.
+    // - We additionally support opt-in Bepu-style speculative collision with a configurable margin.
+    // - We run swept CCD before applying solver body deltas. This avoids having to store
+    //   previous transforms.
+    // - We create contact edges immediately at the time of impact, and request an additional
+    //   speculative distance for the narrow phase if needed to ensure the contact is handled.
+    //   This fixed some pathological cases with CCD against moving objects.
+    // - Miscellaneous differences in structure, naming, and configuration.
 
     // Per-thread time-of-impact fractions (in `[0, 1]`) for each fast body. A fraction of `1.0`
     // means the body is fast but no impact was found.
@@ -822,7 +836,7 @@ fn solve_continuous(
     //
     // Also ensure a contact pair exists for any impacts that were found,
     // and request a speculative distance to help ensure the contact is detected
-    // by the discrete solver next timestep,
+    // by the discrete solver next timestep.
     if !results.is_empty() {
         let mut body_query = bodies.p1();
         for CcdResult {

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -494,11 +494,8 @@ struct CcdResult {
     impact: Option<CcdImpact>,
 }
 
-/// Details of the earliest time-of-impact for a fast body, used to clamp the body's normal
-/// motion this frame and to hand the contact off to the discrete solver next frame.
+/// Details of the earliest time-of-impact for a fast body.
 struct CcdImpact {
-    /// World-space contact normal, pointing from the fast body toward the obstacle.
-    normal: Vector,
     /// The fast body's colliding collider.
     collider1: Entity,
     /// The obstacle's colliding collider.
@@ -724,14 +721,7 @@ fn solve_continuous(
                         sweep_mode, &motion1, collider1, &motion2, collider2, min_toi,
                 ) {
                         min_toi = hit.time_of_impact;
-
-                        // World-space contact normal, outward from the fast body's collider toward
-                        // the obstacle at the time of impact.
-                        let normal: Vector =
-                            motion1.position_at_time(hit.time_of_impact).rotation * hit.normal1;
-
                         best_impact = Some(CcdImpact {
-                            normal,
                             collider1: collider_entity,
                             collider2: collider_entity2,
                             body2: proxy.body,
@@ -759,18 +749,20 @@ fn solve_continuous(
         .collect();
     results.sort_unstable_by_key(|result| result.entity);
 
-    // Apply the time-of-impact corrections to each solver body,
-    // and then hand each fast contact off to the discrete solver
-    // so it resolves the velocity next timestep.
+    // Mark fast bodies and apply any time-of-impact corrections.
+    //
+    // Also ensure a contact pair exists for any impacts that were found,
+    // and request a speculative distance to help ensure the contact is detected
+    // by the discrete solver next timestep,
     if !results.is_empty() {
-        let mut apply = bodies.p1();
+        let mut body_query = bodies.p1();
         for CcdResult {
             entity,
             fraction,
             impact,
         } in results
         {
-            if let Ok(mut solver_body) = apply.get_mut(entity) {
+            if let Ok(mut solver_body) = body_query.get_mut(entity) {
             // Note: This flag is only retained for debug rendering.
             solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 
@@ -782,25 +774,10 @@ fn solve_continuous(
 
                 let t = fraction.min(1.0);
 
-                    if let Some(impact) = &impact {
-                        // Clamp the translation into the obstacle while leaving tangential sliding
-                        // intact, so a body that is mostly sliding along the surface is not frozen.
-                        let approach_translation = solver_body.delta_position.dot(impact.normal);
-                        if approach_translation > 0.0 {
-                            solver_body.delta_position -=
-                                (1.0 - t) * approach_translation * impact.normal;
-                        }
-
-                        // Advance the rotation only up to the time of impact.
-                        solver_body.delta_rotation =
-                            Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
-                    } else {
-                        // No contact normal available for some reason.
-                        // Fall back to scaling the whole delta.
+                    // Scale back the body's motion to the time of impact.
                 solver_body.delta_position *= t;
                 solver_body.delta_rotation =
                     Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
-                    }
                 }
             }
 

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -242,6 +242,7 @@ pub struct CcdPlugin;
 impl Plugin for CcdPlugin {
     fn build(&self, app: &mut App) {
         // Get the `PhysicsSchedule`, and panic if it doesn't exist.
+        #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
         let physics = app
             .get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first");
@@ -549,6 +550,7 @@ struct CcdBodyQuery {
 }
 
 /// A time-of-impact result for a single fast body.
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 struct CcdResult {
     /// The fast body that was swept.
     entity: Entity,
@@ -559,6 +561,7 @@ struct CcdResult {
 }
 
 /// Details of the earliest time-of-impact for a fast body.
+#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 struct CcdImpact {
     /// The fast body's colliding collider.
     collider1: Entity,

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -359,7 +359,7 @@ pub struct SweptCcd {
     /// at the cost of more overhead as sweeps are performed even at lower speeds.
     ///
     /// **Default**: `0.5`
-    pub fast_threshold: Scalar,
+    pub threshold: Scalar,
 }
 
 impl Default for SweptCcd {
@@ -377,7 +377,7 @@ impl SweptCcd {
         Self {
             filter: CcdFilter::DEFAULT,
             mode: SweepMode::NonLinear,
-            fast_threshold: 0.5,
+            threshold: 0.5,
         }
     }
 
@@ -394,6 +394,14 @@ impl SweptCcd {
     #[inline]
     pub const fn with_mode(mut self, mode: SweepMode) -> Self {
         self.mode = mode;
+        self
+    }
+
+    /// Sets the fraction of this body's minimum CCD thickness it may travel in a timestep
+    /// before being treated as a fast-moving body.
+    #[inline]
+    pub const fn with_threshold(mut self, threshold: Scalar) -> Self {
+        self.threshold = threshold;
         self
     }
 }
@@ -660,7 +668,7 @@ fn solve_continuous(
 
         // Check if the body moved more than the threshold fraction of its minimum thickness.
         // CCD is only performed for bodies that are actually at risk of tunneling or deep overlap.
-        if max_motion <= ccd.fast_threshold * min_thickness {
+        if max_motion <= ccd.threshold * min_thickness {
             // Not a fast body, so no CCD is needed.
             return;
         }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -314,7 +314,7 @@ pub struct SweptCcd {
     /// fast bodies are swept against static and kinematic bodies by default,
     /// but not against other dynamic bodies.
     ///
-    /// If the filter is [empty](CcdFilter::EMPTY), CCD is disabled for this body entirely.
+    /// If the filter is [empty](CcdFilter::NONE), CCD is disabled for this body entirely.
     /// This can improve performance but can lead to tunneling. Disabling CCD should rarely
     /// be necessary, as it is only performed for fast-moving bodies, and should have a minimal
     /// performance impact for most applications.
@@ -367,7 +367,7 @@ impl SweptCcd {
 
     /// Sets the [`CcdFilter`] determining which body types this body is swept against.
     ///
-    /// An [empty](CcdFilter::EMPTY) filter disables CCD for this body entirely.
+    /// An [empty](CcdFilter::NONE) filter disables CCD for this body entirely.
     #[inline]
     pub const fn with_filter(mut self, filter: CcdFilter) -> Self {
         self.filter = filter;
@@ -393,7 +393,7 @@ impl SweptCcd {
 /// A bitmask determining which [`RigidBody`] types a [`SweptCcd`] body is swept against
 /// during [Continuous Collision Detection (CCD)](self).
 ///
-/// If [empty](Self::EMPTY), CCD is disabled for the body entirely.
+/// If [empty](Self::NONE), CCD is disabled for the body entirely.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Reflect)]
 #[reflect(Debug, Default, PartialEq)]
@@ -403,10 +403,13 @@ bitflags::bitflags! {
     impl CcdFilter: u8 {
         /// Sweep against other dynamic bodies.
         const DYNAMIC = 1 << 0;
+
         /// Sweep against kinematic bodies.
         const KINEMATIC = 1 << 1;
+
         /// Sweep against static bodies.
         const STATIC = 1 << 2;
+
         /// Sweep against standalone colliders (colliders with no rigid body).
         const STANDALONE = 1 << 3;
 
@@ -421,7 +424,7 @@ bitflags::bitflags! {
             | Self::STANDALONE.bits();
 
         /// Sweep against no body types, effectively disabling CCD for this body.
-        const EMPTY = 0;
+        const NONE = 0;
     }
 }
 
@@ -516,13 +519,13 @@ impl Default for SpeculativeCcd {
 }
 
 impl SpeculativeCcd {
-    /// An unbounded speculative margin. Speculative contacts are generated as far ahead
-    /// as the body's velocity reaches, and the AABB is expanded by the full per-timestep motion.
-    pub const MAX: Self = Self::new(Scalar::MAX);
-
     /// A zero speculative margin. Disables speculative collision and velocity-based
     /// AABB expansion for this body.
     pub const ZERO: Self = Self::new(0.0);
+
+    /// An unbounded speculative margin. Speculative contacts are generated as far ahead
+    /// as the body's velocity reaches, and the AABB is expanded by the full per-timestep motion.
+    pub const MAX: Self = Self::new(Scalar::MAX);
 
     /// Creates a [`SpeculativeCcd`] configuration with the given maximum speculative distance.
     #[inline]

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -1,11 +1,11 @@
-//! Contains components and functionality for Continuous Collision Detection.
+//! Components and functionality for Continuous Collision Detection (CCD).
 //!
 //! # What Is CCD?
 //!
-//! Physics simulation is typically done in a discrete manner.
-//! At the beginning of each physics frame, the simulation checks for collisions,
-//! and if none are found for a given rigid body, it is free to move according to
-//! its velocity and the size of the timestep.
+//! Physics simulation is typically done in a discrete manner. At the beginning
+//! of each timestep, the simulation checks for collisions, and if none are found
+//! for a given rigid body, it is free to move according to its velocity and the size
+//! of the timestep.
 //!
 //! This generally works well for large or slowly moving objects, but fast and small
 //! objects can pass through thin geometry such as walls and triangle meshes.
@@ -19,124 +19,25 @@
 //!     <text x="150" y="325" style="fill: #b4b4b4; font: 18px monospace; text-anchor: middle;">Discrete</text>
 //! </svg>
 //!
-//! **Continuous Collision Detection** (CCD) aims to prevent tunneling.
-//! Currently, two approaches are supported: [Speculative Collision](#speculative-collision) and [Swept CCD](#swept-ccd).
-//! Speculative collision is enabled by default, but swept CCD is opt-in with the [`SweptCcd`] component.
-//! The two approaches can also be used together.
-//!
-//! ## Speculative Collision
-//!
-//! **Speculative collision** is a form of Continuous Collision Detection
-//! where contacts are predicted before they happen. The contacts are only
-//! solved if the entities are expected to come into contact within the next frame.
-//!
-//! To determine whether two bodies may come into contact, their [AABBs](ColliderAabb) are expanded
-//! based on their velocities. Additionally, a **speculative margin** is used to determine
-//! the maximum distance at which a collision pair can generate speculative contacts.
-//!
-//! <svg width="335" height="400" viewBox="0 0 335 400" fill="none" xmlns="http://www.w3.org/2000/svg">
-//!     <rect x="36" y="266" width="298" height="18" fill="#64C850" stroke="black" stroke-width="2"/>
-//!     <circle cx="210" cy="375" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
-//!     <circle cx="210" cy="240" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
-//!     <circle cx="160" cy="160" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
-//!     <path d="M209.471 375.849C209.94 376.141 210.557 375.997 210.849 375.529L215.606 367.888C215.898 367.42 215.754 366.803 215.286 366.511C214.817 366.219 214.2 366.363 213.908 366.831L209.68 373.623L202.888 369.394C202.42 369.102 201.803 369.246 201.511 369.714C201.219 370.183 201.363 370.8 201.831 371.092L209.471 375.849ZM159.026 160.227L159.472 162.146L161.42 161.693L160.974 159.773L159.026 160.227ZM160.365 165.985L161.258 169.825L163.206 169.372L162.313 165.532L160.365 165.985ZM162.151 173.664L163.044 177.503L164.992 177.05L164.099 173.211L162.151 173.664ZM163.937 181.343L164.83 185.182L166.778 184.729L165.885 180.89L163.937 181.343ZM165.722 189.021L166.615 192.86L168.563 192.407L167.67 188.568L165.722 189.021ZM167.508 196.7L168.401 200.539L170.349 200.086L169.456 196.247L167.508 196.7ZM169.294 204.378L170.187 208.218L172.135 207.765L171.242 203.925L169.294 204.378ZM171.08 212.057L171.972 215.896L173.92 215.443L173.028 211.604L171.08 212.057ZM172.865 219.735L173.758 223.575L175.706 223.122L174.813 219.282L172.865 219.735ZM174.651 227.414L175.544 231.253L177.492 230.8L176.599 226.961L174.651 227.414ZM176.437 235.093L177.33 238.932L179.278 238.479L178.385 234.64L176.437 235.093ZM178.222 242.771L179.115 246.61L181.063 246.157L180.17 242.318L178.222 242.771ZM180.008 250.45L180.901 254.289L182.849 253.836L181.956 249.997L180.008 250.45ZM181.794 258.128L182.687 261.968L184.635 261.515L183.742 257.675L181.794 258.128ZM183.58 265.807L184.472 269.646L186.42 269.193L185.528 265.354L183.58 265.807ZM185.365 273.485L186.258 277.325L188.206 276.872L187.313 273.032L185.365 273.485ZM187.151 281.164L188.044 285.003L189.992 284.55L189.099 280.711L187.151 281.164ZM188.937 288.843L189.83 292.682L191.778 292.229L190.885 288.39L188.937 288.843ZM190.722 296.521L191.615 300.36L193.563 299.907L192.67 296.068L190.722 296.521ZM192.508 304.2L193.401 308.039L195.349 307.586L194.456 303.747L192.508 304.2ZM194.294 311.878L195.187 315.718L197.135 315.265L196.242 311.425L194.294 311.878ZM196.08 319.557L196.972 323.396L198.92 322.943L198.028 319.104L196.08 319.557ZM197.865 327.235L198.758 331.075L200.706 330.622L199.813 326.782L197.865 327.235ZM199.651 334.914L200.544 338.753L202.492 338.3L201.599 334.461L199.651 334.914ZM201.437 342.593L202.33 346.432L204.278 345.979L203.385 342.14L201.437 342.593ZM203.222 350.271L204.115 354.111L206.063 353.657L205.17 349.818L203.222 350.271ZM205.008 357.95L205.901 361.789L207.849 361.336L206.956 357.497L205.008 357.95ZM206.794 365.628L207.687 369.468L209.635 369.015L208.742 365.175L206.794 365.628ZM208.58 373.307L209.026 375.226L210.974 374.773L210.528 372.854L208.58 373.307ZM209.471 375.849C209.94 376.141 210.557 375.997 210.849 375.529L215.606 367.888C215.898 367.42 215.754 366.803 215.286 366.511C214.817 366.219 214.2 366.363 213.908 366.831L209.68 373.623L202.888 369.394C202.42 369.102 201.803 369.246 201.511 369.714C201.219 370.183 201.363 370.8 201.831 371.092L209.471 375.849ZM159.026 160.227L159.472 162.146L161.42 161.693L160.974 159.773L159.026 160.227ZM160.365 165.985L161.258 169.825L163.206 169.372L162.313 165.532L160.365 165.985ZM162.151 173.664L163.044 177.503L164.992 177.05L164.099 173.211L162.151 173.664ZM163.937 181.343L164.83 185.182L166.778 184.729L165.885 180.89L163.937 181.343ZM165.722 189.021L166.615 192.86L168.563 192.407L167.67 188.568L165.722 189.021ZM167.508 196.7L168.401 200.539L170.349 200.086L169.456 196.247L167.508 196.7ZM169.294 204.378L170.187 208.218L172.135 207.765L171.242 203.925L169.294 204.378ZM171.08 212.057L171.972 215.896L173.92 215.443L173.028 211.604L171.08 212.057ZM172.865 219.735L173.758 223.575L175.706 223.122L174.813 219.282L172.865 219.735ZM174.651 227.414L175.544 231.253L177.492 230.8L176.599 226.961L174.651 227.414ZM176.437 235.093L177.33 238.932L179.278 238.479L178.385 234.64L176.437 235.093ZM178.222 242.771L179.115 246.61L181.063 246.157L180.17 242.318L178.222 242.771ZM180.008 250.45L180.901 254.289L182.849 253.836L181.956 249.997L180.008 250.45ZM181.794 258.128L182.687 261.968L184.635 261.515L183.742 257.675L181.794 258.128ZM183.58 265.807L184.472 269.646L186.42 269.193L185.528 265.354L183.58 265.807ZM185.365 273.485L186.258 277.325L188.206 276.872L187.313 273.032L185.365 273.485ZM187.151 281.164L188.044 285.003L189.992 284.55L189.099 280.711L187.151 281.164ZM188.937 288.843L189.83 292.682L191.778 292.229L190.885 288.39L188.937 288.843ZM190.722 296.521L191.615 300.36L193.563 299.907L192.67 296.068L190.722 296.521ZM192.508 304.2L193.401 308.039L195.349 307.586L194.456 303.747L192.508 304.2ZM194.294 311.878L195.187 315.718L197.135 315.265L196.242 311.425L194.294 311.878ZM196.08 319.557L196.972 323.396L198.92 322.943L198.028 319.104L196.08 319.557ZM197.865 327.235L198.758 331.075L200.706 330.622L199.813 326.782L197.865 327.235ZM199.651 334.914L200.544 338.753L202.492 338.3L201.599 334.461L199.651 334.914ZM201.437 342.593L202.33 346.432L204.278 345.979L203.385 342.14L201.437 342.593ZM203.222 350.271L204.115 354.111L206.063 353.657L205.17 349.818L203.222 350.271ZM205.008 357.95L205.901 361.789L207.849 361.336L206.956 357.497L205.008 357.95ZM206.794 365.628L207.687 369.468L209.635 369.015L208.742 365.175L206.794 365.628ZM208.58 373.307L209.026 375.226L210.974 374.773L210.528 372.854L208.58 373.307Z" fill="#AF644B"/>
-//!     <path d="M209.775 240.974C210.313 241.099 210.85 240.763 210.974 240.225L212.998 231.455C213.122 230.917 212.787 230.38 212.249 230.256C211.71 230.132 211.174 230.467 211.049 231.006L209.25 238.801L201.455 237.002C200.917 236.878 200.38 237.213 200.256 237.751C200.132 238.29 200.467 238.826 201.006 238.951L209.775 240.974ZM159.152 160.53L209.152 240.53L210.848 239.47L160.848 159.47L159.152 160.53Z" fill="#E19664"/>
-//!     <circle cx="160" cy="265" r="4" fill="#a874d8"/>
-//!     <path d="M160 160V265" stroke="#a874d8" stroke-width="2" stroke-dasharray="5 5"/>
-//!     <rect x="135" y="135" width="99" height="264" stroke="#db9010" stroke-width="1"/>
-//!     <circle cx="160" cy="160" r="159" stroke="#eb4a5a" stroke-width="1"/>
-//!     <text x="184" y="125" style="fill: #db9010; font: 16px monospace; text-anchor: middle;">Collision AABB</text>
-//!     <text x="160" y="40" style="fill: #eb4a5a; font: 16px monospace; text-anchor: middle;">Speculative Margin</text>
-//!     <text x="210" y="340" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Unconstrained</text>
-//!     <text x="210" y="205" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Constrained</text>
-//!     <text y="240" style="fill: #a874d8; font: 16px monospace; font-weight: bold; text-anchor: end;">
-//!         <tspan x="155">Speculative</tspan><tspan x="155" dy="18">Contact</tspan>
-//!     </text>
-//! </svg>
-//!
-//! The current "effective" speculative margin for a body is determined by its velocity
-//! clamped by the specified maximum bound. By default, the maximum bound is infinite,
-//! but it can be configured for all entities using the [`NarrowPhaseConfig`] resource,
-//! and for individual entities using the [`SpeculativeMargin`] component.
-//!
-//! ```
-#![cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
-#![cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
-//! use bevy::prelude::*;
-//!
-//! fn setup(mut commands: Commands) {
-//!     // Spawn a rigid body with a maximum bound for the speculative margin.
-//!     commands.spawn((
-//!         RigidBody::Dynamic,
-//!         Collider::capsule(0.5, 2.0),
-//!         SpeculativeMargin(2.0),
-//!     ));
-//! }
-//! ```
-//!
-//! Speculative collisions are an efficient and generally robust approach
-//! to Continuous Collision Detection. They are enabled for all bodies by default,
-//! provided that the default maximum speculative margin is greater than zero.
-//!
-//! However, speculative collisions aren't entirely without issues,
-//! and there are some cases where large speculative margins can cause undesired behavior.
-//!
-//! ### Caveats of Speculative Collision
-//!
-//! Speculative contacts are approximations. They typically have good enough accuracy,
-//! but when bodies are moving past each other at high speeds, the prediction can sometimes
-//! fail and lead to **ghost collisions**. This happens because contact surfaces are treated
-//! like infinite planes from the point of view of the solver. Ghost collisions typically manifest
-//! as objects bumping into seemingly invisible walls.
-//!
-//! <svg width="475" height="400" viewBox="0 0 475 400" fill="none" xmlns="http://www.w3.org/2000/svg">
-//!     <rect x="36" y="266" width="148" height="18" fill="#64C850" stroke="black" stroke-width="2"/>
-//!     <circle cx="345" cy="375" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
-//!     <circle cx="345" cy="236" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
-//!     <circle cx="160" cy="160" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
-//!     <path d="M344.925 375.997C345.476 376.038 345.956 375.626 345.997 375.075L346.67 366.1C346.712 365.549 346.299 365.069 345.748 365.028C345.197 364.987 344.717 365.4 344.676 365.95L344.078 373.928L336.1 373.33C335.549 373.288 335.069 373.701 335.028 374.252C334.987 374.803 335.4 375.283 335.95 375.324L344.925 375.997ZM159.242 160.652L160.563 162.188L162.079 160.883L160.758 159.348L159.242 160.652ZM163.206 165.259L165.849 168.331L167.365 167.026L164.722 163.955L163.206 165.259ZM168.492 171.402L171.135 174.474L172.651 173.169L170.008 170.098L168.492 171.402ZM173.778 177.545L176.421 180.617L177.937 179.312L175.294 176.241L173.778 177.545ZM179.063 183.688L181.706 186.759L183.222 185.455L180.579 182.383L179.063 183.688ZM184.349 189.831L186.992 192.902L188.508 191.598L185.865 188.526L184.349 189.831ZM189.635 195.974L192.278 199.045L193.794 197.741L191.151 194.669L189.635 195.974ZM194.921 202.117L197.563 205.188L199.079 203.883L196.437 200.812L194.921 202.117ZM200.206 208.259L202.849 211.331L204.365 210.026L201.722 206.955L200.206 208.259ZM205.492 214.402L208.135 217.474L209.651 216.169L207.008 213.098L205.492 214.402ZM210.778 220.545L213.421 223.617L214.937 222.312L212.294 219.241L210.778 220.545ZM216.063 226.688L218.706 229.759L220.222 228.455L217.579 225.383L216.063 226.688ZM221.349 232.831L223.992 235.902L225.508 234.598L222.865 231.526L221.349 232.831ZM226.635 238.974L229.278 242.045L230.794 240.741L228.151 237.669L226.635 238.974ZM231.921 245.117L234.563 248.188L236.079 246.883L233.437 243.812L231.921 245.117ZM237.206 251.259L239.849 254.331L241.365 253.026L238.722 249.955L237.206 251.259ZM242.492 257.402L245.135 260.474L246.651 259.169L244.008 256.098L242.492 257.402ZM247.778 263.545L250.421 266.617L251.937 265.312L249.294 262.241L247.778 263.545ZM253.063 269.688L255.706 272.759L257.222 271.455L254.579 268.383L253.063 269.688ZM258.349 275.831L260.992 278.902L262.508 277.598L259.865 274.526L258.349 275.831ZM263.635 281.974L266.278 285.045L267.794 283.741L265.151 280.669L263.635 281.974ZM268.921 288.116L271.563 291.188L273.079 289.883L270.437 286.812L268.921 288.116ZM274.206 294.259L276.849 297.331L278.365 296.026L275.722 292.955L274.206 294.259ZM279.492 300.402L282.135 303.474L283.651 302.169L281.008 299.098L279.492 300.402ZM284.778 306.545L287.421 309.616L288.937 308.312L286.294 305.241L284.778 306.545ZM290.063 312.688L292.706 315.759L294.222 314.455L291.579 311.383L290.063 312.688ZM295.349 318.831L297.992 321.902L299.508 320.598L296.865 317.526L295.349 318.831ZM300.635 324.974L303.278 328.045L304.794 326.741L302.151 323.669L300.635 324.974ZM305.921 331.116L308.563 334.188L310.079 332.883L307.437 329.812L305.921 331.116ZM311.206 337.259L313.849 340.331L315.365 339.026L312.722 335.955L311.206 337.259ZM316.492 343.402L319.135 346.474L320.651 345.169L318.008 342.098L316.492 343.402ZM321.778 349.545L324.421 352.616L325.937 351.312L323.294 348.241L321.778 349.545ZM327.063 355.688L329.706 358.759L331.222 357.455L328.579 354.383L327.063 355.688ZM332.349 361.831L334.992 364.902L336.508 363.598L333.865 360.526L332.349 361.831ZM337.635 367.974L340.278 371.045L341.794 369.741L339.151 366.669L337.635 367.974ZM342.921 374.117L344.242 375.652L345.758 374.348L344.437 372.812L342.921 374.117ZM344.925 375.997C345.476 376.038 345.956 375.626 345.997 375.075L346.67 366.1C346.712 365.549 346.299 365.069 345.748 365.028C345.197 364.987 344.717 365.4 344.676 365.95L344.078 373.928L336.1 373.33C335.549 373.288 335.069 373.701 335.028 374.252C334.987 374.803 335.4 375.283 335.95 375.324L344.925 375.997ZM159.242 160.652L160.563 162.188L162.079 160.883L160.758 159.348L159.242 160.652ZM163.206 165.259L165.849 168.331L167.365 167.026L164.722 163.955L163.206 165.259ZM168.492 171.402L171.135 174.474L172.651 173.169L170.008 170.098L168.492 171.402ZM173.778 177.545L176.421 180.617L177.937 179.312L175.294 176.241L173.778 177.545ZM179.063 183.688L181.706 186.759L183.222 185.455L180.579 182.383L179.063 183.688ZM184.349 189.831L186.992 192.902L188.508 191.598L185.865 188.526L184.349 189.831ZM189.635 195.974L192.278 199.045L193.794 197.741L191.151 194.669L189.635 195.974ZM194.921 202.117L197.563 205.188L199.079 203.883L196.437 200.812L194.921 202.117ZM200.206 208.259L202.849 211.331L204.365 210.026L201.722 206.955L200.206 208.259ZM205.492 214.402L208.135 217.474L209.651 216.169L207.008 213.098L205.492 214.402ZM210.778 220.545L213.421 223.617L214.937 222.312L212.294 219.241L210.778 220.545ZM216.063 226.688L218.706 229.759L220.222 228.455L217.579 225.383L216.063 226.688ZM221.349 232.831L223.992 235.902L225.508 234.598L222.865 231.526L221.349 232.831ZM226.635 238.974L229.278 242.045L230.794 240.741L228.151 237.669L226.635 238.974ZM231.921 245.117L234.563 248.188L236.079 246.883L233.437 243.812L231.921 245.117ZM237.206 251.259L239.849 254.331L241.365 253.026L238.722 249.955L237.206 251.259ZM242.492 257.402L245.135 260.474L246.651 259.169L244.008 256.098L242.492 257.402ZM247.778 263.545L250.421 266.617L251.937 265.312L249.294 262.241L247.778 263.545ZM253.063 269.688L255.706 272.759L257.222 271.455L254.579 268.383L253.063 269.688ZM258.349 275.831L260.992 278.902L262.508 277.598L259.865 274.526L258.349 275.831ZM263.635 281.974L266.278 285.045L267.794 283.741L265.151 280.669L263.635 281.974ZM268.921 288.116L271.563 291.188L273.079 289.883L270.437 286.812L268.921 288.116ZM274.206 294.259L276.849 297.331L278.365 296.026L275.722 292.955L274.206 294.259ZM279.492 300.402L282.135 303.474L283.651 302.169L281.008 299.098L279.492 300.402ZM284.778 306.545L287.421 309.616L288.937 308.312L286.294 305.241L284.778 306.545ZM290.063 312.688L292.706 315.759L294.222 314.455L291.579 311.383L290.063 312.688ZM295.349 318.831L297.992 321.902L299.508 320.598L296.865 317.526L295.349 318.831ZM300.635 324.974L303.278 328.045L304.794 326.741L302.151 323.669L300.635 324.974ZM305.921 331.116L308.563 334.188L310.079 332.883L307.437 329.812L305.921 331.116ZM311.206 337.259L313.849 340.331L315.365 339.026L312.722 335.955L311.206 337.259ZM316.492 343.402L319.135 346.474L320.651 345.169L318.008 342.098L316.492 343.402ZM321.778 349.545L324.421 352.616L325.937 351.312L323.294 348.241L321.778 349.545ZM327.063 355.688L329.706 358.759L331.222 357.455L328.579 354.383L327.063 355.688ZM332.349 361.831L334.992 364.902L336.508 363.598L333.865 360.526L332.349 361.831ZM337.635 367.974L340.278 371.045L341.794 369.741L339.151 366.669L337.635 367.974ZM342.921 374.117L344.242 375.652L345.758 374.348L344.437 372.812L342.921 374.117Z" fill="#AF644B"/>
-//!     <path d="M345.385 236.923C345.895 236.71 346.136 236.124 345.923 235.615L342.454 227.31C342.242 226.8 341.656 226.56 341.146 226.772C340.637 226.985 340.396 227.571 340.609 228.08L343.692 235.463L336.31 238.546C335.8 238.758 335.56 239.344 335.772 239.854C335.985 240.363 336.571 240.604 337.08 240.391L345.385 236.923ZM159.62 160.925L344.62 236.925L345.38 235.075L160.38 159.075L159.62 160.925Z" fill="#E19664"/>
-//!     <circle cx="160" cy="265" r="4" fill="#a874d8"/>
-//!     <path d="M160 160V265" stroke="#a874d8" stroke-width="2" stroke-dasharray="5 5"/>
-//!     <rect x="135" y="135" width="235" height="264" stroke="#db9010" stroke-width="1"/>
-//!     <circle cx="160" cy="160" r="159" stroke="#eb4a5a" stroke-width="1"/>
-//!     <line x1="160" y1="264" x2="400" y2="264" stroke="#a874d8" stroke-width="2" stroke-dasharray="6 6"/>
-//!     <text x="184" y="125" style="fill: #db9010; font: 16px monospace; text-anchor: middle;">Collision AABB</text>
-//!     <text x="160" y="40" style="fill: #eb4a5a; font: 16px monospace; text-anchor: middle;">Speculative Margin</text>
-//!     <text x="345" y="340" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Unconstrained</text>
-//!     <text x="345" y="205" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Constrained</text>
-//!     <text x="190" y="280" style="fill: #a874d8; font: 16px monospace; font-weight: bold; text-anchor: start;">Ghost Collision Plane</text>
-//! </svg>
-//!
-//! Ghost collisions can be mitigated by using a smaller [`SpeculativeMargin`]
-//! or a higher [`Physics`] timestep rate.
-//!
-//! Another caveat of speculative collisions is that they can still occasionally miss contacts,
-//! especially for thin objects spinning at very high speeds. This is typically quite rare however,
-//! and speculative collision should work fine for the majority of cases.
-//!
-//! Speculative collisions can also absorb some energy in contacts, causing even perfectly elastic
-//! objects to lose kinetic energy over several bounces.
-//!
-//! For an approach that is more expensive but doesn't suffer from ghost collisions,
-//! missed collisions, or inaccurate restitution, consider using swept CCD,
-//! which is described in the following section.
+//! **Continuous Collision Detection** (CCD) aims to prevent tunneling and deep overlap.
+//! Currently, two approaches are supported: [Swept CCD](#swept-ccd) and
+//! [Speculative Collision](#speculative-collision). Swept CCD is performed for fast-moving
+//! dynamic bodies *by default*, and can be configured using the [`SweptCcd`] component,
+//! while speculative collision is fully opt-in via the [`SpeculativeCcd`] component.
 //!
 //! ## Swept CCD
 //!
 //! *Note: Swept CCD currently only supports the built-in `Collider`.*
 //!
-//! **Swept CCD** is a form of Continuous Collision Detection that sweeps potentially colliding objects
-//! from their previous positions to their current positions, and if a collision is found, moves the bodies
-//! back to the time of impact. This way, the normal collision algorithms will be able to detect and handle
-//! the collision during the next frame.
+//! **Swept CCD** is a form of Continuous Collision Detection that sweeps fast-moving dynamic bodies
+//! from their previous positions to their current positions, and if a collision is found along the path,
+//! moves the body back to the time of impact. This way, discrete collision algorithms will be able to detect
+//! and handle the collision during the next timestep.
 //!
-//! There are two variants of swept CCD: [`Linear`](SweepMode::Linear)
-//! and [`NonLinear`](SweepMode::Linear). The difference between the two
-//! is that [`Linear`](SweepMode::Linear) only considers translational motion,
-//! so bodies can still pass through objects that are spinning at high speeds,
-//! while [`NonLinear`](SweepMode::NonLinear) also considers rotational motion,
-//! but is more expensive.
+//! There are two variants of swept CCD: [`SweepMode::Linear`] and [`SweepMode::NonLinear`].
+//! The difference is that [`Linear`](SweepMode::Linear) only considers translational motion,
+//! so fast-spinning bodies can still pass through objects, while [`NonLinear`](SweepMode::NonLinear)
+//! also considers rotational motion, but is more expensive.
 //!
 //! <svg width="300" height="350" viewBox="0 0 300 350" fill="none" xmlns="http://www.w3.org/2000/svg">
 //!     <rect x="141" y="1" width="18" height="298" fill="#64C850" stroke="black" stroke-width="2"/>
@@ -161,9 +62,15 @@
 //!     <path d="M54.0561 245.357L53.1144 245.694L53.1144 245.694L54.0561 245.357ZM54.5719 248.904C55.071 249.14 55.6673 248.927 55.9037 248.428L59.7565 240.294C59.9929 239.795 59.7799 239.199 59.2808 238.963C58.7817 238.726 58.1854 238.939 57.949 239.438L54.5243 246.668L47.2944 243.243C46.7953 243.007 46.199 243.22 45.9626 243.719C45.7261 244.218 45.9391 244.815 46.4382 245.051L54.5719 248.904ZM53.1144 245.694L54.0582 248.336L55.9417 247.664L54.9978 245.021L53.1144 245.694ZM20.3714 230.928C33.4979 225.678 48.3594 232.379 53.1144 245.694L54.9978 245.021C49.8615 230.639 33.808 223.4 19.6286 229.071L20.3714 230.928Z" fill="#E19664"/>
 //! </svg>
 //!
-//! To enable swept CCD for a rigid body, simply add the [`SweptCcd`] component
-//! and make sure that the [`CcdPlugin`] is enabled. The plugin is included
-//! in the [`PhysicsPlugins`] plugin group.
+//! Sweeps are performed **automatically** for every *fast* dynamic body, against both static
+//! and kinematic bodies. A body is considered "fast" if its motion during a timestep is large
+//! relative to its minimum thickness. This way, we only pay the cost of CCD for bodies that
+//! have a risk of tunneling or deep overlap.
+//!
+//! The behavior of swept CCD can be customized using the [`SweptCcd`] component.
+//! This includes configuring which types of bodies sweeps are performed against,
+//! tuning the threshold for what is considered a "fast" body, and changing
+//! the sweep mode:
 //!
 //! ```
 #![cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
@@ -171,41 +78,118 @@
 //! use bevy::prelude::*;
 //!
 //! fn setup(mut commands: Commands) {
-//!     // Spawn a rigid body with swept CCD enabled.
-//!     // `SweepMode::NonLinear` is used by default.
 //!     commands.spawn((
 //!         RigidBody::Dynamic,
 //!         Collider::capsule(0.5, 2.0),
-//!         SweptCcd::default(),
+//!         // These are the default settings
+//!         SweptCcd {
+//!             filter: CcdFilter::DEFAULT,
+//!             mode: SweepMode::NonLinear,
+//!             threshold: 0.5,
+//!         }
 //!     ));
 //! }
 //! ```
 //!
-//! See the [documentation](SweptCcd) of the component for more details
+//! See the documentation of the [`SweptCcd`] component for more details
 //! and configuration options.
 //!
-//! Swept CCD is more expensive than [Speculative Collision](#speculative-collision),
-//! but it doesn't have the same issues with ghost collisions or missed collisions.
-//! It is primarily intended as a safety net when it is crucial that a body never
-//! tunnels through geometry. Swept CCD should only be used when necessary,
-//! as it also has its own set of problems.
+//! This approach to CCD is heavily inspired by [Box2D](https://box2d.org) by Erin Catto.
 //!
 //! ### Caveats of Swept CCD
 //!
-//! The [`Linear`](SweepMode::Linear) and [`NonLinear`](SweepMode::Linear)
-//! approaches can lead to *time loss* or *time stealing*, where bodies appear to momentarily
-//! move slower when Swept CCD is active. This happens because they are essentially moved
-//! backwards in time to avoid missing the collision.
+//! Swept CCD can lead to *time loss* or *time stealing*, where bodies appear to momentarily
+//! slow down or freeze when colliding at high speeds. This happens because they are essentially
+//! moved backwards in time to avoid missing the collision. Time loss could be better accounted for
+//! with a substepped time-of-impact solver, but it would be much more expensive and complex,
+//! so it is not supported yet.
 //!
-//! Swept CCD might also not account for chain reactions properly, so if a fast-moving body
-//! bumps into another body, making it a fast-moving body that potentially bumps into
-//! even more bodies, the collisions might not propagate accurately.
-//! However, speculative contacts do detect secondary collisions quite well,
-//! so using the two together can help mitigate the issue.
+//! Additionally, if two fast-moving bodies are approaching each other, but are not already
+//! in the path of each other's sweeps (ex: projectiles coming from different directions),
+//! they can miss each other. This can be solved by also enabling [speculative collision](#speculative-collision)
+//! in order to expand their AABBs based on velocity and predict contacts before they happen.
 //!
-//! Time loss and chain reactions could also be better accounted for with a substepped
-//! time-of-impact solver, but that would be much more expensive and complex,
-//! so it is not yet supported.
+//! ## Speculative Collision
+//!
+//! **Speculative collision** is a form of Continuous Collision Detection
+//! where contacts are predicted before they happen. It is only performed
+//! for bodies that have the [`SpeculativeCcd`] component.
+//!
+//! To determine whether two bodies may come into contact within the next timestep,
+//! speculative collision expands their [`ColliderAabb`]s based on their velocities.
+//! Additionally, a **speculative margin** is used to determine the maximum distance
+//! at which two shapes can generate speculative contacts.
+//!
+//! <svg width="335" height="400" viewBox="0 0 335 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+//!     <rect x="36" y="266" width="298" height="18" fill="#64C850" stroke="black" stroke-width="2"/>
+//!     <circle cx="210" cy="375" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <circle cx="210" cy="240" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <circle cx="160" cy="160" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
+//!     <path d="M209.471 375.849C209.94 376.141 210.557 375.997 210.849 375.529L215.606 367.888C215.898 367.42 215.754 366.803 215.286 366.511C214.817 366.219 214.2 366.363 213.908 366.831L209.68 373.623L202.888 369.394C202.42 369.102 201.803 369.246 201.511 369.714C201.219 370.183 201.363 370.8 201.831 371.092L209.471 375.849ZM159.026 160.227L159.472 162.146L161.42 161.693L160.974 159.773L159.026 160.227ZM160.365 165.985L161.258 169.825L163.206 169.372L162.313 165.532L160.365 165.985ZM162.151 173.664L163.044 177.503L164.992 177.05L164.099 173.211L162.151 173.664ZM163.937 181.343L164.83 185.182L166.778 184.729L165.885 180.89L163.937 181.343ZM165.722 189.021L166.615 192.86L168.563 192.407L167.67 188.568L165.722 189.021ZM167.508 196.7L168.401 200.539L170.349 200.086L169.456 196.247L167.508 196.7ZM169.294 204.378L170.187 208.218L172.135 207.765L171.242 203.925L169.294 204.378ZM171.08 212.057L171.972 215.896L173.92 215.443L173.028 211.604L171.08 212.057ZM172.865 219.735L173.758 223.575L175.706 223.122L174.813 219.282L172.865 219.735ZM174.651 227.414L175.544 231.253L177.492 230.8L176.599 226.961L174.651 227.414ZM176.437 235.093L177.33 238.932L179.278 238.479L178.385 234.64L176.437 235.093ZM178.222 242.771L179.115 246.61L181.063 246.157L180.17 242.318L178.222 242.771ZM180.008 250.45L180.901 254.289L182.849 253.836L181.956 249.997L180.008 250.45ZM181.794 258.128L182.687 261.968L184.635 261.515L183.742 257.675L181.794 258.128ZM183.58 265.807L184.472 269.646L186.42 269.193L185.528 265.354L183.58 265.807ZM185.365 273.485L186.258 277.325L188.206 276.872L187.313 273.032L185.365 273.485ZM187.151 281.164L188.044 285.003L189.992 284.55L189.099 280.711L187.151 281.164ZM188.937 288.843L189.83 292.682L191.778 292.229L190.885 288.39L188.937 288.843ZM190.722 296.521L191.615 300.36L193.563 299.907L192.67 296.068L190.722 296.521ZM192.508 304.2L193.401 308.039L195.349 307.586L194.456 303.747L192.508 304.2ZM194.294 311.878L195.187 315.718L197.135 315.265L196.242 311.425L194.294 311.878ZM196.08 319.557L196.972 323.396L198.92 322.943L198.028 319.104L196.08 319.557ZM197.865 327.235L198.758 331.075L200.706 330.622L199.813 326.782L197.865 327.235ZM199.651 334.914L200.544 338.753L202.492 338.3L201.599 334.461L199.651 334.914ZM201.437 342.593L202.33 346.432L204.278 345.979L203.385 342.14L201.437 342.593ZM203.222 350.271L204.115 354.111L206.063 353.657L205.17 349.818L203.222 350.271ZM205.008 357.95L205.901 361.789L207.849 361.336L206.956 357.497L205.008 357.95ZM206.794 365.628L207.687 369.468L209.635 369.015L208.742 365.175L206.794 365.628ZM208.58 373.307L209.026 375.226L210.974 374.773L210.528 372.854L208.58 373.307ZM209.471 375.849C209.94 376.141 210.557 375.997 210.849 375.529L215.606 367.888C215.898 367.42 215.754 366.803 215.286 366.511C214.817 366.219 214.2 366.363 213.908 366.831L209.68 373.623L202.888 369.394C202.42 369.102 201.803 369.246 201.511 369.714C201.219 370.183 201.363 370.8 201.831 371.092L209.471 375.849ZM159.026 160.227L159.472 162.146L161.42 161.693L160.974 159.773L159.026 160.227ZM160.365 165.985L161.258 169.825L163.206 169.372L162.313 165.532L160.365 165.985ZM162.151 173.664L163.044 177.503L164.992 177.05L164.099 173.211L162.151 173.664ZM163.937 181.343L164.83 185.182L166.778 184.729L165.885 180.89L163.937 181.343ZM165.722 189.021L166.615 192.86L168.563 192.407L167.67 188.568L165.722 189.021ZM167.508 196.7L168.401 200.539L170.349 200.086L169.456 196.247L167.508 196.7ZM169.294 204.378L170.187 208.218L172.135 207.765L171.242 203.925L169.294 204.378ZM171.08 212.057L171.972 215.896L173.92 215.443L173.028 211.604L171.08 212.057ZM172.865 219.735L173.758 223.575L175.706 223.122L174.813 219.282L172.865 219.735ZM174.651 227.414L175.544 231.253L177.492 230.8L176.599 226.961L174.651 227.414ZM176.437 235.093L177.33 238.932L179.278 238.479L178.385 234.64L176.437 235.093ZM178.222 242.771L179.115 246.61L181.063 246.157L180.17 242.318L178.222 242.771ZM180.008 250.45L180.901 254.289L182.849 253.836L181.956 249.997L180.008 250.45ZM181.794 258.128L182.687 261.968L184.635 261.515L183.742 257.675L181.794 258.128ZM183.58 265.807L184.472 269.646L186.42 269.193L185.528 265.354L183.58 265.807ZM185.365 273.485L186.258 277.325L188.206 276.872L187.313 273.032L185.365 273.485ZM187.151 281.164L188.044 285.003L189.992 284.55L189.099 280.711L187.151 281.164ZM188.937 288.843L189.83 292.682L191.778 292.229L190.885 288.39L188.937 288.843ZM190.722 296.521L191.615 300.36L193.563 299.907L192.67 296.068L190.722 296.521ZM192.508 304.2L193.401 308.039L195.349 307.586L194.456 303.747L192.508 304.2ZM194.294 311.878L195.187 315.718L197.135 315.265L196.242 311.425L194.294 311.878ZM196.08 319.557L196.972 323.396L198.92 322.943L198.028 319.104L196.08 319.557ZM197.865 327.235L198.758 331.075L200.706 330.622L199.813 326.782L197.865 327.235ZM199.651 334.914L200.544 338.753L202.492 338.3L201.599 334.461L199.651 334.914ZM201.437 342.593L202.33 346.432L204.278 345.979L203.385 342.14L201.437 342.593ZM203.222 350.271L204.115 354.111L206.063 353.657L205.17 349.818L203.222 350.271ZM205.008 357.95L205.901 361.789L207.849 361.336L206.956 357.497L205.008 357.95ZM206.794 365.628L207.687 369.468L209.635 369.015L208.742 365.175L206.794 365.628ZM208.58 373.307L209.026 375.226L210.974 374.773L210.528 372.854L208.58 373.307Z" fill="#AF644B"/>
+//!     <path d="M209.775 240.974C210.313 241.099 210.85 240.763 210.974 240.225L212.998 231.455C213.122 230.917 212.787 230.38 212.249 230.256C211.71 230.132 211.174 230.467 211.049 231.006L209.25 238.801L201.455 237.002C200.917 236.878 200.38 237.213 200.256 237.751C200.132 238.29 200.467 238.826 201.006 238.951L209.775 240.974ZM159.152 160.53L209.152 240.53L210.848 239.47L160.848 159.47L159.152 160.53Z" fill="#E19664"/>
+//!     <circle cx="160" cy="265" r="4" fill="#a874d8"/>
+//!     <path d="M160 160V265" stroke="#a874d8" stroke-width="2" stroke-dasharray="5 5"/>
+//!     <rect x="135" y="135" width="99" height="264" stroke="#db9010" stroke-width="1"/>
+//!     <circle cx="160" cy="160" r="159" stroke="#eb4a5a" stroke-width="1"/>
+//!     <text x="184" y="125" style="fill: #db9010; font: 16px monospace; text-anchor: middle;">Collision AABB</text>
+//!     <text x="160" y="40" style="fill: #eb4a5a; font: 16px monospace; text-anchor: middle;">Speculative Margin</text>
+//!     <text x="210" y="340" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Unconstrained</text>
+//!     <text x="210" y="205" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Constrained</text>
+//!     <text y="240" style="fill: #a874d8; font: 16px monospace; font-weight: bold; text-anchor: end;">
+//!         <tspan x="155">Speculative</tspan><tspan x="155" dy="18">Contact</tspan>
+//!     </text>
+//! </svg>
+//!
+//! By default, Avian keeps AABBs tight, and only predicts contacts up to a small,
+//! fixed [`contact_tolerance`], which aims to improve stability and avoid jitter
+//! for resting bodies. By adding the [`SpeculativeCcd`] component, you can increase
+//! the maximum speculative distance and opt in to velocity-based AABB expansion,
+//! enabling speculative contact behavior.
+//!
+//! Speculative collisions can be very efficient for highly dynamic scenes,
+//! but a large speculative margin can also lead to excessive collision tests
+//! and false positives, which are described below.
+//!
+//! [`contact_tolerance`]: NarrowPhaseConfig::contact_tolerance
+//!
+//! ### Caveats of Speculative Collision
+//!
+//! Speculative contacts are approximations. They typically have good enough accuracy,
+//! but when bodies are moving past each other at high speeds, the prediction can sometimes
+//! fail and lead to **ghost collisions**. This happens because contact surfaces are treated
+//! like infinite planes from the point of view of the contact solver. Ghost collisions
+//! typically manifest as objects bumping into seemingly invisible walls or seams.
+//!
+//! <svg width="475" height="400" viewBox="0 0 475 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+//!     <rect x="36" y="266" width="148" height="18" fill="#64C850" stroke="black" stroke-width="2"/>
+//!     <circle cx="345" cy="375" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <circle cx="345" cy="236" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <circle cx="160" cy="160" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
+//!     <path d="M344.925 375.997C345.476 376.038 345.956 375.626 345.997 375.075L346.67 366.1C346.712 365.549 346.299 365.069 345.748 365.028C345.197 364.987 344.717 365.4 344.676 365.95L344.078 373.928L336.1 373.33C335.549 373.288 335.069 373.701 335.028 374.252C334.987 374.803 335.4 375.283 335.95 375.324L344.925 375.997ZM159.242 160.652L160.563 162.188L162.079 160.883L160.758 159.348L159.242 160.652ZM163.206 165.259L165.849 168.331L167.365 167.026L164.722 163.955L163.206 165.259ZM168.492 171.402L171.135 174.474L172.651 173.169L170.008 170.098L168.492 171.402ZM173.778 177.545L176.421 180.617L177.937 179.312L175.294 176.241L173.778 177.545ZM179.063 183.688L181.706 186.759L183.222 185.455L180.579 182.383L179.063 183.688ZM184.349 189.831L186.992 192.902L188.508 191.598L185.865 188.526L184.349 189.831ZM189.635 195.974L192.278 199.045L193.794 197.741L191.151 194.669L189.635 195.974ZM194.921 202.117L197.563 205.188L199.079 203.883L196.437 200.812L194.921 202.117ZM200.206 208.259L202.849 211.331L204.365 210.026L201.722 206.955L200.206 208.259ZM205.492 214.402L208.135 217.474L209.651 216.169L207.008 213.098L205.492 214.402ZM210.778 220.545L213.421 223.617L214.937 222.312L212.294 219.241L210.778 220.545ZM216.063 226.688L218.706 229.759L220.222 228.455L217.579 225.383L216.063 226.688ZM221.349 232.831L223.992 235.902L225.508 234.598L222.865 231.526L221.349 232.831ZM226.635 238.974L229.278 242.045L230.794 240.741L228.151 237.669L226.635 238.974ZM231.921 245.117L234.563 248.188L236.079 246.883L233.437 243.812L231.921 245.117ZM237.206 251.259L239.849 254.331L241.365 253.026L238.722 249.955L237.206 251.259ZM242.492 257.402L245.135 260.474L246.651 259.169L244.008 256.098L242.492 257.402ZM247.778 263.545L250.421 266.617L251.937 265.312L249.294 262.241L247.778 263.545ZM253.063 269.688L255.706 272.759L257.222 271.455L254.579 268.383L253.063 269.688ZM258.349 275.831L260.992 278.902L262.508 277.598L259.865 274.526L258.349 275.831ZM263.635 281.974L266.278 285.045L267.794 283.741L265.151 280.669L263.635 281.974ZM268.921 288.116L271.563 291.188L273.079 289.883L270.437 286.812L268.921 288.116ZM274.206 294.259L276.849 297.331L278.365 296.026L275.722 292.955L274.206 294.259ZM279.492 300.402L282.135 303.474L283.651 302.169L281.008 299.098L279.492 300.402ZM284.778 306.545L287.421 309.616L288.937 308.312L286.294 305.241L284.778 306.545ZM290.063 312.688L292.706 315.759L294.222 314.455L291.579 311.383L290.063 312.688ZM295.349 318.831L297.992 321.902L299.508 320.598L296.865 317.526L295.349 318.831ZM300.635 324.974L303.278 328.045L304.794 326.741L302.151 323.669L300.635 324.974ZM305.921 331.116L308.563 334.188L310.079 332.883L307.437 329.812L305.921 331.116ZM311.206 337.259L313.849 340.331L315.365 339.026L312.722 335.955L311.206 337.259ZM316.492 343.402L319.135 346.474L320.651 345.169L318.008 342.098L316.492 343.402ZM321.778 349.545L324.421 352.616L325.937 351.312L323.294 348.241L321.778 349.545ZM327.063 355.688L329.706 358.759L331.222 357.455L328.579 354.383L327.063 355.688ZM332.349 361.831L334.992 364.902L336.508 363.598L333.865 360.526L332.349 361.831ZM337.635 367.974L340.278 371.045L341.794 369.741L339.151 366.669L337.635 367.974ZM342.921 374.117L344.242 375.652L345.758 374.348L344.437 372.812L342.921 374.117ZM344.925 375.997C345.476 376.038 345.956 375.626 345.997 375.075L346.67 366.1C346.712 365.549 346.299 365.069 345.748 365.028C345.197 364.987 344.717 365.4 344.676 365.95L344.078 373.928L336.1 373.33C335.549 373.288 335.069 373.701 335.028 374.252C334.987 374.803 335.4 375.283 335.95 375.324L344.925 375.997ZM159.242 160.652L160.563 162.188L162.079 160.883L160.758 159.348L159.242 160.652ZM163.206 165.259L165.849 168.331L167.365 167.026L164.722 163.955L163.206 165.259ZM168.492 171.402L171.135 174.474L172.651 173.169L170.008 170.098L168.492 171.402ZM173.778 177.545L176.421 180.617L177.937 179.312L175.294 176.241L173.778 177.545ZM179.063 183.688L181.706 186.759L183.222 185.455L180.579 182.383L179.063 183.688ZM184.349 189.831L186.992 192.902L188.508 191.598L185.865 188.526L184.349 189.831ZM189.635 195.974L192.278 199.045L193.794 197.741L191.151 194.669L189.635 195.974ZM194.921 202.117L197.563 205.188L199.079 203.883L196.437 200.812L194.921 202.117ZM200.206 208.259L202.849 211.331L204.365 210.026L201.722 206.955L200.206 208.259ZM205.492 214.402L208.135 217.474L209.651 216.169L207.008 213.098L205.492 214.402ZM210.778 220.545L213.421 223.617L214.937 222.312L212.294 219.241L210.778 220.545ZM216.063 226.688L218.706 229.759L220.222 228.455L217.579 225.383L216.063 226.688ZM221.349 232.831L223.992 235.902L225.508 234.598L222.865 231.526L221.349 232.831ZM226.635 238.974L229.278 242.045L230.794 240.741L228.151 237.669L226.635 238.974ZM231.921 245.117L234.563 248.188L236.079 246.883L233.437 243.812L231.921 245.117ZM237.206 251.259L239.849 254.331L241.365 253.026L238.722 249.955L237.206 251.259ZM242.492 257.402L245.135 260.474L246.651 259.169L244.008 256.098L242.492 257.402ZM247.778 263.545L250.421 266.617L251.937 265.312L249.294 262.241L247.778 263.545ZM253.063 269.688L255.706 272.759L257.222 271.455L254.579 268.383L253.063 269.688ZM258.349 275.831L260.992 278.902L262.508 277.598L259.865 274.526L258.349 275.831ZM263.635 281.974L266.278 285.045L267.794 283.741L265.151 280.669L263.635 281.974ZM268.921 288.116L271.563 291.188L273.079 289.883L270.437 286.812L268.921 288.116ZM274.206 294.259L276.849 297.331L278.365 296.026L275.722 292.955L274.206 294.259ZM279.492 300.402L282.135 303.474L283.651 302.169L281.008 299.098L279.492 300.402ZM284.778 306.545L287.421 309.616L288.937 308.312L286.294 305.241L284.778 306.545ZM290.063 312.688L292.706 315.759L294.222 314.455L291.579 311.383L290.063 312.688ZM295.349 318.831L297.992 321.902L299.508 320.598L296.865 317.526L295.349 318.831ZM300.635 324.974L303.278 328.045L304.794 326.741L302.151 323.669L300.635 324.974ZM305.921 331.116L308.563 334.188L310.079 332.883L307.437 329.812L305.921 331.116ZM311.206 337.259L313.849 340.331L315.365 339.026L312.722 335.955L311.206 337.259ZM316.492 343.402L319.135 346.474L320.651 345.169L318.008 342.098L316.492 343.402ZM321.778 349.545L324.421 352.616L325.937 351.312L323.294 348.241L321.778 349.545ZM327.063 355.688L329.706 358.759L331.222 357.455L328.579 354.383L327.063 355.688ZM332.349 361.831L334.992 364.902L336.508 363.598L333.865 360.526L332.349 361.831ZM337.635 367.974L340.278 371.045L341.794 369.741L339.151 366.669L337.635 367.974ZM342.921 374.117L344.242 375.652L345.758 374.348L344.437 372.812L342.921 374.117Z" fill="#AF644B"/>
+//!     <path d="M345.385 236.923C345.895 236.71 346.136 236.124 345.923 235.615L342.454 227.31C342.242 226.8 341.656 226.56 341.146 226.772C340.637 226.985 340.396 227.571 340.609 228.08L343.692 235.463L336.31 238.546C335.8 238.758 335.56 239.344 335.772 239.854C335.985 240.363 336.571 240.604 337.08 240.391L345.385 236.923ZM159.62 160.925L344.62 236.925L345.38 235.075L160.38 159.075L159.62 160.925Z" fill="#E19664"/>
+//!     <circle cx="160" cy="265" r="4" fill="#a874d8"/>
+//!     <path d="M160 160V265" stroke="#a874d8" stroke-width="2" stroke-dasharray="5 5"/>
+//!     <rect x="135" y="135" width="235" height="264" stroke="#db9010" stroke-width="1"/>
+//!     <circle cx="160" cy="160" r="159" stroke="#eb4a5a" stroke-width="1"/>
+//!     <line x1="160" y1="264" x2="400" y2="264" stroke="#a874d8" stroke-width="2" stroke-dasharray="6 6"/>
+//!     <text x="184" y="125" style="fill: #db9010; font: 16px monospace; text-anchor: middle;">Collision AABB</text>
+//!     <text x="160" y="40" style="fill: #eb4a5a; font: 16px monospace; text-anchor: middle;">Speculative Margin</text>
+//!     <text x="345" y="340" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Unconstrained</text>
+//!     <text x="345" y="205" style="fill: #b4b4b4; font: 16px monospace; text-anchor: start;">Constrained</text>
+//!     <text x="190" y="280" style="fill: #a874d8; font: 16px monospace; font-weight: bold; text-anchor: start;">Ghost Collision Plane</text>
+//! </svg>
+//!
+//! Another caveat of speculative collision is that it can still occasionally miss contacts,
+//! especially for fast-spinning objects, as speculative contacts do not properly account for
+//! rotational motion.
+//!
+//! Speculative collisions can also absorb some energy in contacts, causing even perfectly elastic
+//! objects to lose kinetic energy over several bounces.
+//!
+//! These caveats together with the performance impact of velocity-expanded AABBs
+//! are why Avian does not predict contacts beyond the small [`contact_tolerance`]
+//! by default. Still, speculative contacts can be a good option for some scenes,
+//! which is what the opt-in [`SpeculativeCcd`] component is for.
 //!
 //! ## Other Ways to Avoid Tunneling
 //!
@@ -215,7 +199,7 @@
 //!
 //! The most obvious way is to simply avoid small or thin geometry such as triangle meshes,
 //! and to make colliders for objects like walls slightly thicker than necessary.
-//! This is of course typically not possible everywhere, but it is good to keep in mind
+//! This is of course not possible everywhere, but it is good to keep in mind
 //! when authoring levels.
 //!
 //! Triangle mesh colliders are especially prone to tunneling for dynamic rigid bodies.
@@ -267,23 +251,19 @@ impl Plugin for CcdPlugin {
     }
 }
 
-/// A component that configures [Continuous Collision Detection](self) (CCD)
+/// A component that configures [Swept Continuous Collision Detection (CCD)](self#swept-ccd)
 /// for a [dynamic](RigidBody::Dynamic) [`RigidBody`].
 ///
-/// Only dynamic bodies support CCD. Fast-moving dynamic bodies are swept against static and
-/// kinematic bodies automatically, even without this component (see the
-/// [module-level documentation](self)).
+/// By default, swept CCD is performed automatically for fast-moving dynamic bodies,
+/// against static and kinematic bodies but not other dynamic bodies.
 ///
-/// Add `SweptCcd` to:
+/// Adding this component allows you to:
 ///
-/// - control which body types this body is swept against during CCD (via [`filter`](Self::filter))
+/// - control which types of bodies sweeps are performed against (via [`filter`](Self::filter))
 /// - choose the [sweep mode](SweepMode) (via [`mode`](Self::mode))
-/// - disable CCD for the body (via an empty [`filter`](Self::filter))
+/// - adjust the threshold for when CCD is triggered (via [`threshold`](Self::threshold))
 ///
-/// The component has no effect on static or kinematic bodies.
-///
-/// By default, CCD considers both translational and rotational motion, and sweeps against
-/// static and kinematic bodies but not other dynamic bodies.
+/// This component has no effect on static or kinematic bodies, as they do not support CCD.
 ///
 /// Read the [module-level documentation](self) for more information about what CCD is,
 /// what it is used for, and what limitations and tradeoffs it can have.
@@ -312,9 +292,11 @@ impl Plugin for CcdPlugin {
 ///     // and is additionally swept against other dynamic bodies.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         SweptCcd::default()
-///             .with_mode(SweepMode::Linear)
-///             .with_filter(CcdFilter::ALL),
+///         SweptCcd {
+///             filter: CcdFilter::ALL,
+///             mode: SweepMode::Linear,
+///             ..default()
+///         }
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
@@ -369,9 +351,11 @@ impl Default for SweptCcd {
 }
 
 impl SweptCcd {
-    /// Creates a [`SweptCcd`] configuration with default settings: CCD enabled,
-    /// [`SweepMode::NonLinear`], swept against static and kinematic bodies
-    /// but not other dynamic bodies.
+    /// Creates a [`SweptCcd`] configuration with default settings:
+    ///
+    /// - [`filter`](Self::filter): [`CcdFilter::DEFAULT`] (sweeps against static and kinematic bodies)
+    /// - [`mode`](Self::mode): [`SweepMode::NonLinear`]
+    /// - [`threshold`](Self::threshold): `0.5`
     #[inline]
     pub const fn new() -> Self {
         Self {
@@ -474,19 +458,19 @@ pub enum SweepMode {
 }
 
 /// A component that enables [speculative collision](self#speculative-collision)
-/// and velocity-expanded [AABBs](ColliderAabb) for a [dynamic](RigidBody::Dynamic) [`RigidBody`],
+/// and velocity-expanded [AABBs](ColliderAabb) for a [`RigidBody`],
 /// allowing it to predict and react to contacts before they happen.
 ///
 /// Without this component, a body still receives a small, fixed [`contact_tolerance`]
 /// and automatic [swept CCD](self#swept-ccd), but no velocity-based speculative margin
 /// or AABB expansion.
 ///
-/// Speculative collision can be cheaper than swept CCD, but speculative contacts are approximations,
-/// and large margins can cause [ghost collisions](self#caveats-of-speculative-collision).
-/// The [`max_distance`](Self::max_distance) property bounds the margin to mitigate this.
+/// Speculative collisions can be cheaper than swept CCD for highly dynamic scenes,
+/// but are more approximate, and can cause [ghost collisions](self#caveats-of-speculative-collision).
+/// The [`max_distance`](Self::max_distance) property bounds the margin to help mitigate this.
 ///
-/// Bodies with this component oftentimes also sweep against other dynamic bodies
-/// via [`SweptCcd::filter`].
+/// Read the [module-level documentation](self) for more information about what CCD is,
+/// what it is used for, and what limitations and tradeoffs it can have.
 ///
 /// [`contact_tolerance`]: NarrowPhaseConfig::contact_tolerance
 ///
@@ -534,13 +518,11 @@ impl Default for SpeculativeCcd {
 impl SpeculativeCcd {
     /// An unbounded speculative margin. Speculative contacts are generated as far ahead
     /// as the body's velocity reaches, and the AABB is expanded by the full per-timestep motion.
-    pub const MAX: Self = Self {
-        max_distance: Scalar::MAX,
-    };
+    pub const MAX: Self = Self::new(Scalar::MAX);
 
     /// A zero speculative margin. Disables speculative collision and velocity-based
     /// AABB expansion for this body.
-    pub const ZERO: Self = Self { max_distance: 0.0 };
+    pub const ZERO: Self = Self::new(0.0);
 
     /// Creates a [`SpeculativeCcd`] configuration with the given maximum speculative distance.
     #[inline]
@@ -714,9 +696,9 @@ fn solve_continuous(
         // Sweep each collider attached to the body.
         for collider_entity in fast.colliders {
             let Ok((collider1, &collider_pos1, &collider_rot1)) = colliders.get(collider_entity)
-        else {
-            continue;
-        };
+            else {
+                continue;
+            };
 
             let motion1 =
                 collider_sweep_motion(collider_pos1, collider_rot1, body_com_world, body, inv_dt);
@@ -796,17 +778,17 @@ fn solve_continuous(
 
                     // Use a non-linear sweep unless both bodies opt into linear sweeps.
                     let sweep_mode = if mode1 == SweepMode::Linear && mode2 == SweepMode::Linear {
-                    SweepMode::Linear
-                } else {
-                    SweepMode::NonLinear
-                };
+                        SweepMode::Linear
+                    } else {
+                        SweepMode::NonLinear
+                    };
 
                     // Compute the time of impact for this pair of colliders. If it's the earliest
                     // so far, record the details needed to clamp the body's normal motion and hand
                     // the contact off to the discrete solver next frame.
                     if let Some(hit) = compute_ccd_toi(
                         sweep_mode, &motion1, collider1, &motion2, collider2, min_toi,
-                ) {
+                    ) {
                         min_toi = hit.time_of_impact;
                         best_impact = Some(CcdImpact {
                             collider1: collider_entity,
@@ -850,21 +832,21 @@ fn solve_continuous(
         } in results
         {
             if let Ok(mut solver_body) = body_query.get_mut(entity) {
-            // Note: This flag is only retained for debug rendering.
-            solver_body.flags.insert(SolverBodyFlags::IS_FAST);
-
-            if fraction < 1.0 {
                 // Note: This flag is only retained for debug rendering.
-                solver_body
-                    .flags
-                    .insert(SolverBodyFlags::HAD_TIME_OF_IMPACT);
+                solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 
-                let t = fraction.min(1.0);
+                if fraction < 1.0 {
+                    // Note: This flag is only retained for debug rendering.
+                    solver_body
+                        .flags
+                        .insert(SolverBodyFlags::HAD_TIME_OF_IMPACT);
+
+                    let t = fraction.min(1.0);
 
                     // Scale back the body's motion to the time of impact.
-                solver_body.delta_position *= t;
-                solver_body.delta_rotation =
-                    Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
+                    solver_body.delta_position *= t;
+                    solver_body.delta_rotation =
+                        Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
                 }
             }
 
@@ -972,14 +954,14 @@ fn compute_ccd_toi(
         .ok()??
     } else {
         cast_shapes_nonlinear(
-        motion1,
+            motion1,
             shape1.as_ref(),
-        motion2,
+            motion2,
             shape2.as_ref(),
-                0.0,
-                min_toi,
-                false,
-            )
+            0.0,
+            min_toi,
+            false,
+        )
         .ok()??
     };
 

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -272,11 +272,13 @@ impl Plugin for CcdPlugin {
 ///
 /// Only dynamic bodies support CCD. Fast-moving dynamic bodies are swept against static and
 /// kinematic bodies automatically, even without this component (see the
-/// [module-level documentation](self)). Add `SweptCcd` to:
+/// [module-level documentation](self)).
 ///
-/// - also sweep the body against other **dynamic** bodies (via [`include_dynamic`](Self::include_dynamic))
+/// Add `SweptCcd` to:
+///
+/// - control which body types this body is swept against during CCD (via [`filter`](Self::filter))
 /// - choose the [sweep mode](SweepMode) (via [`mode`](Self::mode))
-/// - disable CCD for the body (via [`enabled`](Self::enabled))
+/// - disable CCD for the body (via an empty [`filter`](Self::filter))
 ///
 /// The component has no effect on static or kinematic bodies.
 ///
@@ -312,7 +314,7 @@ impl Plugin for CcdPlugin {
 ///         RigidBody::Dynamic,
 ///         SweptCcd::default()
 ///             .with_mode(SweepMode::Linear)
-///             .with_include_dynamic(true),
+///             .with_filter(CcdFilter::ALL),
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
@@ -324,17 +326,19 @@ impl Plugin for CcdPlugin {
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default, PartialEq)]
 pub struct SweptCcd {
-    /// Whether CCD is enabled for this body.
+    /// The types of bodies this body is swept against during CCD.
     ///
-    /// Setting this to `false` disables CCD for the body entirely.
-    /// This can improve performance but can lead to tunneling.
+    /// Each [`RigidBody`] type can be toggled independently. For example,
+    /// fast bodies are swept against static and kinematic bodies by default,
+    /// but not against other dynamic bodies.
     ///
-    /// Disabling CCD should rarely be necessary, as it is only performed
-    /// for fast-moving bodies, and should have a minimal performance impact
-    /// for most applications.
+    /// If the filter is [empty](CcdFilter::EMPTY), CCD is disabled for this body entirely.
+    /// This can improve performance but can lead to tunneling. Disabling CCD should rarely
+    /// be necessary, as it is only performed for fast-moving bodies, and should have a minimal
+    /// performance impact for most applications.
     ///
-    /// **Default**: `true`
-    pub enabled: bool,
+    /// **Default**: [`CcdFilter::DEFAULT`] (static and kinematic bodies)
+    pub filter: CcdFilter,
 
     /// The [sweep mode](SweepMode) used for this body.
     ///
@@ -356,14 +360,6 @@ pub struct SweptCcd {
     ///
     /// **Default**: `0.5`
     pub fast_threshold: Scalar,
-
-    /// Whether the body is additionally swept against other dynamic bodies.
-    ///
-    /// Dynamic bodies are always swept against static and kinematic bodies;
-    /// this only controls whether they are also swept against each other.
-    ///
-    /// **Default**: `false`
-    pub include_dynamic: bool,
 }
 
 impl Default for SweptCcd {
@@ -374,21 +370,23 @@ impl Default for SweptCcd {
 
 impl SweptCcd {
     /// Creates a [`SweptCcd`] configuration with default settings: CCD enabled,
-    /// [`SweepMode::NonLinear`], swept against static and kinematic bodies but not dynamic bodies.
+    /// [`SweepMode::NonLinear`], swept against static and kinematic bodies
+    /// but not other dynamic bodies.
     #[inline]
     pub const fn new() -> Self {
         Self {
-            enabled: true,
+            filter: CcdFilter::DEFAULT,
             mode: SweepMode::NonLinear,
             fast_threshold: 0.5,
-            include_dynamic: false,
         }
     }
 
-    /// Sets whether CCD is enabled for this body.
+    /// Sets the [`CcdFilter`] determining which body types this body is swept against.
+    ///
+    /// An [empty](CcdFilter::EMPTY) filter disables CCD for this body entirely.
     #[inline]
-    pub const fn with_enabled(mut self, enabled: bool) -> Self {
-        self.enabled = enabled;
+    pub const fn with_filter(mut self, filter: CcdFilter) -> Self {
+        self.filter = filter;
         self
     }
 
@@ -398,16 +396,50 @@ impl SweptCcd {
         self.mode = mode;
         self
     }
+}
 
-    /// Sets whether the body is additionally swept against other dynamic bodies.
-    #[inline]
-    pub const fn with_include_dynamic(mut self, include_dynamic: bool) -> Self {
-        self.include_dynamic = include_dynamic;
-        self
+/// A bitmask determining which [`RigidBody`] types a [`SweptCcd`] body is swept against
+/// during [Continuous Collision Detection](self).
+///
+/// If [empty](Self::EMPTY), CCD is disabled for the body entirely.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Reflect)]
+#[reflect(Debug, Default, PartialEq)]
+pub struct CcdFilter(u8);
+
+bitflags::bitflags! {
+    impl CcdFilter: u8 {
+        /// Sweep against other dynamic bodies.
+        const DYNAMIC = 1 << 0;
+        /// Sweep against kinematic bodies.
+        const KINEMATIC = 1 << 1;
+        /// Sweep against static bodies.
+        const STATIC = 1 << 2;
+        /// Sweep against standalone colliders (colliders with no rigid body).
+        const STANDALONE = 1 << 3;
+
+        /// The default filter: sweep against static and kinematic bodies,
+        /// but not against other dynamic bodies or colliders without a body.
+        const DEFAULT = Self::KINEMATIC.bits() | Self::STATIC.bits();
+
+        /// Sweep against all body types and standalone colliders.
+        const ALL = Self::DYNAMIC.bits()
+            | Self::KINEMATIC.bits()
+            | Self::STATIC.bits()
+            | Self::STANDALONE.bits();
+
+        /// Sweep against no body types, effectively disabling CCD for this body.
+        const EMPTY = 0;
     }
 }
 
-/// The algorithm used for sweepds during [Continuous Collision Detection](self#swept-ccd).
+impl Default for CcdFilter {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// The algorithm used for sweeps during [Continuous Collision Detection](self#swept-ccd).
 ///
 /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`] is preferred.
 ///
@@ -445,7 +477,8 @@ pub enum SweepMode {
 /// and large margins can cause [ghost collisions](self#caveats-of-speculative-collision).
 /// The [`max_distance`](Self::max_distance) property bounds the margin to mitigate this.
 ///
-/// Bodies with this component oftentimes also enable [`SweptCcd::include_dynamic`].
+/// Bodies with this component oftentimes also sweep against other dynamic bodies
+/// via [`SweptCcd::filter`].
 ///
 /// [`contact_tolerance`]: NarrowPhaseConfig::contact_tolerance
 ///
@@ -464,7 +497,7 @@ pub enum SweepMode {
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
 #[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
 ///         SpeculativeCcd::new(2.0),
-///         SweptCcd::default().with_include_dynamic(true),
+///         SweptCcd::default().with_filter(CcdFilter::ALL),
 ///     ));
 /// }
 /// ```
@@ -591,7 +624,7 @@ fn solve_continuous(
 
         let ccd = fast.ccd.copied().unwrap_or_default();
 
-        if !ccd.enabled {
+        if ccd.filter.is_empty() {
             return;
         }
 
@@ -647,12 +680,20 @@ fn solve_continuous(
         let mode1 = ccd.mode;
         let body_com_world = fast.position.0 + fast.rotation * fast.com.0;
 
-        // Determine which trees to sweep against.
+        // Determine which trees to sweep against based on the body's filter.
         let trees_to_query: [Option<&ColliderTree>; 4] = [
-            Some(&trees.static_tree),
-            Some(&trees.standalone_tree),
-            Some(&trees.kinematic_tree),
-            ccd.include_dynamic.then_some(&trees.dynamic_tree),
+            ccd.filter
+                .contains(CcdFilter::DYNAMIC)
+                .then_some(&trees.dynamic_tree),
+            ccd.filter
+                .contains(CcdFilter::KINEMATIC)
+                .then_some(&trees.kinematic_tree),
+            ccd.filter
+                .contains(CcdFilter::STATIC)
+                .then_some(&trees.static_tree),
+            ccd.filter
+                .contains(CcdFilter::STANDALONE)
+                .then_some(&trees.standalone_tree),
         ];
 
         // The smallest time of impact found across all of the body's colliders.

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -246,7 +246,9 @@ use core::cell::RefCell;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use dynamics::solver::SolverDiagnostics;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-use parry::query::{NonlinearRigidMotion, ShapeCastOptions, cast_shapes, cast_shapes_nonlinear};
+use parry::query::{
+    NonlinearRigidMotion, ShapeCastHit, ShapeCastOptions, cast_shapes, cast_shapes_nonlinear,
+};
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use thread_local::ThreadLocal;
 
@@ -420,6 +422,43 @@ pub enum SweepMode {
     NonLinear,
 }
 
+/// A marker component that expands a body's [`ColliderAabb`] based on
+/// its velocity each timestep.
+///
+/// By default, AABBs are kept tight, only expanded by a small fixed margin.
+/// The downside is that a fast body's AABB does not reach ahead along its path,
+/// so two fast-moving bodies approacing each other from different directions
+/// might not collide even with [CCD](self), because their swept shapes would not
+/// find each other. Adding this component works around the issue, at the cost of
+/// more broad phase collision tests due to the larger AABB.
+///
+/// It is only recommended to add this component to fast-moving bodies
+/// that should reliably collide with other fast-moving bodies.
+/// Oftentimes these entities also have [`CcdSettings::include_dynamic`] enabled.
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// fn setup(mut commands: Commands) {
+///     // A fast body whose AABB is expanded by its velocity
+///     // and is also swept against other dynamic bodies for CCD.
+///     commands.spawn((
+///         RigidBody::Dynamic,
+#[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
+#[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
+///         SpeculativeAabb,
+///         CcdSettings::default().with_include_dynamic(true),
+///     ));
+/// }
+/// ```
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default, PartialEq)]
+pub struct SpeculativeAabb;
+
 /// Read-only [`SolverBody`] motion data used to reconstruct a body's per-frame sweep.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 #[derive(QueryData)]
@@ -440,6 +479,27 @@ struct CcdResult {
     entity: Entity,
     /// The time of impact fraction in `[0, 1]`,
     fraction: Scalar,
+    /// Details of the earliest impact, if one was found.
+    impact: Option<CcdImpact>,
+}
+
+/// Details of the earliest time-of-impact for a fast body, used to clamp the body's normal
+/// motion this frame and to hand the contact off to the discrete solver next frame.
+struct CcdImpact {
+    /// World-space contact normal, pointing from the fast body toward the obstacle.
+    normal: Vector,
+    /// The fast body's colliding collider.
+    collider1: Entity,
+    /// The obstacle's colliding collider.
+    collider2: Entity,
+    /// The obstacle's body, if any (static colliders have none).
+    body2: Option<Entity>,
+    /// Additional speculative distance to request for the discrete solver next timestep,
+    /// so that the contact is detected even if the bodies were separated at the TOI impact.
+    ///
+    /// This is typically only relevant for dynamic-dynamic and dynamic-kinematic impacts
+    /// where the final pose of the other shape ended up separated from the TOI impact point.
+    distance: Scalar,
 }
 
 /// Performs [Continuous Collision Detection](self).
@@ -454,7 +514,7 @@ fn solve_continuous(
     colliders: Query<(&Collider, &Position, &Rotation)>,
     mut bodies: ParamSet<(Query<CcdBodyQuery>, Query<&mut SolverBody>)>,
     trees: Res<ColliderTrees>,
-    contact_graph: Res<ContactGraph>,
+    mut contact_graph: ResMut<ContactGraph>,
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
@@ -530,14 +590,15 @@ fn solve_continuous(
             return;
         }
 
-        // Records a fast body's time-of-impact fraction on the current thread.
-        let record = |fraction| {
+        // Records a fast body's time-of-impact fraction and earliest impact on the current thread.
+        let record = |fraction, impact| {
             thread_local_results
                 .get_or(|| RefCell::new(Vec::new()))
                 .borrow_mut()
                 .push(CcdResult {
                     entity: fast.entity,
                     fraction,
+                    impact,
                 });
         };
 
@@ -555,6 +616,9 @@ fn solve_continuous(
         // The smallest time of impact found across all of the body's colliders.
         // Starts at the full timestep duration.
         let mut min_toi = delta_secs;
+
+        // Details of the earliest impact found across all of the body's colliders.
+        let mut best_impact: Option<CcdImpact> = None;
 
         // Sweep each collider attached to the body.
         for collider_entity in fast.colliders {
@@ -646,12 +710,30 @@ fn solve_continuous(
                     SweepMode::NonLinear
                 };
 
-                    // Compute the time of impact for this pair of colliders,
-                    // and update the minimum if it's the earliest one so far.
-                if let Some(toi) = compute_ccd_toi(
+                    // Compute the time of impact for this pair of colliders. If it's the earliest
+                    // so far, record the details needed to clamp the body's normal motion and hand
+                    // the contact off to the discrete solver next frame.
+                    if let Some(hit) = compute_ccd_toi(
                         sweep_mode, &motion1, collider1, &motion2, collider2, min_toi,
                 ) {
-                    min_toi = toi;
+                        min_toi = hit.time_of_impact;
+
+                        // World-space contact normal, outward from the fast body's collider toward
+                        // the obstacle at the time of impact.
+                        let normal: Vector =
+                            motion1.position_at_time(hit.time_of_impact).rotation * hit.normal1;
+
+                        best_impact = Some(CcdImpact {
+                            normal,
+                            collider1: collider_entity,
+                            collider2: collider_entity2,
+                            body2: proxy.body,
+                            // The additional speculative distance only needs to span the gap
+                            // the fast contact opens. The body's max travel is a safe upper bound
+                            // that the fast-body test already computed. The narrow phase has a more
+                            // elaborate velocity test that decides whether to actually keep the contact.
+                            distance: max_motion,
+                        });
                     }
 
                     true
@@ -660,23 +742,28 @@ fn solve_continuous(
         }
 
         // Record the minimum time of impact as a fraction of the timestep.
-        record(min_toi * inv_dt);
+        record(min_toi * inv_dt, best_impact);
     });
 
-    // Collect the per-thread results.
-    let results: Vec<CcdResult> = thread_local_results
+    // Collect the per-thread results and sort them for determinism.
+    let mut results: Vec<CcdResult> = thread_local_results
         .into_iter()
         .flat_map(|cell| cell.into_inner())
         .collect();
+    results.sort_unstable_by_key(|result| result.entity);
 
-    // Finally, apply the time-of-impact corrections by scaling the pose deltas of each solver body.
+    // Apply the time-of-impact corrections to each solver body,
+    // and then hand each fast contact off to the discrete solver
+    // so it resolves the velocity next timestep.
     if !results.is_empty() {
         let mut apply = bodies.p1();
-        for CcdResult { entity, fraction } in results {
-            let Ok(mut solver_body) = apply.get_mut(entity) else {
-                continue;
-            };
-
+        for CcdResult {
+            entity,
+            fraction,
+            impact,
+        } in results
+        {
+            if let Ok(mut solver_body) = apply.get_mut(entity) {
             // Note: This flag is only retained for debug rendering.
             solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 
@@ -687,9 +774,59 @@ fn solve_continuous(
                     .insert(SolverBodyFlags::HAD_TIME_OF_IMPACT);
 
                 let t = fraction.min(1.0);
+
+                    if let Some(impact) = &impact {
+                        // Clamp the translation into the obstacle while leaving tangential sliding
+                        // intact, so a body that is mostly sliding along the surface is not frozen.
+                        let approach_translation = solver_body.delta_position.dot(impact.normal);
+                        if approach_translation > 0.0 {
+                            solver_body.delta_position -=
+                                (1.0 - t) * approach_translation * impact.normal;
+                        }
+
+                        // Advance the rotation only up to the time of impact.
+                        solver_body.delta_rotation =
+                            Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
+                    } else {
+                        // No contact normal available for some reason.
+                        // Fall back to scaling the whole delta.
                 solver_body.delta_position *= t;
                 solver_body.delta_rotation =
                     Rotation::IDENTITY.nlerp(solver_body.delta_rotation, t);
+                    }
+                }
+            }
+
+            // Ensure a contact pair exists and request an additional speculative distance.
+            // This helps ensure the contact is detected by the discrete solver next timestep,
+            // even if the bodies ended up separated at the TOI impact.
+            //
+            // This is typically only relevant for dynamic-dynamic and dynamic-kinematic impacts
+            // where the final pose of the other shape ended up separated from the TOI impact point.
+            // In the `tumbler` example, this manifested as dynamic boxes continuously having a TOI impact
+            // against the spinning container, being effectively frozen in place with no proper
+            // velocity correction, which also caused significant overlap with other boxes.
+            if fraction < 1.0
+                && let Some(impact) = impact
+            {
+                if let Some((_edge, pair)) =
+                    contact_graph.get_mut(impact.collider1, impact.collider2)
+                {
+                    pair.ccd_speculative_distance =
+                        pair.ccd_speculative_distance.max(impact.distance);
+                } else {
+                    let mut edge = ContactEdge::new(impact.collider1, impact.collider2);
+                    edge.body1 = Some(entity);
+                    edge.body2 = impact.body2;
+                    let body1 = Some(entity);
+                    let body2 = impact.body2;
+                    let distance = impact.distance;
+                    contact_graph.add_edge_with(edge, |pair| {
+                        pair.body1 = body1;
+                        pair.body2 = body2;
+                        pair.ccd_speculative_distance = distance;
+                    });
+                }
             }
         }
     }
@@ -700,7 +837,7 @@ fn solve_continuous(
 /// Reconstructs the sweep of a single collider for the timestep from its [`SolverBody`] deltas,
 /// as a Parry [`NonlinearRigidMotion`] with per-second velocities.
 ///
-/// `collider_pos`/`collider_rot` are the collider's world pose at the start of the frame, and
+/// `collider_pos`/`collider_rot` are the collider's world pose at the start of the timestep, and
 /// `com_world` is its body's center of mass in world space. The body rotates about its center of
 /// mass, so this supports colliders offset from the body origin (i.e. child colliders).
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
@@ -732,7 +869,7 @@ fn static_motion(pos: Position, rot: Rotation) -> NonlinearRigidMotion {
     NonlinearRigidMotion::constant_position(make_pose(pos, rot))
 }
 
-/// Computes the time of impact at which `motion1` (sweeping `collider1`) first touches
+/// Computes the [`ShapeCastHit`] at which `motion1` (sweeping `collider1`) first touches
 /// `motion2` (sweeping `collider2`), if any, using the specified `mode`.
 ///
 /// Returns `None` if no impact is found within `min_toi`.
@@ -744,11 +881,11 @@ fn compute_ccd_toi(
     motion2: &NonlinearRigidMotion,
     collider2: &Collider,
     min_toi: Scalar,
-) -> Option<Scalar> {
+) -> Option<ShapeCastHit> {
     let shape1 = collider1.shape_scaled();
     let shape2 = collider2.shape_scaled();
 
-    let toi = if mode == SweepMode::Linear {
+    let hit = if mode == SweepMode::Linear {
         cast_shapes(
             &motion1.start,
             motion1.linvel,
@@ -763,7 +900,6 @@ fn compute_ccd_toi(
             },
         )
         .ok()??
-        .time_of_impact
     } else {
         cast_shapes_nonlinear(
         motion1,
@@ -775,8 +911,7 @@ fn compute_ccd_toi(
                 false,
             )
         .ok()??
-        .time_of_impact
     };
 
-    (toi > 0.0 && toi < min_toi).then_some(toi)
+    (hit.time_of_impact > 0.0 && hit.time_of_impact < min_toi).then_some(hit)
 }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -567,8 +567,6 @@ struct CcdImpact {
     collider1: Entity,
     /// The obstacle's colliding collider.
     collider2: Entity,
-    /// The obstacle's body, if any (static colliders have none).
-    body2: Option<Entity>,
     /// Additional speculative distance to request for the discrete solver next timestep,
     /// so that the contact is detected even if the bodies were separated at the TOI impact.
     ///
@@ -813,7 +811,6 @@ fn solve_continuous(
                         best_impact = Some(CcdImpact {
                             collider1: collider_entity,
                             collider2: collider_entity2,
-                            body2: proxy.body,
                             // The additional speculative distance only needs to span the gap
                             // the fast contact opens. The body's max travel is a safe upper bound
                             // that the fast-body test already computed. The narrow phase has a more
@@ -870,7 +867,7 @@ fn solve_continuous(
                 }
             }
 
-            // Ensure a contact pair exists and request an additional speculative distance.
+            // Request an additional speculative distance for any existing separated contact pair.
             // This helps ensure the contact is detected by the discrete solver next timestep,
             // even if the bodies ended up separated at the TOI impact.
             //
@@ -881,24 +878,10 @@ fn solve_continuous(
             // velocity correction, which also caused significant overlap with other boxes.
             if fraction < 1.0
                 && let Some(impact) = impact
-            {
-                if let Some((_edge, pair)) =
+                && let Some((_edge, pair)) =
                     contact_graph.get_mut(impact.collider1, impact.collider2)
-                {
-                    pair.speculative_distance = pair.speculative_distance.max(impact.distance);
-                } else {
-                    let mut edge = ContactEdge::new(impact.collider1, impact.collider2);
-                    edge.body1 = Some(entity);
-                    edge.body2 = impact.body2;
-                    let body1 = Some(entity);
-                    let body2 = impact.body2;
-                    let distance = impact.distance;
-                    contact_graph.add_edge_with(edge, |pair| {
-                        pair.body1 = body1;
-                        pair.body2 = body2;
-                        pair.speculative_distance = distance;
-                    });
-                }
+            {
+                pair.speculative_distance = pair.speculative_distance.max(impact.distance);
             }
         }
     }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -301,7 +301,7 @@ impl Plugin for CcdPlugin {
 ///             filter: CcdFilter::ALL,
 ///             mode: SweepMode::Linear,
 ///             ..default()
-///         }
+///         },
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -246,10 +246,12 @@ impl Plugin for CcdPlugin {
     )]
     fn build(&self, app: &mut App) {
         // Get the `PhysicsSchedule`, and panic if it doesn't exist.
+        #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
         let physics = app
             .get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first");
 
+        #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
         physics.add_systems(solve_continuous.in_set(SolverSystems::ContinuousCollision));
     }
 }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -240,14 +240,16 @@ use thread_local::ThreadLocal;
 pub struct CcdPlugin;
 
 impl Plugin for CcdPlugin {
+    #[cfg_attr(
+        not(any(feature = "parry-f32", feature = "parry-f64")),
+        expect(unused_variables)
+    )]
     fn build(&self, app: &mut App) {
         // Get the `PhysicsSchedule`, and panic if it doesn't exist.
-        #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
         let physics = app
             .get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first");
 
-        #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
         physics.add_systems(solve_continuous.in_set(SolverSystems::ContinuousCollision));
     }
 }

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use super::solver::xpbd::XpbdSolverPlugin;
     #[expect(deprecated)]
     pub use super::{
-        ccd::{CcdPlugin, CcdSettings, SpeculativeAabb, SweepMode},
+        ccd::{CcdPlugin, CcdSettings, SpeculativeCcd, SweepMode},
         integrator::{
             CustomPositionIntegration, CustomVelocityIntegration, Gravity, IntegratorPlugin,
         },

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use super::solver::xpbd::XpbdSolverPlugin;
     #[expect(deprecated)]
     pub use super::{
-        ccd::{CcdPlugin, CcdSettings, SweepMode},
+        ccd::{CcdPlugin, CcdSettings, SpeculativeAabb, SweepMode},
         integrator::{
             CustomPositionIntegration, CustomVelocityIntegration, Gravity, IntegratorPlugin,
         },

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use super::solver::xpbd::XpbdSolverPlugin;
     #[expect(deprecated)]
     pub use super::{
-        ccd::{CcdPlugin, CcdSettings, SpeculativeCcd, SweepMode},
+        ccd::{CcdPlugin, SpeculativeCcd, SweepMode, SweptCcd},
         integrator::{
             CustomPositionIntegration, CustomVelocityIntegration, Gravity, IntegratorPlugin,
         },

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use super::solver::xpbd::XpbdSolverPlugin;
     #[expect(deprecated)]
     pub use super::{
-        ccd::{CcdPlugin, SpeculativeCcd, SweepMode, SweptCcd},
+        ccd::{CcdFilter, CcdPlugin, SpeculativeCcd, SweepMode, SweptCcd},
         integrator::{
             CustomPositionIntegration, CustomVelocityIntegration, Gravity, IntegratorPlugin,
         },

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use super::solver::xpbd::XpbdSolverPlugin;
     #[expect(deprecated)]
     pub use super::{
-        ccd::{CcdPlugin, SpeculativeMargin, SweepMode, SweptCcd},
+        ccd::{CcdPlugin, CcdSettings, SweepMode},
         integrator::{
             CustomPositionIntegration, CustomVelocityIntegration, Gravity, IntegratorPlugin,
         },

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -84,7 +84,7 @@ pub mod prelude {
             JointFrame, JointPlugin, LinearMotor, MotorModel, PrismaticJoint, RevoluteJoint,
         },
         rigid_body::{
-            body_radii::{BodyRadii, BodyRadiiPlugin},
+            body_size_metrics::{BodySizeMetrics, BodySizeMetricsPlugin},
             forces::{
                 ConstantAngularAcceleration, ConstantForce, ConstantLinearAcceleration,
                 ConstantLocalForce, ConstantLocalLinearAcceleration, ConstantTorque, ForcePlugin,

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -84,6 +84,7 @@ pub mod prelude {
             JointFrame, JointPlugin, LinearMotor, MotorModel, PrismaticJoint, RevoluteJoint,
         },
         rigid_body::{
+            body_radii::{BodyRadii, BodyRadiiPlugin},
             forces::{
                 ConstantAngularAcceleration, ConstantForce, ConstantLinearAcceleration,
                 ConstantLocalForce, ConstantLocalLinearAcceleration, ConstantTorque, ForcePlugin,

--- a/src/dynamics/rigid_body/body_radii.rs
+++ b/src/dynamics/rigid_body/body_radii.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     dynamics::rigid_body::mass_properties::components::ComputedCenterOfMass,
     math::Scalar,
-    schedule::PhysicsSchedule,
+    schedule::{PhysicsSchedule, PhysicsStepSystems},
 };
 
 /// Radii associated with a [`RigidBody`] and its colliders.
@@ -63,7 +63,14 @@ pub struct BodyRadiiPlugin<C: AnyCollider> {
 
 impl<C: AnyCollider> Plugin for BodyRadiiPlugin<C> {
     fn build(&self, app: &mut App) {
-        app.add_systems(PhysicsSchedule, update_body_radii::<C>);
+        // Update body radii before they are consumed by the solver and continuous collision
+        // detection. Allowing ambiguities lets multiple collision backends coexist.
+        app.add_systems(
+            PhysicsSchedule,
+            update_body_radii::<C>
+                .before(PhysicsStepSystems::Solver)
+                .ambiguous_with_all(),
+        );
     }
 }
 

--- a/src/dynamics/rigid_body/body_radii.rs
+++ b/src/dynamics/rigid_body/body_radii.rs
@@ -1,0 +1,112 @@
+//! Radii associated with a [`RigidBody`] and its colliders.
+//!
+//! See [`BodyRadii`] for more information.
+
+use core::marker::PhantomData;
+
+use bevy::{ecs::system::StaticSystemParam, prelude::*};
+
+use crate::{
+    collision::collider::{
+        AnyCollider, ColliderContext, collider_hierarchy::RigidBodyColliders,
+        collider_transform::ColliderTransform,
+    },
+    dynamics::rigid_body::mass_properties::components::ComputedCenterOfMass,
+    math::Scalar,
+    schedule::PhysicsSchedule,
+};
+
+/// Radii associated with a [`RigidBody`] and its colliders.
+///
+/// These can be used for various purposes, such as determining thresholds
+/// for Continuous Collision Detection (CCD), sleeping, and contact recycling.
+///
+/// The values are automatically computed and updated by the [`BodyRadiiPlugin`].
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+pub struct BodyRadii {
+    /// The minimum "core" thickness of the colliders attached to the body.
+    ///
+    /// Typically corresponds to the minimum distance from the centroid
+    /// of any given shape to its surface.
+    ///
+    /// This can be useful for Continuous Collision Detection (CCD)
+    /// to determine how far the body can move before it might start to tunnel
+    /// through other geometry, for example.
+    pub min_thickness: Scalar,
+
+    /// The maximum distance from the center of mass of the body to the surface
+    /// of any of its colliders.
+    ///
+    /// Typically corresponds to the radius of the sphere formed by sweeping
+    /// the body about its center of mass.
+    ///
+    /// This can be useful for determining the maximum velocity that a point
+    /// on the body can have, which can be used for sleeping and contact recycling
+    /// thresholds, for example.
+    pub sweep_radius: Scalar,
+}
+
+impl Default for BodyRadii {
+    fn default() -> Self {
+        Self {
+            min_thickness: Scalar::INFINITY,
+            sweep_radius: 0.0,
+        }
+    }
+}
+
+/// A plugin for computing and updating [`BodyRadii`] for rigid bodies.
+#[derive(Default)]
+pub struct BodyRadiiPlugin<C: AnyCollider> {
+    _phantom: PhantomData<C>,
+}
+
+impl<C: AnyCollider> Plugin for BodyRadiiPlugin<C> {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PhysicsSchedule, update_body_radii::<C>);
+    }
+}
+
+fn update_body_radii<C: AnyCollider>(
+    mut bodies: Query<(
+        &mut BodyRadii,
+        &RigidBodyColliders,
+        Ref<ComputedCenterOfMass>,
+    )>,
+    colliders: Query<(Entity, &C, &ColliderTransform)>,
+    changed_colliders: Query<(), Or<(Changed<C>, Changed<ColliderTransform>)>>,
+    context: StaticSystemParam<C::Context>,
+) {
+    let context = context.into_inner();
+
+    for (mut body_radii, rb_colliders, com) in bodies.iter_mut() {
+        if !com.is_changed()
+            && !rb_colliders
+                .iter()
+                .any(|collider_entity| changed_colliders.contains(collider_entity))
+        {
+            // Neither the center of mass nor any of the colliders have changed.
+            continue;
+        }
+
+        let mut min_thickness: Scalar = Scalar::INFINITY;
+        let mut sweep_radius: Scalar = 0.0;
+
+        // Find the minimum thickness and maximum sweep radius.
+        for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
+            // Compute the minimum thickness
+            let ctx = ColliderContext::new(entity, &context);
+            let thickness = collider.min_thickness_with_context(ctx);
+            min_thickness = min_thickness.min(thickness);
+
+            // Compute the sweep radius
+            let ctx = ColliderContext::new(entity, &context);
+            let point = com.0 - collider_transform.translation;
+            let distance_to_com = collider.max_distance_to_point_with_context(point, ctx);
+            sweep_radius = sweep_radius.max(distance_to_com);
+        }
+
+        body_radii.min_thickness = min_thickness;
+        body_radii.sweep_radius = sweep_radius;
+    }
+}

--- a/src/dynamics/rigid_body/body_size_metrics.rs
+++ b/src/dynamics/rigid_body/body_size_metrics.rs
@@ -21,9 +21,13 @@ use crate::{
 /// Size metrics associated with a [`RigidBody`] and its colliders.
 ///
 /// These can be used for various purposes, such as determining thresholds
-/// for Continuous Collision Detection (CCD), sleeping, and contact recycling.
+/// for [Continuous Collision Detection (CCD)][CCD], [sleeping], and contact recycling.
 ///
 /// The values are automatically computed and updated by the [`BodySizeMetricsPlugin`].
+///
+/// [`RigidBody`]: crate::dynamics::rigid_body::RigidBody
+/// [CCD]: crate::dynamics::ccd
+/// [sleeping]: crate::dynamics::sleeping
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 pub struct BodySizeMetrics {
     /// A conservative minimum thickness used by [Continuous Collision Detection (CCD)][CCD]

--- a/src/dynamics/rigid_body/body_size_metrics.rs
+++ b/src/dynamics/rigid_body/body_size_metrics.rs
@@ -1,6 +1,8 @@
-//! Radii associated with a [`RigidBody`] and its colliders.
+//! Size metrics associated with a [`RigidBody`] and its colliders.
 //!
-//! See [`BodyRadii`] for more information.
+//! See [`BodySizeMetrics`] for more information.
+//!
+//! [`RigidBody`]: crate::dynamics::rigid_body::RigidBody
 
 use core::marker::PhantomData;
 
@@ -16,23 +18,25 @@ use crate::{
     schedule::{PhysicsSchedule, PhysicsStepSystems},
 };
 
-/// Radii associated with a [`RigidBody`] and its colliders.
+/// Size metrics associated with a [`RigidBody`] and its colliders.
 ///
 /// These can be used for various purposes, such as determining thresholds
 /// for Continuous Collision Detection (CCD), sleeping, and contact recycling.
 ///
-/// The values are automatically computed and updated by the [`BodyRadiiPlugin`].
+/// The values are automatically computed and updated by the [`BodySizeMetricsPlugin`].
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
-pub struct BodyRadii {
-    /// The minimum "core" thickness of the colliders attached to the body.
+pub struct BodySizeMetrics {
+    /// A conservative minimum thickness used by [Continuous Collision Detection (CCD)][CCD]
+    /// to determine how far the body can move in a single timestep before it might start to
+    /// tunnel through geometry.
     ///
-    /// Typically corresponds to the minimum distance from the centroid
+    /// This is the minimum [`ccd_thickness`] of the colliders attached to the body,
+    /// and typically corresponds to the minimum distance from the centroid
     /// of any given shape to its surface.
     ///
-    /// This can be useful for Continuous Collision Detection (CCD)
-    /// to determine how far the body can move before it might start to tunnel
-    /// through other geometry, for example.
-    pub min_thickness: Scalar,
+    /// [CCD]: crate::dynamics::ccd
+    /// [`ccd_thickness`]: crate::collision::collider::AnyCollider::ccd_thickness_with_context
+    pub ccd_thickness: Scalar,
 
     /// The maximum distance from the center of mass of the body to the surface
     /// of any of its colliders.
@@ -46,37 +50,37 @@ pub struct BodyRadii {
     pub sweep_radius: Scalar,
 }
 
-impl Default for BodyRadii {
+impl Default for BodySizeMetrics {
     fn default() -> Self {
         Self {
-            min_thickness: Scalar::INFINITY,
+            ccd_thickness: Scalar::INFINITY,
             sweep_radius: 0.0,
         }
     }
 }
 
-/// A plugin for computing and updating [`BodyRadii`] for rigid bodies.
+/// A plugin for computing and updating [`BodySizeMetrics`] for rigid bodies.
 #[derive(Default)]
-pub struct BodyRadiiPlugin<C: AnyCollider> {
+pub struct BodySizeMetricsPlugin<C: AnyCollider> {
     _phantom: PhantomData<C>,
 }
 
-impl<C: AnyCollider> Plugin for BodyRadiiPlugin<C> {
+impl<C: AnyCollider> Plugin for BodySizeMetricsPlugin<C> {
     fn build(&self, app: &mut App) {
-        // Update body radii before they are consumed by the solver and continuous collision
+        // Update body size metrics before they are consumed by the solver and continuous collision
         // detection. Allowing ambiguities lets multiple collision backends coexist.
         app.add_systems(
             PhysicsSchedule,
-            update_body_radii::<C>
+            update_body_size_metrics::<C>
                 .before(PhysicsStepSystems::Solver)
                 .ambiguous_with_all(),
         );
     }
 }
 
-fn update_body_radii<C: AnyCollider>(
+fn update_body_size_metrics<C: AnyCollider>(
     mut bodies: Query<(
-        &mut BodyRadii,
+        &mut BodySizeMetrics,
         &RigidBodyColliders,
         Ref<ComputedCenterOfMass>,
     )>,
@@ -86,7 +90,7 @@ fn update_body_radii<C: AnyCollider>(
 ) {
     let context = context.into_inner();
 
-    for (mut body_radii, rb_colliders, com) in bodies.iter_mut() {
+    for (mut size_metrics, rb_colliders, com) in bodies.iter_mut() {
         if !com.is_changed()
             && !rb_colliders
                 .iter()
@@ -96,15 +100,15 @@ fn update_body_radii<C: AnyCollider>(
             continue;
         }
 
-        let mut min_thickness: Scalar = Scalar::INFINITY;
+        let mut ccd_thickness: Scalar = Scalar::INFINITY;
         let mut sweep_radius: Scalar = 0.0;
 
-        // Find the minimum thickness and maximum sweep radius.
+        // Find the minimum CCD thickness and maximum sweep radius.
         for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
-            // Compute the minimum thickness
+            // Compute the CCD thickness
             let ctx = ColliderContext::new(entity, &context);
-            let thickness = collider.min_thickness_with_context(ctx);
-            min_thickness = min_thickness.min(thickness);
+            let thickness = collider.ccd_thickness_with_context(ctx);
+            ccd_thickness = ccd_thickness.min(thickness);
 
             // Compute the sweep radius
             let ctx = ColliderContext::new(entity, &context);
@@ -113,7 +117,7 @@ fn update_body_radii<C: AnyCollider>(
             sweep_radius = sweep_radius.max(distance_to_com);
         }
 
-        body_radii.min_thickness = min_thickness;
-        body_radii.sweep_radius = sweep_radius;
+        size_metrics.ccd_thickness = ccd_thickness;
+        size_metrics.sweep_radius = sweep_radius;
     }
 }

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -275,6 +275,9 @@ use derive_more::From;
     ComputedMass,
     ComputedAngularInertia,
     ComputedCenterOfMass,
+    // Used by continuous collision detection and other systems for computing
+    // some thresholds based on the size metrics of the body.
+    BodyRadii,
     // Required for local forces and acceleration.
     AccumulatedLocalAcceleration,
     // TODO: We can remove these pre-solve deltas once joints don't use XPBD.

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -1,6 +1,6 @@
 //! Common components and bundles for rigid bodies.
 
-pub mod body_radii;
+pub mod body_size_metrics;
 pub mod forces;
 pub mod mass_properties;
 pub mod sleeping;
@@ -277,7 +277,7 @@ use derive_more::From;
     ComputedCenterOfMass,
     // Used by continuous collision detection and other systems for computing
     // some thresholds based on the size metrics of the body.
-    BodyRadii,
+    BodySizeMetrics,
     // Required for local forces and acceleration.
     AccumulatedLocalAcceleration,
     // TODO: We can remove these pre-solve deltas once joints don't use XPBD.

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -1,5 +1,6 @@
 //! Common components and bundles for rigid bodies.
 
+pub mod body_radii;
 pub mod forces;
 pub mod mass_properties;
 pub mod sleeping;

--- a/src/dynamics/rigid_body/physics_material.rs
+++ b/src/dynamics/rigid_body/physics_material.rs
@@ -281,8 +281,7 @@ impl From<Scalar> for Friction {
 ///   This can be caused by [friction](Friction), [damping](LinearDamping), or simulation inaccuracies.
 ///
 /// - Collisions can have more or less bounce than expected, especially when objects are moving very fast.
-///   This is largely due to the the sequential solver and [speculative collision](dynamics::ccd#speculative-collision).
-///   For more accurate restitution, consider disabling speculative collision and using [`SweptCcd`] instead.
+///   This is largely due to the the sequential solver and [continuous collision](dynamics::ccd) scheme.
 ///
 /// - An object falling flat on the ground with multiple contact points may tip over on one side or corner a bit.
 ///   This is because contact points are solved sequentially, and the order of contact points affects the result.

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -36,7 +36,7 @@ use bevy::{app::PluginGroupBuilder, prelude::*};
 /// | [`SolverBodyPlugin`]              | Manages [solver bodies](dynamics::solver::solver_body::SolverBody).                                                                                        |
 /// | [`IntegratorPlugin`]              | Handles motion caused by velocity, and applies external forces and gravity.                                                                                |
 /// | [`SolverPlugin`]                  | Manages and solves contacts, [joints](dynamics::joints), and other constraints.                                                                            |
-/// | [`CcdPlugin`]                     | Performs sweep-based [Continuous Collision Detection](dynamics::ccd) for bodies with the [`SweptCcd`] component.                                           |
+/// | [`CcdPlugin`]                     | Performs [Continuous Collision Detection (CCD)](dynamics::ccd) for fast dynamic bodies.                                                                    |
 /// | [`IslandPlugin`]                  | Manages [simulation islands](dynamics::solver::islands) for sleeping and waking.                                                                           |
 /// | [`IslandSleepingPlugin`]          | Manages sleeping and waking of [simulation islands](dynamics::solver::islands).                                                                            |
 /// | [`JointGraphPlugin`]              | Manages the [`JointGraph`](joint_graph::JointGraph) for each joint type.                                                                                   |

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -166,8 +166,8 @@ impl Plugin for SolverPlugin {
 ///
 /// Note that this is *not* used to scale forces or any other user-facing inputs or outputs.
 /// Instead, the value is only used to scale some internal length-based tolerances, such as
-/// [`SleepingThreshold::linear`] and [`NarrowPhaseConfig::default_speculative_margin`],
-/// as well as the scale used for [debug rendering](PhysicsDebugPlugin).
+/// [`SleepingThreshold::linear`] and [`NarrowPhaseConfig::contact_tolerance`], as well as
+/// the scale used for [debug rendering](PhysicsDebugPlugin).
 ///
 /// Choosing the appropriate length unit can help improve stability and robustness.
 ///

--- a/src/dynamics/solver/schedule.rs
+++ b/src/dynamics/solver/schedule.rs
@@ -38,6 +38,7 @@ impl Plugin for SolverSchedulePlugin {
                 SolverSystems::Substep,
                 SolverSystems::PostSubstep,
                 SolverSystems::Restitution,
+                SolverSystems::ContinuousCollision,
                 SolverSystems::Finalize,
                 SolverSystems::StoreContactImpulses,
             )
@@ -87,8 +88,9 @@ pub struct SubstepSchedule;
 /// 3. Prepare contact constraints ([`SolverSystems::PrepareContactConstraints`])
 /// 4. Substepping loop (runs the [`SubstepSchedule`] [`SubstepCount`] times; see [`SolverSystems::Substep`])
 /// 5. Apply restitution ([`SolverSystems::Restitution`])
-/// 6. Write back solver body data to rigid bodies. ([`SolverSystems::Finalize`])
-/// 7. Store contact impulses for next frame's warm starting ([`SolverSystems::StoreContactImpulses`])
+/// 6. Perform Continuous Collision Detection (CCD) for fast dynamic bodies ([`SolverSystems::ContinuousCollision`])
+/// 7. Write back solver body data to rigid bodies. ([`SolverSystems::Finalize`])
+/// 8. Store contact impulses for next frame's warm starting ([`SolverSystems::StoreContactImpulses`])
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SolverSystems {
     /// Prepares [solver bodies] for the substepping loop.
@@ -107,6 +109,8 @@ pub enum SolverSystems {
     PostSubstep,
     /// Applies [restitution](Restitution) for bodies after solving overlap.
     Restitution,
+    /// Performs [Continuous Collision Detection (CCD)](dynamics::ccd) for fast dynamic bodies.
+    ContinuousCollision,
     /// Writes back solver body data to rigid bodies.
     Finalize,
     /// Copies contact impulses from [`ContactConstraints`] to the contacts in the [`ContactGraph`].

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -153,6 +153,12 @@ bitflags::bitflags! {
         const IS_KINEMATIC = 1 << 6;
         /// Set if gyroscopic motion is enabled.
         const GYROSCOPIC_MOTION = 1 << 7;
+        /// Set during the continuous collision stage if the body moved fast enough
+        /// to be treated as a "fast body" and have its motion swept. Transient.
+        const IS_FAST = 1 << 8;
+        /// Set during the continuous collision stage if the body's motion was stopped
+        /// at a time of impact. Transient.
+        const HAD_TIME_OF_IMPACT = 1 << 9;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,8 +718,8 @@ impl PhysicsPlugins {
     ///
     /// Note that this is *not* used to scale forces or any other user-facing inputs or outputs.
     /// Instead, the value is only used to scale some internal length-based tolerances, such as
-    /// [`SleepingThreshold::linear`] and [`NarrowPhaseConfig::default_speculative_margin`],
-    /// as well as the scale used for [debug rendering](PhysicsDebugPlugin).
+    /// [`SleepingThreshold::linear`] and [`NarrowPhaseConfig::contact_tolerance`], as well as
+    /// the scale used for [debug rendering](PhysicsDebugPlugin).
     ///
     /// Choosing the appropriate length unit can help improve stability and robustness.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,6 +609,7 @@ use prelude::*;
 /// | [`JointPlugin`]                   | A plugin for managing and initializing [joints](dynamics::joints). Does *not* include the actual joint solver.                                             |
 /// | [`MassPropertyPlugin`]            | Manages mass properties of dynamic [rigid bodies](RigidBody).                                                                                              |
 /// | [`ForcePlugin`]                   | Manages and applies external forces, torques, and acceleration for rigid bodies. See the [module-level documentation](dynamics::rigid_body::forces).       |
+/// | [`BodyRadiiPlugin`]               | Manages [`BodyRadii`] for rigid bodies, which are used for various optimizations.                                                                          |
 /// | [`SpatialQueryPlugin`]            | Handles spatial queries like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting).                                        |
 /// | [`PhysicsInterpolationPlugin`]    | [`Transform`] interpolation and extrapolation for rigid bodies.                                                                                            |
 /// | [`PhysicsTransformPlugin`]        | Manages physics transforms and synchronizes them with [`Transform`].                                                                                       |
@@ -773,7 +774,8 @@ impl PluginGroup for PhysicsPlugins {
         let builder = builder
             .add(ColliderBackendPlugin::<Collider>::new(self.schedule))
             .add(ColliderTreePlugin::<Collider>::default())
-            .add(NarrowPhasePlugin::<Collider>::default());
+            .add(NarrowPhasePlugin::<Collider>::default())
+            .add(BodyRadiiPlugin::<Collider>::default());
 
         // Add solver plugins.
         let builder = builder.add_group(SolverPlugins::new_with_length_unit(self.length_unit));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,8 @@
 //! - [Lock translational and rotational axes](LockedAxes)
 //! - [Dominance]
 //! - [Continuous Collision Detection (CCD)](dynamics::ccd)
-//!     - [Speculative collision](dynamics::ccd#speculative-collision)
 //!     - [Swept CCD](dynamics::ccd#swept-ccd)
+//!     - [Speculative collision](dynamics::ccd#speculative-collision)
 //! - [`Transform` interpolation and extrapolation](PhysicsInterpolationPlugin)
 //! - [Temporarily disabling a rigid body](RigidBodyDisabled)
 //! - [Automatic deactivation with sleeping](Sleeping)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,7 +548,7 @@ pub mod prelude {
         PhysicsPlugins,
         collider_tree::{ColliderTreeOptimization, ColliderTreePlugin, TreeOptimizationMode},
         collision::prelude::*,
-        dynamics::{self, ccd::SpeculativeMargin, prelude::*},
+        dynamics::{self, prelude::*},
         interpolation::*,
         physics_transform::{PhysicsTransformHelper, PhysicsTransformPlugin, Position, Rotation},
         schedule::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,7 @@ use prelude::*;
 /// | [`JointPlugin`]                   | A plugin for managing and initializing [joints](dynamics::joints). Does *not* include the actual joint solver.                                             |
 /// | [`MassPropertyPlugin`]            | Manages mass properties of dynamic [rigid bodies](RigidBody).                                                                                              |
 /// | [`ForcePlugin`]                   | Manages and applies external forces, torques, and acceleration for rigid bodies. See the [module-level documentation](dynamics::rigid_body::forces).       |
-/// | [`BodyRadiiPlugin`]               | Manages [`BodyRadii`] for rigid bodies, which are used for various optimizations.                                                                          |
+/// | [`BodySizeMetricsPlugin`]         | Manages [`BodySizeMetrics`] for rigid bodies, which are used for various optimizations.                                                                    |
 /// | [`SpatialQueryPlugin`]            | Handles spatial queries like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting).                                        |
 /// | [`PhysicsInterpolationPlugin`]    | [`Transform`] interpolation and extrapolation for rigid bodies.                                                                                            |
 /// | [`PhysicsTransformPlugin`]        | Manages physics transforms and synchronizes them with [`Transform`].                                                                                       |
@@ -775,7 +775,7 @@ impl PluginGroup for PhysicsPlugins {
             .add(ColliderBackendPlugin::<Collider>::new(self.schedule))
             .add(ColliderTreePlugin::<Collider>::default())
             .add(NarrowPhasePlugin::<Collider>::default())
-            .add(BodyRadiiPlugin::<Collider>::default());
+            .add(BodySizeMetricsPlugin::<Collider>::default());
 
         // Add solver plugins.
         let builder = builder.add_group(SolverPlugins::new_with_length_unit(self.length_unit));

--- a/src/physics_transform/transform.rs
+++ b/src/physics_transform/transform.rs
@@ -310,12 +310,6 @@ impl Rotation {
         (self.sin, self.cos)
     }
 
-    /// Rotates the given vector by `self`.
-    #[deprecated(note = "use the `Mul` impl instead, like `rot * vec`")]
-    pub fn rotate(&self, vec: Vector) -> Vector {
-        self * vec
-    }
-
     /// Computes the length or norm of the complex number used to represent the rotation.
     ///
     /// The length is typically expected to be `1.0`. Unexpectedly denormalized rotations
@@ -347,6 +341,20 @@ impl Rotation {
     #[inline]
     pub fn length_recip(self) -> Scalar {
         Vector::new(self.sin, self.cos).length_recip()
+    }
+
+    /// Computes the chord length of the rotation, which is the straight-line
+    /// distance between the start and end points of the rotation on a unit circle.
+    #[inline]
+    pub fn chord_length(self) -> Scalar {
+        // The chord length traveled by a point rotated by `θ` on a unit circle
+        // is `2 * sin(θ / 2)`.
+        //
+        // In 2D, `2 * sin(θ / 2) = sqrt(2 * (1 - cos(θ)))`, using the stored cosine.
+        //
+        // TODO: A "2D quaternion" that stores cos(theta / 2) and sin(theta / 2)
+        //       could avoid the sqrt and be more accurate in some places.
+        (2.0 * (1.0 - self.cos)).max(0.0).sqrt()
     }
 
     /// Returns `self` with a length of `1.0` if possible, and `None` otherwise.
@@ -758,6 +766,18 @@ impl Rotation {
 
     /// No rotation.
     pub const IDENTITY: Self = Self(Quaternion::IDENTITY);
+
+    /// Computes the chord length of the rotation, which is the straight-line
+    /// distance between the start and end points of the rotation on a unit circle.
+    #[inline]
+    pub fn chord_length(self) -> Scalar {
+        // The chord length traveled by a point rotated by `θ` on a unit circle
+        // is `2 * sin(θ / 2)`.
+        //
+        // In 3D, the vector part of the quaternion has length `sin(θ / 2)`,
+        // so doubling it gives the chord length `2 * sin(θ / 2)` directly.
+        2.0 * self.xyz().length()
+    }
 
     /// Returns the angle (in radians) for the minimal rotation for transforming this rotation into another.
     #[inline]

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,11 +60,11 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x34e9643f;
+    let expected = 0x89ba82f7;
 
     assert!(
         hash == expected,
-        "\nExpected transform hash 0x{:x}, found 0x{:x} instead.\nIf changes in behavior were expected, update the hash in src/tests/determinism_2d.rs on line 61.\n",
+        "\nExpected transform hash 0x{:x}, found 0x{:x} instead.\nIf changes in behavior were expected, update the hash in src/tests/determinism_2d.rs on line 63.\n",
         expected,
         hash,
     );


### PR DESCRIPTION
# Objective

Fixes #990.

Currently, Avian relies heavily on [Bepu-style](https://github.com/bepu/bepuphysics2/blob/master/Documentation/ContinuousCollisionDetection.md) **speculative collision** with an unbounded speculative margin. This has two major problems:

- This style of speculative collision is very prone to ghost collisions. Whenever an object moves past some surface at a moderate to high speed, you'll likely see it bump against the surface. Cases like #990 are especially bad and unexpected from a user POV.
- Expanding all AABBs based on velocity leads to a lot of unnecessary contact pairs in the broad phase and narrow phase. It also affect spatial queries since they reuse the same BVHs. This overhead can add up in scenes with a lot of dynamic bodies.

While we do support swept CCD as an alternative when ghost collisions are a problem, it would be better if we didn't have these problems to begin with *by default*.

The dream combo we want is:

- No tunneling or penetration for fast-moving bodies *by default*
- No ghost collisions due to speculative collision

It turns out that the CCD algorithm used by Box2D is *almost* exactly what we want.

## Solution

Implement Box2D-inspired continuous collision detection. At a high level:

- AABBs are kept tight, only expanded by a small, fixed contact tolerance of `0.02` (`B2_SPECULATIVE_DISTANCE`)
- Enlarged AABBs are additionally expanded by an AABB margin of up to `0.05` (`B2_MAX_AABB_MARGIN`), computed based on the bounding radius of the shape and an expansion factor (`B2_AABB_MARGIN_FRACTION`)
- Narrow phase collision detection also uses a fixed contact tolerance of `0.02` (`B2_SPECULATIVE_DISTANCE`)
- CCD runs near the end of the solver, clamping movement to the first time of impact (TOI)
  - Sweeps are only performed for "fast" dynamic bodies
  - A body is fast if its maximum motion (computed based on a sweep radius and velocity or pose delta) exceeds the shape's minimum CCD "thickness" times a safety factor
  - Sweeps are done by intersecting velocity-expanded AABBs with each BVH and performing TOI queries between each candidate shape pair

This approach keeps AABBs tight by default, avoids ghost collisions at high speeds, and only incurs meaningful CCD overhead for fast-moving bodies that actually have a chance to tunnel or reach deep overlap.

Swept CCD is enabled *by default* for fast-moving dynamic bodies, and can be configured using the `SweptCcd` component:

```rust
pub struct SweptCcd {
    /// The types of bodies this body is swept against during CCD.
    pub filter: CcdFilter,

    /// The sweep mode used for this body (linear or non-linear).
    pub mode: SweepMode,

    /// The fraction of a body's minimum `ccd_thickness` it may travel
    /// in a timestep before being treated as a fast-moving body.
    pub threshold: Scalar,
}
```

Additionally, unlike Box2D, I kept the old Bepu-style speculative collision around, but it is now opt-in via a `SpeculativeCcd` component:

```rust
pub struct SpeculativeCcd {
    /// The maximum distance at which speculative contacts are generated for this body,
    /// and the maximum distance its `ColliderAabb` is expanded along its velocity each timestep.
    pub max_distance: Scalar,
}
```

This can still be useful for some highly dynamic scenes where ghost collisions are not a problem, and can fill some gaps that swept CCD leaves (notably, it helps with CCD *between* two fast-moving bodies, and also reduces time-loss problems).

### 



### Differences to Box2D

Box2D's algorithm has a few notable limitations and problems that I encountered when implementing it:

1. CCD is only performed against static bodies by default. For dynamic-dynamic or dynamic-kinematic CCD, you must mark one of the dynamic bodies as a "bullet". I consider CCD against kinematic bodies to also be important in many cases (ex: moving platforms, elevators, various moving obstacles, characters), and would like to enable it for them by default, while keeping dynamic-dynamic CCD opt-in.

2. CCD between two bullets is not supported. This also makes it impossible to have e.g. bullets hit fast-spinning objects reliably, or to have two fast-moving projectiles hit each other mid-air reliably without manually implementing the projectiles with shape casts. I can understand why it is like this, but I think it is still too limiting and unexpected from a user POV.

3. CCD between a dynamic body and another moving body sometimes gets stuck in a "TOI loop" where the other body ends up separated from the TOI impact at its end pose, causing the discrete solver to miss the contact and trigger CCD again the next timestep. In the `tumbler` example, if you made the boxes bullets, they would "slide" strangely against the spinning container's walls with a persistent TOI impact active, without correcting velocity properly, causing other bodies to overlap with them. This is perhaps a rare edge case (you probably wouldn't make these bullets in Box2D), but because I want to support dynamic-kinematic CCD by default, it is actually relevant.

<img width="2049" height="1846" alt="Weird CCD behavior" src="https://github.com/user-attachments/assets/af68374c-bc8a-4f3f-b22b-0ad4fe37582d" />

*Weird CCD behavior in Box2D (see the green boxes)*

I ended up solving these problems as follows:

1. CCD is performed against dynamic-static and dynamic-kinematic pairs by default. You can opt in to dynamic-dynamic CCD by configuring `SweptCcd::filter` for an entity.

2. CCD is supported between two dynamic bodies by configuring `SweptCcd::filter` for both bodies. One problem is that because the collider AABBs are kept tight, the sweeps might not find the bodies unless they already overlap the swept AABB. To work around this, you can add `SpeculativeCcd` for these bodies, which also enables velocity expansion for the AABB. The `projectile_bounce` example demonstrates two fast-moving projectiles hitting each other with this.

3. Every TOI impact associated with a contact pair is guaranteed to be seen by the discrete solver by setting a `ContactPair::speculative_distance` property to increase the prediction distance enough to make sure the contact is detected by the narrow phase. This fixes the TOI freezing I was seeing.

I also diverge from Box2D in some other notable ways:

- We run CCD before applying solver body deltas, in a step separate from "finalize bodies", which allows us to avoid storing previous poses and keeps things more modular.
- We support configuring the CCD threshold per-body.
- Lots of small differences in naming and structure.

This gives us tunneling-free behavior for dynamic-static and dynamic-kinematic contacts *by default*, without ghost collisions commonly seen with unbounded speculative contacts, with additional opt-in dynamic-dynamic CCD, while keeping tight AABBs by default, all with a fairly cheap and minimal algorithm. Nice!

## Testing

Ran a bunch of test scenarios and demo scenes. See the new CCD examples for some of them.

---

## Showcase

### Tumbler

This is the `tumbler` example (inspired by Box2D), modified to enable CCD between all the dynamic bodies:

https://github.com/user-attachments/assets/7da2c12f-abf5-4d69-ab2c-9174daf43cf2

(apologies for the compression artifacts and short length, ran into GitHub file size limits :/)

You can see that everything still behaves reasonably, and with decent performance. In Box2D, the bodies exhibit strange behavior against the walls (see earlier image) and also don't support dynamic-dynamic CCD.

### Spinners

This is the `spinners` example, demonstrating the use of dynamic-dynamic CCD to make rapidly spinning objects hit small projectiles:

https://github.com/user-attachments/assets/b8339726-3115-46ea-93aa-a92da686937a

With non-linear sweeps, the spinners hit the projectiles reliably, unlike with linear sweeps or no swept CCD at all. However, they exhibit time loss, as they cannot complete the full rotational movement in order to prevent tunneling. By enabling speculative collision, this problem is alleviated, at the cost of its general problems (like ghost collisions).

### Projectile Bounce

This is the `projectile_bounce` example, demonstrating how Avian supports two fast-moving projectiles hitting each other midair and bouncing off of each other:

https://github.com/user-attachments/assets/ba186b6d-aace-4c59-a16f-a90f86c8f9b5

### Speculative Ghost Collision Avoidance

This is the `speculative_ghost` example taken from Box2D, demonstrating that moving right past an object at a high speed does not produce a ghost collision, as the speculative contact distance is kept very small by default:

https://github.com/user-attachments/assets/ce92ecfb-1dc2-48b6-a901-b783f723a7d7

When the box hits the platform, you can also see swept CCD kicking in, as the box stops at the time of impact (green outline).