### PR TITLE
Make movement handling less framerate-dependent for the kinematic character examples

### DIFF
--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -209,18 +209,22 @@ fn movement(
 ) {
     let delta_secs = time.delta_secs_f64().adjust_precision();
 
-    for event in movement_reader.read() {
-        for (movement, mut linear_velocity, is_grounded) in &mut controllers {
-            match event {
-                MovementAction::Move(direction) => {
-                    linear_velocity.x += *direction * movement.acceleration * delta_secs;
-                }
-                MovementAction::Jump => {
-                    if is_grounded {
-                        linear_velocity.y = movement.jump_impulse;
-                    }
-                }
-            }
+    // Accumulated movement actions to make movement less framerate-dependent.
+    let (jumping, direction): (bool, Scalar) =
+        movement_reader
+            .read()
+            .fold((false, 0.0), |(jumping, dir), action| match action {
+                // For movement actions, use existing jump and add to the existing movement
+                // accumulator.
+                MovementAction::Move(d) => (jumping, (dir + d).clamp(-1.0, 1.0)),
+                // For jump actions, use existing movemnt and set the jump field to true.
+                MovementAction::Jump => (true, dir),
+            });
+
+    for (movement, mut linear_velocity, is_grounded) in &mut controllers {
+        linear_velocity.x += direction * movement.acceleration * delta_secs;
+        if jumping && is_grounded {
+            linear_velocity.y = movement.jump_impulse;
         }
     }
 }

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -220,16 +220,16 @@ fn movement(
     let delta_secs = time.delta_secs_f64().adjust_precision();
 
     // Accumulated movement actions to make movement less framerate-dependent.
-    let (jumping, direction): (bool, Vec2) =
-        movement_reader
-            .read()
-            .fold((false, Vec2::ZERO), |(jumping, dir), action| match action {
-                // For movement actions, use existing jump and add to the existing movement
-                // direction.
-                MovementAction::Move(d) => (jumping, (dir + d).normalize_or_zero()),
-                // For jump actions, use existing movemnt and set the jump field to true.
-                MovementAction::Jump => (true, dir),
-            });
+    let (jumping, direction): (bool, Vector2) = movement_reader.read().fold(
+        (false, Vector2::ZERO),
+        |(jumping, dir), action| match action {
+            // For movement actions, use existing jump and add to the existing movement
+            // direction.
+            MovementAction::Move(d) => (jumping, (dir + d).normalize_or_zero()),
+            // For jump actions, use existing movemnt and set the jump field to true.
+            MovementAction::Jump => (true, dir),
+        },
+    );
 
     for (movement, mut linear_velocity, is_grounded) in &mut controllers {
         linear_velocity.x += direction.x * movement.acceleration * delta_secs;

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -219,19 +219,23 @@ fn movement(
 ) {
     let delta_secs = time.delta_secs_f64().adjust_precision();
 
-    for event in movement_reader.read() {
-        for (movement, mut linear_velocity, is_grounded) in &mut controllers {
-            match event {
-                MovementAction::Move(direction) => {
-                    linear_velocity.x += direction.x * movement.acceleration * delta_secs;
-                    linear_velocity.z -= direction.y * movement.acceleration * delta_secs;
-                }
-                MovementAction::Jump => {
-                    if is_grounded {
-                        linear_velocity.y = movement.jump_impulse;
-                    }
-                }
-            }
+    // Accumulated movement actions to make movement less framerate-dependent.
+    let (jumping, direction): (bool, Vec2) =
+        movement_reader
+            .read()
+            .fold((false, Vec2::ZERO), |(jumping, dir), action| match action {
+                // For movement actions, use existing jump and add to the existing movement
+                // direction.
+                MovementAction::Move(d) => (jumping, (dir + d).normalize_or_zero()),
+                // For jump actions, use existing movemnt and set the jump field to true.
+                MovementAction::Jump => (true, dir),
+            });
+
+    for (movement, mut linear_velocity, is_grounded) in &mut controllers {
+        linear_velocity.x += direction.x * movement.acceleration * delta_secs;
+        linear_velocity.z -= direction.y * movement.acceleration * delta_secs;
+        if is_grounded && jumping {
+            linear_velocity.y = movement.jump_impulse;
         }
     }
 }


### PR DESCRIPTION
# Objective
A simple fix for the movement action handling in the 2d and 3d kinematic character examples. I noticed when stealing the code for my own project that the events would accumulate between FixedUpdate runs at higher frame-rates (e.g. 120hz) causing the character to go ballistic.

This behavior isn't present in the dynamic character example since everything is done in the main Update schedule instead.

More could probably be done with these examples. For example, making the events target specific entities or a more extensive re-write but this is just meant to be a quick fix for a simple example.

## Solution
Simple near-term fix was just to fold() all the events and use that output to influence the simulation. Not entirely sure if this is the _correct_ approach, but it works and is simple enough.

## Testing
Set window's `present_mode` to AutoNoVsync to confirm consistent behavior
```rust
...
            DefaultPlugins.set(WindowPlugin {
                primary_window: Some(Window {
                    present_mode: bevy::window::PresentMode::AutoNoVsync,
                    ..Default::default()
                }),
                ..Default::default()
            }),
...
```  

## Showcase
Before (Old behavior, AutoNoVsync):

https://github.com/user-attachments/assets/18b64f22-4aba-49e7-8888-fc31498c0550

After:

https://github.com/user-attachments/assets/98a9f3e7-cd87-465d-945f-5d3dae913c5a

Similar behavior in the 2d example.