### PR TITLE
Make CustomIntegration tags derive Clone

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -175,7 +175,7 @@ impl Gravity {
 ///
 /// - Contact impulses and joint impulses for dynamic bodies
 /// - Impulses applied via [`Forces`]
-#[derive(Component, Debug, Default, Reflect)]
+#[derive(Component, Debug, Default, Reflect, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component, Debug, Default)]
@@ -188,7 +188,7 @@ pub struct CustomVelocityIntegration;
 ///
 /// This can be useful for implementing kinematic bodies that are moved according to custom logic,
 /// such as with [`MoveAndSlide`].
-#[derive(Component, Debug, Default, Reflect)]
+#[derive(Component, Debug, Default, Reflect, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component, Debug, Default)]


### PR DESCRIPTION
# Objective

The Custom*Integration tag Components aren't Clone and I need them to be.

## Solution

Derive Clone and Copy for the unit structs.
