### PR TITLE
fix trimesh returned by IntoCollider for plane shapes

### DIFF
--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -23,7 +23,7 @@ impl IntoCollider<Collider> for InfinitePlane3d {
             rotation * Vector::new(half_size, 0.0, half_size),
         ];
 
-        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])
+        Collider::trimesh(vertices, vec![[0, 1, 2], [0, 2, 3]])
     }
 }
 
@@ -38,7 +38,7 @@ impl IntoCollider<Collider> for Plane3d {
             rotation * Vector::new(half_size.x, 0.0, half_size.y),
         ];
 
-        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])
+        Collider::trimesh(vertices, vec![[0, 1, 2], [0, 2, 3]])
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #1011

## Solution

Generate two different triangles instead of the same triangle twice.

## Testing

Attempting to `cargo test` this repository OOMed my PC, so I didn't run those. However, I was able to use a custom `MyInfinitePlane3d` in my initial app where I discovered the issue; returning `Collider::trimesh(vertices, vec![[0, 1, 2], [0, 2, 3]])` from its `IntoCollider` implementation seemed to get the correct ray-cast results.