### PR TITLE
Only run CI on Ubuntu by default for Rust file changes

### DIFF
--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -1,0 +1,17 @@
+name: Commit Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  no-ai-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Required so the full commit range is available
+          fetch-depth: 0
+      - uses: Jondolf/ai-commit-check@v1

--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -1,17 +1,18 @@
 name: Commit Checks
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  no-ai-commits:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          # Required so the full commit range is available
-          fetch-depth: 0
-      - uses: Jondolf/ai-commit-check@v1
+    no-ai-commits:
+        name: No AI Commits
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  # Required so the full commit range is available
+                  fetch-depth: 0
+            - uses: Jondolf/ai-commit-check@v1

--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     no-ai-commits:
         name: No AI Commits

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,6 +13,10 @@ on:
             - ".cargo/**"
             - ".github/workflows/rust.yaml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
     CARGO_TERM_COLOR: always
     RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,10 +1,17 @@
-name: CI
+name: Rust
 
 on:
     push:
         branches: [main]
     pull_request:
         branches: [main]
+        types: [opened, synchronize, reopened, ready_for_review]
+        paths:
+            - "**.rs"
+            - "**/Cargo.toml"
+            - "**/Cargo.lock"
+            - ".cargo/**"
+            - ".github/workflows/rust.yaml"
 
 env:
     CARGO_TERM_COLOR: always
@@ -48,7 +55,7 @@ jobs:
         name: Test Suite
         strategy:
             matrix:
-                os: [windows-latest, macos-latest, ubuntu-latest]
+                os: ${{ fromJSON((github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Cross-Platform')) && '["windows-latest","macos-latest","ubuntu-latest"]' || '["ubuntu-latest"]') }}
         env:
             RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only -Zthreads=0
         runs-on: ${{ matrix.os }}
@@ -124,12 +131,3 @@ jobs:
               run: cargo fmt --all -- --check
             - name: Run cargo clippy
               run: cargo clippy --locked --all-targets
-
-    no-ai-commits:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v6
-              with:
-                  # Required so the full commit range is available
-                  fetch-depth: 0
-            - uses: Jondolf/ai-commit-check@v1


### PR DESCRIPTION
Running full CI on all platforms for all changes takes a long time and is largely redundant. We should only run CI on Ubuntu by default for PRs, but still run on all platforms on `main` and on PRs with a Cross-Platform label. Rust jobs should also be scoped to PRs that touch Rust files.