### PR TITLE
add `no-render(-f64)` feature groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ and precision:
 cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 ```
 
+## Headless Simulation
+
+To remove dependency on `bevy_render` (allowing use for CLIs and other headless applications),
+you can use the `no-render` or `no-render-f64` feature groups (depending on your desired precision):
+
+```shell
+# For 2D applications:
+cargo add avian2d --no-default-features --features no-render
+cargo add avian2d --no-default-features --features no-render-f64 # for 64-bit sim
+# For 3D applications:
+cargo add avian3d --no-default-features --features no-render
+cargo add avian3d --no-default-features --features no-render-f64 # for 64-bit sim
+``
+
 ## Version Table
 
 | Bevy    | Avian         |

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -13,15 +13,29 @@ categories = ["game-development", "science", "simulation"]
 
 [features]
 default = [
-    "2d",
-    "f32",
-    "parry-f32",
     "debug-plugin",
+    "no-render",
+    "bevy_picking",
+]
+
+# a feature group for physics simulation without render dependencies
+# (servers, headless, etc...)
+no-render = [
+    "2d",
+    "parry-f32",
     "xpbd_joints",
     "parallel",
     "bevy_scene",
-    "bevy_picking",
 ]
+# a feature group for 64-bit physics simulation without render dependencies
+no-render-f64 = [
+    "2d",
+    "parry-f64",
+    "xpbd_joints",
+    "parallel",
+    "bevy_scene",
+]
+
 2d = []
 f32 = []
 f64 = []

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -13,16 +13,31 @@ categories = ["game-development", "science", "simulation"]
 
 [features]
 default = [
-    "3d",
-    "f32",
-    "parry-f32",
     "debug-plugin",
+    "no-render",
+    "bevy_picking",
+]
+
+# a feature group for physics simulation without render dependencies
+# (servers, headless, etc...)
+no-render = [
+    "3d",
+    "parry-f32",
     "xpbd_joints",
     "parallel",
     "collider-from-mesh",
     "bevy_scene",
-    "bevy_picking",
 ]
+# a feature group for 64-bit physics simulation without render dependencies
+no-render-f64 = [
+    "3d",
+    "parry-f64",
+    "xpbd_joints",
+    "parallel",
+    "collider-from-mesh",
+    "bevy_scene",
+]
+
 3d = []
 f32 = []
 f64 = []


### PR DESCRIPTION
# Objective

Bumped into https://github.com/bevyengine/bevy/discussions/24638, where it's a bit surprising that Avian, by default, pulls in `bevy_render` as a dependency purely for the debug plugin (and nothing else), and the only way to *not* do that is to manually copy the feature list for default, and remove the debug-plugin feature.

## Solution

Introduce no-render and no-render-f64 feature groups to make it easy to build Avian headlessly.

Also add a section to the README about using these features.

## Testing

- Did you test these changes? If so, how?
Created a test project using the new feature groups, and made sure it built.
- Are there any parts that need more testing?
No, this is just feature re-organization
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
On platforms/environments where rendering/windowing is not supported, using the introduced features should allow Avian to still be built.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Not relevant