### PR TITLE
Fix fast-spinning balls sinking into the ground

### DIFF
--- a/migration-guides/0.7-to-main.md
+++ b/migration-guides/0.7-to-main.md
@@ -94,3 +94,15 @@ consider using the `FlushContactStatusChangesQueue` command.
 Each `SolverBody` and `SolverBodyInertia` associated with awake dynamic and kinematic bodies
 is now stored in a `SolverBodies` resource instead of a component on the entity. The index
 of the solver body associated with a given entity is stored in the `SolverBodyIndex` component.
+
+## Contact Anchor Pivots
+
+`ContactManifold` and `ContactConstraint` have two new public fields,
+`anchor_pivot1` and `anchor_pivot2`. When set, only the part of the contact
+anchors from the body's center of mass to the pivot follows the body's
+rotation when tracking contact separation during substeps. This is used for
+rotationally symmetric shapes like circles and spheres to keep fast-spinning
+rolling bodies from sinking into the ground.
+
+If you construct these types manually, set the fields to `None` to keep
+the previous behavior of treating the full anchors as material points.

--- a/src/collision/collider/parry/contact_query.rs
+++ b/src/collision/collider/parry/contact_query.rs
@@ -173,6 +173,13 @@ pub fn contact_manifolds(
     let isometry2 = make_pose(position2, rotation2);
     let isometry12 = isometry1.inv_mul(&isometry2);
 
+    // Balls get an anchor pivot at the shape's center, which is zero here since
+    // the anchors computed below are relative to it. The narrow phase adds the
+    // offset from the body's center of mass when adjusting the anchors.
+    // See `ContactManifold::anchor_pivot1` for details.
+    let anchor_pivot1 = collider1.shape_scaled().as_ball().map(|_| Vector::ZERO);
+    let anchor_pivot2 = collider2.shape_scaled().as_ball().map(|_| Vector::ZERO);
+
     // TODO: Reuse manifolds from previous frame to improve performance
     let mut new_manifolds =
         Vec::<parry::query::ContactManifold<(), ()>>::with_capacity(manifolds.len());
@@ -223,7 +230,10 @@ pub fn contact_manifolds(
             -contact.dist.f32(),
         )];
 
-        manifolds.push(ContactManifold::new(points, normal));
+        let mut manifold = ContactManifold::new(points, normal);
+        manifold.anchor_pivot1 = anchor_pivot1;
+        manifold.anchor_pivot2 = anchor_pivot2;
+        manifolds.push(manifold);
     }
 
     manifolds.extend(new_manifolds.iter().filter_map(|manifold| {
@@ -252,7 +262,9 @@ pub fn contact_manifolds(
                 .with_feature_ids(contact.fid1.into(), contact.fid2.into())
         });
 
-        let manifold = ContactManifold::new(points, normal);
+        let mut manifold = ContactManifold::new(points, normal);
+        manifold.anchor_pivot1 = anchor_pivot1;
+        manifold.anchor_pivot2 = anchor_pivot2;
 
         Some(manifold)
     }));

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -384,6 +384,22 @@ pub struct ContactManifold {
     /// such as conveyor belts.
     #[cfg(feature = "3d")]
     pub tangent_velocity: Vector,
+    /// An optional pivot for the contact anchors on the first shape, relative to the
+    /// body's center of mass. When tracking contact separation during substeps, only
+    /// the part of each anchor from the center of mass to the pivot follows the body's
+    /// rotation; the part from the pivot to the contact point does not.
+    ///
+    /// This is used for shapes that are rotationally symmetric about their center,
+    /// such as circles and spheres, with the pivot at the shape's center. Their contact
+    /// point does not follow the shape's own rotation, and treating the full anchor as
+    /// a material point makes fast-spinning rolling bodies sink into the ground.
+    ///
+    /// Defaults to `None`, meaning that the full anchors follow the body's rotation.
+    pub anchor_pivot1: Option<Vector>,
+    /// Same as [`anchor_pivot1`](Self::anchor_pivot1), but for the second shape.
+    ///
+    /// Defaults to `None`.
+    pub anchor_pivot2: Option<Vector>,
 }
 
 impl ContactManifold {
@@ -405,6 +421,8 @@ impl ContactManifold {
             tangent_speed: 0.0,
             #[cfg(feature = "3d")]
             tangent_velocity: Vector::ZERO,
+            anchor_pivot1: None,
+            anchor_pivot2: None,
         }
     }
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -825,6 +825,17 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                     let normal = manifold.normal;
 
+                    // The anchors are transformed to be relative to the centers of mass
+                    // of the bodies below. The anchor pivots get the same treatment,
+                    // as the offset from the center of mass to the shape follows
+                    // the body's rotation.
+                    if let Some(pivot) = &mut manifold.anchor_pivot1 {
+                        *pivot += collider_offset1 - world_com1;
+                    }
+                    if let Some(pivot) = &mut manifold.anchor_pivot2 {
+                        *pivot += collider_offset2 - world_com2;
+                    }
+
                     // Transform and prune contact points.
                     manifold.retain_points_mut(|point| {
                         // Transform contact points to be relative to the centers of mass of the bodies.

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -99,6 +99,10 @@ pub struct ContactConstraint {
     pub contact_id: ContactId,
     /// The index of the contact manifold in the [`ContactPair`].
     pub manifold_index: usize,
+    /// See [`ContactManifold::anchor_pivot1`].
+    pub anchor_pivot1: Option<Vector>,
+    /// See [`ContactManifold::anchor_pivot2`].
+    pub anchor_pivot2: Option<Vector>,
 }
 
 impl ContactConstraint {
@@ -207,6 +211,8 @@ impl ContactConstraint {
             points,
             contact_id,
             manifold_index,
+            anchor_pivot1: manifold.anchor_pivot1,
+            anchor_pivot2: manifold.anchor_pivot2,
         }
     }
 
@@ -273,8 +279,17 @@ impl ContactConstraint {
 
         // Normal impulses
         for point in self.points.iter_mut() {
-            let r1 = body1.delta_rotation * point.anchor1;
-            let r2 = body2.delta_rotation * point.anchor2;
+            // If an anchor pivot is set, only the part of the anchor from the center
+            // of mass to the pivot follows the body's rotation.
+            // See `ContactManifold::anchor_pivot1`.
+            let r1 = match self.anchor_pivot1 {
+                None => body1.delta_rotation * point.anchor1,
+                Some(pivot) => body1.delta_rotation * pivot + (point.anchor1 - pivot),
+            };
+            let r2 = match self.anchor_pivot2 {
+                None => body2.delta_rotation * point.anchor2,
+                Some(pivot) => body2.delta_rotation * pivot + (point.anchor2 - pivot),
+            };
 
             // Compute current separation.
             let delta_separation = delta_translation + (r2 - r1);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -213,3 +213,72 @@ fn no_ambiguity_errors() {
     .finish();
     app.update();
 }
+
+#[test]
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+// Casts are needed so that the test works with both the `f32` and `f64` features.
+#[allow(clippy::unnecessary_cast)]
+fn fast_rolling_ball_does_not_sink() {
+    // A small, fast-rolling ball spins by a large angle each time step.
+    // Its contact anchor used to be treated as a material point following the
+    // body's rotation when tracking contact separation during substeps, which
+    // made the solver believe the contact was separating and let the ball sink
+    // deep into the ground (over half its radius at 125 rad/s and 60 Hz).
+    use crate::math::Real;
+
+    let mut app = create_app();
+
+    const RADIUS: f32 = 0.008; // a marble-sized ball
+    const SPEED: f32 = 1.0;
+
+    app.add_systems(Startup, |mut commands: Commands| {
+        // Long static floor with its top surface at y = 0.
+        commands.spawn((
+            RigidBody::Static,
+            #[cfg(feature = "2d")]
+            Collider::rectangle(20.0, 0.1),
+            #[cfg(feature = "3d")]
+            Collider::cuboid(20.0, 0.1, 1.0),
+            Transform::from_xyz(9.0, -0.05, 0.0),
+        ));
+        // Ball resting on the floor, rolling to the right without slipping.
+        commands.spawn((
+            RigidBody::Dynamic,
+            #[cfg(feature = "2d")]
+            Collider::circle(RADIUS),
+            #[cfg(feature = "3d")]
+            Collider::sphere(RADIUS),
+            Transform::from_xyz(0.0, RADIUS, 0.0),
+            LinearVelocity(Vector::X * SPEED),
+            #[cfg(feature = "2d")]
+            AngularVelocity(-SPEED / RADIUS),
+            #[cfg(feature = "3d")]
+            AngularVelocity(Vector::Z * (-SPEED / RADIUS)),
+        ));
+    });
+
+    // Run startup systems
+    app.update();
+
+    // Roll for five seconds.
+    for _ in 0..300 {
+        tick_app(&mut app, 1.0 / 60.0);
+    }
+
+    let mut query = app.world_mut().query::<(&Position, &RigidBody)>();
+    let (position, _) = query
+        .iter(app.world())
+        .find(|(_, rb)| rb.is_dynamic())
+        .unwrap();
+
+    // The ball should still ride on the surface at approximately y = radius.
+    let depth = RADIUS as Real - position.y;
+    assert!(
+        depth < 0.05 * RADIUS as Real,
+        "rolling ball sank into the ground: ride depth {depth} is {:.1}% of its radius",
+        depth / RADIUS as Real * 100.0
+    );
+}


### PR DESCRIPTION
# Objective

A fast-rolling ball sinks into the ground: a 16 mm marble at 1 m/s rides 55% of its radius deep at 60 Hz. The substep separation update rotates contact anchors as material points, but a ball's contact point does not follow its own rotation. At ~2 rad of spin per step the solver thinks the contact is separating and under-supports the ball.

Even at lower speeds this causes serious ghost bumps.

## Solution

Split the ball-side anchor: only the COM-to-center part rotates, the center-to-contact part stays fixed. Stored as `anchor_pivot1/2: Option<Vector>` on `ContactManifold`/`ContactConstraint`; `None` = old behavior.

- AI disclosure: Used fore debugging my game, creating a reproducer app, help writing the fix
- Migration guide: two new public fields.

## Future work

The same error affects any rotationally symmetric shape rolling on its curved surface, e.g. a capsule or cylinder on its side. Those are only symmetric about one axis, so only the spin about that axis can be excluded, and each contact point needs its own pivot (the closest point on the inner segment) instead of the single per-manifold pivot added here. Since severity scales with spin per substep, fast-spinning balls are by far the worst case; the rest can be a follow-up if the need shows up.

## Testing

- New test `fast_rolling_ball_does_not_sink` (2D + 3D): 48% ride depth without the fix, <5% with it.
- Full suite green with the CI feature set; determinism hash unchanged.
- Ride depth, 0.008 m ball at 1 m/s:

  | tick rate | before | after |
  |-----------|--------|-------|
  | 30 Hz     | 98%    | 1.6%  |
  | 60 Hz     | 54.7%  | 0.5%  |
  | 240 Hz    | 3.5%   | 0.2%  |

---

## Showcase

### Before

<img width="2143" height="1216" alt="image" src="https://github.com/user-attachments/assets/5a438139-979f-401d-b82d-60357fa0dd95" />

### After

<img width="2143" height="1209" alt="image" src="https://github.com/user-attachments/assets/a087c707-9b81-40a5-9653-659ee1d423e0" />

Fixes #1056 
