### PR TITLE
Fix rigid body and collider cloning

### DIFF
--- a/src/collider_tree/proxy_key.rs
+++ b/src/collider_tree/proxy_key.rs
@@ -1,6 +1,12 @@
 use core::hint::unreachable_unchecked;
 
-use bevy::{ecs::component::Component, reflect::Reflect};
+use bevy::{
+    ecs::{
+        component::Component,
+        entity::{ComponentCloneCtx, SourceComponent},
+    },
+    reflect::Reflect,
+};
 
 use crate::prelude::RigidBody;
 
@@ -12,7 +18,13 @@ use crate::prelude::RigidBody;
 ///
 /// [`ColliderTree`]: crate::collider_tree::ColliderTree
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash, Reflect)]
+#[component(clone_behavior = Custom(clone_placeholder_proxy_key))]
 pub struct ColliderTreeProxyKey(u32);
+
+// Avoid aliasing keys when cloning colliders
+fn clone_placeholder_proxy_key(_source: &SourceComponent, ctx: &mut ComponentCloneCtx) {
+    ctx.write_target_component(ColliderTreeProxyKey::PLACEHOLDER);
+}
 
 impl ColliderTreeProxyKey {
     /// A placeholder proxy key used before the proxy is actually created.

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -46,7 +46,12 @@ mod sleeping;
 pub use sleeping::{IslandSleepingPlugin, SleepBody, SleepIslands, WakeBody, WakeIslands};
 
 use bevy::{
-    ecs::{entity_disabling::Disabled, lifecycle::HookContext, world::DeferredWorld},
+    ecs::{
+        entity::{ComponentCloneCtx, SourceComponent},
+        entity_disabling::Disabled,
+        lifecycle::HookContext,
+        world::DeferredWorld,
+    },
     prelude::*,
 };
 
@@ -1309,8 +1314,17 @@ impl<Id: Copy> Copy for IslandNode<Id> {}
 /// A component that stores [`PhysicsIsland`] connectivity data for a rigid body.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, PartialEq, Eq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[component(on_add = BodyIslandNode::on_add, on_remove = BodyIslandNode::on_remove)]
+#[component(
+    on_add = BodyIslandNode::on_add,
+    on_remove = BodyIslandNode::on_remove,
+    clone_behavior = Custom(clone_placeholder_body_island_node),
+)]
 pub struct BodyIslandNode(IslandNode<Entity>);
+
+// Avoid incorrect prev/next links when cloning a rigid body
+fn clone_placeholder_body_island_node(_source: &SourceComponent, ctx: &mut ComponentCloneCtx) {
+    ctx.write_target_component(BodyIslandNode::default());
+}
 
 impl BodyIslandNode {
     /// Creates a new [`BodyIslandNode`] with the given island ID.


### PR DESCRIPTION
# Objective

Fixes #1013.

There's a few components that contain unique IDs or other info that should not be cloned directly, but rather should be created fresh, or things will crash or break. This currently breaks entity cloning.

## Solution

Change the clone behavior of these components.

## Testing

Ran the repro in #1013.