### PR TITLE
Fix RUSTSEC-2026-0173: Migrate from proc-macro-error2 to proc-macro-error3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 name = "avian_derive"
 version = "0.2.2"
 dependencies = [
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn",
@@ -4560,22 +4560,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -14,6 +14,6 @@ bench = false
 
 [dependencies]
 proc-macro2 = "1.0.78"
-proc-macro-error2 = "2.0"
+proc-macro-error3 = "3.0"
 quote = "1.0"
 syn = "2.0"

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -2,7 +2,7 @@
 
 use proc_macro::TokenStream;
 
-use proc_macro_error2::{abort, emit_error, proc_macro_error};
+use proc_macro_error3::{abort, emit_error, proc_macro_error};
 use quote::quote;
 use syn::{Data, DeriveInput, parse_macro_input, spanned::Spanned};
 


### PR DESCRIPTION
# Objective

Fixes #995 - RUSTSEC-2026-0173: proc-macro-error2 is unmaintained.

## Solution

As discussed, replace proc-macro-error2 with the drop-in replacement proc-macro-error3.

## Testing

I ran `cargo build` locally.