### PR TITLE
Add PhysicsTransformWriter for on-demand Position->Transform sync

### DIFF
--- a/src/physics_transform/helper.rs
+++ b/src/physics_transform/helper.rs
@@ -1,18 +1,20 @@
 use bevy::{
     ecs::{
         entity::{Entity, EntityNotSpawnedError},
+        hierarchy::{ChildOf, Children},
+        query::With,
         system::{Query, SystemParam, lifetimeless::Write},
         world::Mut,
     },
-    transform::{
-        components::GlobalTransform,
-        helper::{ComputeGlobalTransformError, TransformHelper},
-    },
+    transform::components::{GlobalTransform, Transform},
+    transform::helper::{ComputeGlobalTransformError, TransformHelper},
 };
 use thiserror::Error;
 
+#[cfg(feature = "2d")]
+use crate::math::Quaternion;
 use crate::{
-    math::AdjustPrecision,
+    math::{AdjustPrecision, AsF32},
     prelude::{Position, Rotation},
 };
 
@@ -104,4 +106,120 @@ pub enum UpdatePhysicsTransformError {
     /// This probably means that your hierarchy has been improperly maintained.
     #[error("{0}")]
     MalformedHierarchy(EntityNotSpawnedError),
+}
+
+/// A system parameter for writing up-to-date [`Transform`] components from
+/// [`Position`] and [`Rotation`] on demand, without advancing the simulation.
+///
+/// This is the inverse of [`PhysicsTransformHelper::update_physics_transform`]:
+/// it pushes the physics pose out to [`Transform`] immediately, for cases like
+/// setting [`Position`]/[`Rotation`] directly and then reading or rendering the
+/// result before the schedule (and its `position_to_transform` writeback) runs.
+///
+/// Like the `position_to_transform` system, nested bodies are resolved against
+/// their parent's [`GlobalTransform`].
+#[derive(SystemParam)]
+pub struct PhysicsTransformWriter<'w, 's> {
+    bodies: Query<
+        'w,
+        's,
+        (
+            &'static mut Transform,
+            &'static Position,
+            &'static Rotation,
+            Option<&'static ChildOf>,
+        ),
+    >,
+    parents: Query<
+        'w,
+        's,
+        (
+            &'static GlobalTransform,
+            Option<&'static Position>,
+            Option<&'static Rotation>,
+        ),
+        With<Children>,
+    >,
+}
+
+impl PhysicsTransformWriter<'_, '_> {
+    /// Updates the [`Transform`] of `entity` from its [`Position`] and
+    /// [`Rotation`] (and its parent's, for nested bodies). The inverse of
+    /// [`PhysicsTransformHelper::update_physics_transform`].
+    ///
+    /// [`Transform`]: bevy::transform::components::Transform
+    pub fn update_transform(&mut self, entity: Entity) -> Result<(), UpdatePhysicsTransformError> {
+        let (pos, rot, parent) = {
+            let (_, pos, rot, parent) = self
+                .bodies
+                .get(entity)
+                .map_err(|_| UpdatePhysicsTransformError::MissingTransform(entity))?;
+            (*pos, *rot, parent.map(|&ChildOf(parent)| parent))
+        };
+
+        #[cfg(feature = "3d")]
+        let (translation, rotation) = if let Some(parent) = parent {
+            let (parent_transform, parent_pos, parent_rot) = self
+                .parents
+                .get(parent)
+                .map_err(|_| UpdatePhysicsTransformError::MissingTransform(parent))?;
+            let parent_transform = parent_transform.compute_transform();
+            let parent_pos = parent_pos.map_or(parent_transform.translation, |pos| pos.f32());
+            let parent_rot = parent_rot.map_or(parent_transform.rotation, |rot| rot.f32());
+            let parent_transform = Transform::from_translation(parent_pos)
+                .with_rotation(parent_rot)
+                .with_scale(parent_transform.scale);
+            let new_transform = GlobalTransform::from(
+                Transform::from_translation(pos.f32()).with_rotation(rot.f32()),
+            )
+            .reparented_to(&GlobalTransform::from(parent_transform));
+            (new_transform.translation, new_transform.rotation)
+        } else {
+            (pos.f32(), rot.f32())
+        };
+
+        #[cfg(feature = "2d")]
+        let (translation, rotation) = {
+            let z = self
+                .bodies
+                .get(entity)
+                .map(|(transform, ..)| transform.translation.z)
+                .unwrap_or(0.0);
+            if let Some(parent) = parent {
+                let (parent_transform, parent_pos, parent_rot) = self
+                    .parents
+                    .get(parent)
+                    .map_err(|_| UpdatePhysicsTransformError::MissingTransform(parent))?;
+                let parent_transform = parent_transform.compute_transform();
+                let parent_pos = parent_pos.map_or(parent_transform.translation, |pos| {
+                    pos.f32().extend(parent_transform.translation.z)
+                });
+                let parent_rot = parent_rot.map_or(parent_transform.rotation, |rot| {
+                    Quaternion::from(*rot).f32()
+                });
+                let parent_scale = parent_transform.scale;
+                let parent_transform = Transform::from_translation(parent_pos)
+                    .with_rotation(parent_rot)
+                    .with_scale(parent_scale);
+                let new_transform = GlobalTransform::from(
+                    Transform::from_translation(
+                        pos.f32().extend(parent_pos.z + z * parent_scale.z),
+                    )
+                    .with_rotation(Quaternion::from(rot).f32()),
+                )
+                .reparented_to(&GlobalTransform::from(parent_transform));
+                (new_transform.translation, new_transform.rotation)
+            } else {
+                (pos.f32().extend(z), Quaternion::from(rot).f32())
+            }
+        };
+
+        let (mut transform, ..) = self
+            .bodies
+            .get_mut(entity)
+            .map_err(|_| UpdatePhysicsTransformError::MissingTransform(entity))?;
+        transform.translation = translation;
+        transform.rotation = rotation;
+        Ok(())
+    }
 }

--- a/src/physics_transform/mod.rs
+++ b/src/physics_transform/mod.rs
@@ -8,7 +8,7 @@ pub use transform::{Position, PreSolveDeltaPosition, PreSolveDeltaRotation, Rota
 pub(crate) use transform::{RotationValue, init_physics_transform};
 
 mod helper;
-pub use helper::PhysicsTransformHelper;
+pub use helper::{PhysicsTransformHelper, PhysicsTransformWriter};
 
 #[cfg(test)]
 mod tests;

--- a/src/physics_transform/tests.rs
+++ b/src/physics_transform/tests.rs
@@ -1,5 +1,4 @@
 use crate::{physics_transform::PhysicsTransformConfig, prelude::*};
-#[cfg(feature = "3d")]
 use approx::assert_relative_eq;
 use bevy::prelude::*;
 
@@ -264,4 +263,62 @@ fn test_init_transforms_basics() {
             assert!(app.world().get::<Rotation>(e_7_without_rb).is_none());
         }
     }
+}
+
+#[cfg(feature = "3d")]
+#[test]
+fn test_update_transform_writes_transform_from_position() {
+    use crate::physics_transform::PhysicsTransformWriter;
+    use bevy::ecs::system::RunSystemOnce;
+
+    let mut app = App::new();
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            RigidBody::Dynamic,
+            Position::from_xyz(1.0, 2.0, 3.0),
+            Rotation(Quaternion::from_axis_angle(Vector::Y, 0.5)),
+            Transform::default(),
+        ))
+        .id();
+
+    app.world_mut()
+        .run_system_once(move |mut writer: PhysicsTransformWriter| {
+            writer.update_transform(entity).unwrap();
+        })
+        .unwrap();
+
+    let transform = app.world().get::<Transform>(entity).unwrap();
+    assert_relative_eq!(transform.translation, Vec3::new(1.0, 2.0, 3.0));
+    assert_relative_eq!(transform.rotation, Quat::from_axis_angle(Vec3::Y, 0.5));
+}
+
+#[cfg(feature = "2d")]
+#[test]
+fn test_update_transform_writes_transform_from_position() {
+    use crate::physics_transform::PhysicsTransformWriter;
+    use bevy::ecs::system::RunSystemOnce;
+
+    let mut app = App::new();
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            RigidBody::Dynamic,
+            Position::from_xy(1.0, 2.0),
+            Rotation::radians(0.5),
+            Transform::default(),
+        ))
+        .id();
+
+    app.world_mut()
+        .run_system_once(move |mut writer: PhysicsTransformWriter| {
+            writer.update_transform(entity).unwrap();
+        })
+        .unwrap();
+
+    let transform = app.world().get::<Transform>(entity).unwrap();
+    assert_relative_eq!(transform.translation, Vec3::new(1.0, 2.0, 0.0));
+    assert_relative_eq!(transform.rotation, Quat::from_rotation_z(0.5));
 }


### PR DESCRIPTION
## What

Adds a `PhysicsTransformWriter` system parameter with `update_transform(entity)`, the inverse of `PhysicsTransformHelper::update_physics_transform`. It writes an entity's `Transform` from its `Position`/`Rotation` (and its parent's, for nested bodies) on demand, reusing the same logic as the `position_to_transform` writeback.

Closes #1001.

## Why

There is currently no supported way to push a directly-written `Position`/`Rotation` out to `Transform` without stepping the schedule. The existing helper only does the opposite direction (`Transform` → `Position`). Running `PhysicsSchedule` manually with a zero `Time<Physics>` delta is guarded out (`if !delta.is_zero()`), and any non-zero delta advances the simulation and feeds per-timestep solver terms (e.g. the soft-constraint bias `separation / delta_secs`), so there is no derive-without-integrate path. This is needed for setting poses programmatically and then reading/rendering the result before the schedule runs (teleport/replay to scripted states, editor tooling, deterministic tests).

## Open question for reviewers

The issue suggested adding `update_transform` to `PhysicsTransformHelper`. I implemented it as a **sibling** `SystemParam` instead, because writing `Transform` conflicts with that helper's `TransformHelper` (which reads `Transform`) within a single `SystemParam`. Folding it into the existing helper would need a `ParamSet` and would touch its public fields. Happy to restructure onto the helper if you prefer that shape.

## Testing

- `cargo check`/`clippy` pass for both `avian2d` and `avian3d`.
- Added `test_update_transform_writes_transform_from_position` for both 2d and 3d; `cargo test -p avian{2,3}d --lib physics_transform` passes.
