### PR TITLE
Add AI Policy and CI Check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ https://github.com/avianphysics/avian/blob/main/AI_POLICY.md
 ## Solution
 
 - Describe the solution used to achieve the objective above.
+- Was AI used in design, code, or communication? In which ways?
 
 <!--
 Note: If your PR contains breaking changes relative to the latest release,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
 # Objective
 
+<!--
+Before you contribute, make sure you review our AI policy!
+https://github.com/avianphysics/avian/blob/main/AI_POLICY.md
+-->
+
 - Describe the objective or issue this PR addresses.
 - If you're fixing a specific issue, say "Fixes #X".
 
@@ -28,7 +33,7 @@ Note: If your PR contains breaking changes relative to the latest release,
 - Help others understand the result of this PR by showcasing your awesome work!
 - If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
 - If this PR includes a visual change, consider adding a screenshot, GIF, or video
-  - If you want, you could even include a before/after comparison!
+    - If you want, you could even include a before/after comparison!
 - If the Migration Guide adequately covers the changes, you can delete this section
 
 While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         name: Check Minimal Features
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
               with:
@@ -32,7 +32,7 @@ jobs:
         name: Check Documentation
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
               with:
@@ -54,7 +54,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: dtolnay/rust-toolchain@nightly
               with:
                   components: llvm-tools-preview
@@ -109,7 +109,7 @@ jobs:
         name: Lints
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: dtolnay/rust-toolchain@stable
               with:
                   components: rustfmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 env:
     CARGO_TERM_COLOR: always
@@ -20,9 +20,9 @@ jobs:
             - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
               with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-all-crates: true
-                shared-key: lints
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+                  cache-all-crates: true
+                  shared-key: lints
             - name: Install Linux dependencies
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libx264-164 libx264-dev
             - name: Run cargo check
@@ -36,9 +36,9 @@ jobs:
             - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
               with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-all-crates: true
-                shared-key: lints
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+                  cache-all-crates: true
+                  shared-key: lints
             - name: Install Linux dependencies
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libx264-164 libx264-dev
             - name: Run cargo doc
@@ -57,7 +57,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@nightly
               with:
-                components: llvm-tools-preview
+                  components: llvm-tools-preview
             - uses: cargo-bins/cargo-binstall@main
             - name: Install Linux dependencies
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libx264-164 libx264-dev
@@ -71,41 +71,40 @@ jobs:
             - name: set LD_LIBRARY_PATH on unix
               id: ld-unix
               run: |
-                # Linux
-                echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
-                # macOS
-                echo "DYLD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
-                echo "libdir=$(rustc --print target-libdir)" >> "$GITHUB_OUTPUT"
+                  # Linux
+                  echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
+                  # macOS
+                  echo "DYLD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
+                  echo "libdir=$(rustc --print target-libdir)" >> "$GITHUB_OUTPUT"
               if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
             - name: set LD_LIBRARY_PATH on Windows
               id: ld-windows
               run: |
-                $libDir = (rustc --print target-libdir)
-                Add-Content -Path $env:GITHUB_ENV -Value "RUST_LIB_DIR=$libDir"
-                Add-Content -Path $env:GITHUB_PATH -Value "$libDir"
-                "libdir=$libDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+                  $libDir = (rustc --print target-libdir)
+                  Add-Content -Path $env:GITHUB_ENV -Value "RUST_LIB_DIR=$libDir"
+                  Add-Content -Path $env:GITHUB_PATH -Value "$libDir"
+                  "libdir=$libDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
               shell: pwsh
               if: ${{ matrix.os == 'windows-latest' }}
             - name: Restore Rust cache on Unix
               uses: Swatinem/rust-cache@v2
               if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
               with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-directories: ${{ steps.ld-unix.outputs.libdir }}
-                cache-all-crates: true
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+                  cache-directories: ${{ steps.ld-unix.outputs.libdir }}
+                  cache-all-crates: true
             - name: Restore Rust cache on Windows
               uses: Swatinem/rust-cache@v2
               if: ${{ matrix.os == 'windows-latest' }}
               with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-directories: ${{ steps.ld-windows.outputs.libdir }}
-                cache-all-crates: true
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+                  cache-directories: ${{ steps.ld-windows.outputs.libdir }}
+                  cache-all-crates: true
             - name: Run cargo test
               run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,xpbd_joints,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
             - name: Run doc tests
               run: cargo test --locked --doc --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,xpbd_joints,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
-  
-           
+
     lints:
         name: Lints
         runs-on: ubuntu-latest
@@ -113,12 +112,12 @@ jobs:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
               with:
-                components: rustfmt, clippy
+                  components: rustfmt, clippy
             - uses: Swatinem/rust-cache@v2
               with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-all-crates: true
-                shared-key: lints
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+                  cache-all-crates: true
+                  shared-key: lints
             - name: Install Linux dependencies
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libx264-164 libx264-dev
             - name: Run cargo fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,12 @@ jobs:
               run: cargo fmt --all -- --check
             - name: Run cargo clippy
               run: cargo clippy --locked --all-targets
+
+    no-ai-commits:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  # Required so the full commit range is available
+                  fetch-depth: 0
+            - uses: Jondolf/ai-commit-check@v1

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,15 @@
+# AI Policy
+
+The use of AI assistance, especially in the form of generative AI, continues to be a heated topic in open source communities. We have policies in place regarding the quality of contributions and expectations of contributors to try and maintain a friendly and welcoming developer community:
+
+- No LLM-generated commits (ex: Claude commits). This is automatically enforced by a CI check.
+- No LLM-generated communication (ex: issues, PR descriptions, bug reports), except for translation or accessibility purposes.
+- You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
+- You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
+- Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.
+- Use of LLMs in contributions or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
+- Maintainers reserve the right to close any issues or PRs on the premise of being LLM-generated. This is a subjective judgement call made on a case-by-case basis.
+
+In general, we do not police how contributions are made. What matters to us is the quality of contributions and communication surrounding them. This is a human community, and we do not tolerate or wish to interact with raw LLM output. Fellow humans who act in good faith and take accountability for their work are welcome.
+
+Respect these policies when interacting with the community, both in the GitHub repositories and on the Discord server. If you have concerns about these policies or any individuals, please reach out to the maintainers first to discuss them privately.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -8,7 +8,7 @@ The use of AI assistance, especially in the form of generative AI, continues to 
 - You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
 - You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
 - Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.
-- Use of LLMs in design, contributions, or communication should always be disclosed. LLM-powered tab autocompletion for trivial or mechanical edits and boilerplate requires no disclosure.
+- Use of LLMs in design, contributions, or communication should always be disclosed. LLM-powered tab autocompletion for trivial or mechanical edits requires no disclosure.
 - Maintainers reserve the right to close any issues or PRs on the premise of being LLM-generated. This is a subjective judgement call made on a case-by-case basis.
 
 In general, we do not police how contributions are made. What matters to us is the quality of contributions and communication surrounding them. This is a human community, and we do not tolerate or wish to interact with raw LLM output. Fellow humans who act in good faith and take accountability for their work are welcome.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -4,6 +4,7 @@ The use of AI assistance, especially in the form of generative AI, continues to 
 
 - No LLM-generated commits (ex: Claude commits). This is automatically enforced by a CI check.
 - No LLM-generated communication (ex: issues, PR descriptions, bug reports), except for translation or accessibility purposes.
+- No AI-generated art or assets.
 - You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
 - You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
 - Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -7,7 +7,7 @@ The use of AI assistance, especially in the form of generative AI, continues to 
 - You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
 - You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
 - Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.
-- Use of LLMs in contributions or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
+- Use of LLMs in design, contributions or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
 - Maintainers reserve the right to close any issues or PRs on the premise of being LLM-generated. This is a subjective judgement call made on a case-by-case basis.
 
 In general, we do not police how contributions are made. What matters to us is the quality of contributions and communication surrounding them. This is a human community, and we do not tolerate or wish to interact with raw LLM output. Fellow humans who act in good faith and take accountability for their work are welcome.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -7,7 +7,7 @@ The use of AI assistance, especially in the form of generative AI, continues to 
 - You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
 - You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
 - Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.
-- Use of LLMs in design, contributions or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
+- Use of LLMs in design, contributions, or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
 - Maintainers reserve the right to close any issues or PRs on the premise of being LLM-generated. This is a subjective judgement call made on a case-by-case basis.
 
 In general, we do not police how contributions are made. What matters to us is the quality of contributions and communication surrounding them. This is a human community, and we do not tolerate or wish to interact with raw LLM output. Fellow humans who act in good faith and take accountability for their work are welcome.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -8,7 +8,7 @@ The use of AI assistance, especially in the form of generative AI, continues to 
 - You, as a member of the community, are responsible for every line of code and comment you contribute. This includes all design and implementation decisions.
 - You must fully understand your contributions, and be able to hold a conversation about their contents with fellow contributors.
 - Contributions should be largely consistent with existing project conventions. Exhibiting multiple clear signs of LLM output is a red flag, but please do not start witch hunts. Some people just have similar writing styles.
-- Use of LLMs in design, contributions, or communication should always be disclosed. LLM-powered tab autocompletion requires no disclosure.
+- Use of LLMs in design, contributions, or communication should always be disclosed. LLM-powered tab autocompletion for trivial or mechanical edits and boilerplate requires no disclosure.
 - Maintainers reserve the right to close any issues or PRs on the premise of being LLM-generated. This is a subjective judgement call made on a case-by-case basis.
 
 In general, we do not police how contributions are made. What matters to us is the quality of contributions and communication surrounding them. This is a human community, and we do not tolerate or wish to interact with raw LLM output. Fellow humans who act in good faith and take accountability for their work are welcome.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Below are some of the core design principles used in Avian.
 - **Made with Bevy, for Bevy.** No wrappers around existing engines.
 - **Provide an ergonomic and familiar API.** Ergonomics is key for a good experience.
 - **Utilize the ECS as much as possible.** The engine should feel like a part of Bevy, and it shouldn't
-    need to maintain a separate physics world.
+  need to maintain a separate physics world.
 - **Use a highly modular plugin architecture.** Users should be able to replace parts of the engine
-    with their own implementations.
+  with their own implementations.
 - **Have good documentation.** A physics engine is pointless if you don't know how to use it.
 
 ## Features
@@ -28,29 +28,29 @@ Below are some of the core design principles used in Avian.
 Below are some of the current features of Avian.
 
 - Dynamic, kinematic and static rigid bodies
-  - Linear and angular velocity
-  - External forces, torque and impulses
-  - Gravity and gravity scale
-  - Linear and angular damping
-  - Locking translational and rotational axes
-  - Rigid body dominance
-  - Continuous Collision Detection (CCD)
-  - Automatic deactivation with sleeping
+    - Linear and angular velocity
+    - External forces, torque and impulses
+    - Gravity and gravity scale
+    - Linear and angular damping
+    - Locking translational and rotational axes
+    - Rigid body dominance
+    - Continuous Collision Detection (CCD)
+    - Automatic deactivation with sleeping
 - Collision detection powered by [Parry](https://parry.rs)
-  - Colliders with configurable collision layers, density, material properties and more
-  - Collider generation for meshes and entire scenes
-  - Collision events
-  - Access to colliding entities
-  - Filtering and modifying collisions with collision hooks
-  - Manual contact queries and intersection tests
+    - Colliders with configurable collision layers, density, material properties and more
+    - Collider generation for meshes and entire scenes
+    - Collision events
+    - Access to colliding entities
+    - Filtering and modifying collisions with collision hooks
+    - Manual contact queries and intersection tests
 - Constraints and joints
-  - Several built-in joint types: fixed, distance, prismatic, revolute, spherical
-  - Support for custom joints and other constraints using XPBD
+    - Several built-in joint types: fixed, distance, prismatic, revolute, spherical
+    - Support for custom joints and other constraints using XPBD
 - Spatial queries
-  - Raycasting, shapecasting, point projection and intersection tests
-  - Ergonomic component-based API for raycasts and shapecasts
-  - Flexible `SpatialQuery` system parameter
-  - Spatial query filters
+    - Raycasting, shapecasting, point projection and intersection tests
+    - Ergonomic component-based API for raycasts and shapecasts
+    - Flexible `SpatialQuery` system parameter
+    - Spatial query filters
 - `Transform` interpolation and extrapolation for fixed timesteps
 - Debug rendering for colliders, AABBs, contacts, joints, spatial queries, and more
 - Configurable scheduling and high customizability
@@ -159,26 +159,26 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 
 ## Version Table
 
-| Bevy    | Avian         |
-| ------- | ------------- |
-| 0.18    | 0.5-0.6, main |
-| 0.17    | 0.4           |
-| 0.16    | 0.3           |
-| 0.15    | 0.2           |
-| 0.14    | 0.1           |
+| Bevy | Avian         |
+| ---- | ------------- |
+| 0.18 | 0.5-0.6, main |
+| 0.17 | 0.4           |
+| 0.16 | 0.3           |
+| 0.15 | 0.2           |
+| 0.14 | 0.1           |
 
 Avian provides [migration guides](./migration-guides) for each version.
 
 <details>
   <summary>Bevy XPBD versions (the predecessor of Avian)</summary>
 
-  | Bevy | Bevy XPBD |
-  | ---- | --------- |
-  | 0.14 | 0.5       |
-  | 0.13 | 0.4       |
-  | 0.12 | 0.3       |
-  | 0.11 | 0.2       |
-  | 0.10 | 0.1       |
+| Bevy | Bevy XPBD |
+| ---- | --------- |
+| 0.14 | 0.5       |
+| 0.13 | 0.4       |
+| 0.12 | 0.3       |
+| 0.11 | 0.2       |
+| 0.10 | 0.1       |
 
 </details>
 
@@ -186,9 +186,14 @@ Avian provides [migration guides](./migration-guides) for each version.
 
 If you encounter any problems, feel free to open issues or create pull requests.
 For larger changes and additions, it's better to open an issue or ask me for input
-before making a pull request.
+before making a pull request. Make sure to review our [AI policy](/AI_POLICY.md)
+before contributing.
 
-You can also ask for help or ask questions on the [Bevy Discord](https://discord.com/invite/gMUk5Ph)
+We also have our own [Avian Dev Discord](https://discord.gg/nE5xt4JdPx) server
+for development discussions related to Avian or other physics topics. Hop in
+if you want to chat or follow along!
+
+For other guidance or questions, consider joining us on the [Bevy Discord](https://discord.com/invite/gMUk5Ph)
 server's Avian Physics topic in `#ecosystem-crates`. My username on the Discord is `Jondolf` (`@jondolfdev`).
 
 ## Acknowledgements


### PR DESCRIPTION
# Objective

We have had a couple of PRs with AI commits at this point (#964, #994). I have closed these, as we don't accept AI commits to be merged, but we don't actually have any policies about this explicitly laid out anywhere. We should have a clear policy on AI usage that we can point people to.

Bevy has its own [AI policy](https://bevy.org/learn/contribute/policies/ai/), but I'm not a huge fan of how it is written; it's verbose, and focuses primarily on copyright, litigation, and strict rulings. For the purposes of fostering a healthy community, I would prefer to focus more on quality, accountability, human communication, and the social and behavioral aspects surrounding AI usage.

Additionally, we should have a CI check that fails if an AI-authored commit is detected. This is primarily to make sure we don't let AI authorship slip through (it forever leaves a mark on the commit history, which has caused tension in the Bevy community) and to automatically filter slop that a human hasn't audited.

## Solution

Add an AI policy. This was written in collaboration with some other peeps who share similar thoughts about what it should look like.

Additionally, add an AI commit check in CI. This uses [AI Commit Check](https://github.com/Jondolf/ai-commit-check), which is a GitHub action that I wrote for this purpose and published for general usage.

## Testing

Tested the AI commit checker on another repo. We'll also see if it works if/when we actually get a real AI-authored PR.