### PR TITLE
Fix Gravity doc example indentation

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -135,11 +135,11 @@ pub type IntegrationSet = IntegrationSystems;
 ///         .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
 #[cfg_attr(
     feature = "2d",
-    doc = "         .insert_resource(Gravity(Vec2::NEG_Y * 100.0))"
+    doc = "        .insert_resource(Gravity(Vec2::NEG_Y * 100.0))"
 )]
 #[cfg_attr(
     feature = "3d",
-    doc = "         .insert_resource(Gravity(Vec3::NEG_Y * 19.6))"
+    doc = "        .insert_resource(Gravity(Vec3::NEG_Y * 19.6))"
 )]
 ///         .run();
 /// }


### PR DESCRIPTION
# Objective

<!--
Before you contribute, make sure you review our AI policy!
https://github.com/avianphysics/avian/blob/main/AI_POLICY.md
-->

Fix stray leading space in Gravity doc example: [Gravity - avian2d](https://docs.rs/avian2d/0.7.0/avian2d/dynamics/integrator/struct.Gravity.html#example) and [Gravity - avian3d](https://docs.rs/avian3d/0.7.0/avian3d/dynamics/integrator/struct.Gravity.html#example).

## Solution

Removed the extra space in the docs for 2d and 3d.

<!--
Note: If your PR contains breaking changes relative to the latest release,
      remember to add a migration guide! See `migration-guides/README.md`.
-->

## Testing

Built the docs and ran the doc tests locally.

---

## Showcase

<details>
  <summary>Before</summary>

  <img width="666" height="244" alt="beforeter" src="https://github.com/user-attachments/assets/83a07771-c639-4279-ac06-efea267a23f6" />
</details>

<details>
  <summary>After</summary>

  <img width="666" height="244" alt="after" src="https://github.com/user-attachments/assets/09db08ab-e4c2-4ca1-bdef-87f47062ff72" />
</details>
