### PR TITLE
Fix non-touching contacts not moving to sleeping set

### DIFF
--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -96,6 +96,14 @@ pub struct ContactGraph {
 
     /// A map from entities to their corresponding node indices in the contact graph.
     entity_to_node: SparseSecondaryEntityMap<NodeIndex>,
+
+    /// A reusable scratch buffer of contact IDs used when transferring contacts
+    /// between the active and sleeping sets, to avoid allocating on every call
+    /// to [`sleep_entity_with`] and [`wake_entity_with`].
+    ///
+    /// [`sleep_entity_with`]: Self::sleep_entity_with
+    /// [`wake_entity_with`]: Self::wake_entity_with
+    scratch_contact_ids: Vec<ContactId>,
 }
 
 /// An undirected graph where each node is an entity and each edge is a [`ContactEdge`].
@@ -704,7 +712,7 @@ impl ContactGraph {
         }
     }
 
-    /// Transfers touching contacts of a body from the sleeping contacts to the active contacts,
+    /// Transfers the contacts of a body from the sleeping contacts to the active contacts,
     /// calling the given callback for each [`ContactPair`] that is moved to active contacts.
     #[inline]
     pub fn wake_entity_with<F>(&mut self, entity: Entity, mut pair_callback: F)
@@ -717,23 +725,19 @@ impl ContactGraph {
         };
 
         // Find all edges connected to the entity.
-        let contact_ids: Vec<ContactId> = self
-            .edges
-            .edge_weights(index)
-            .filter_map(|edge| edge.is_sleeping().then_some(edge.id))
-            .collect();
+        let mut contact_ids = core::mem::take(&mut self.scratch_contact_ids);
+        contact_ids.extend(
+            self.edges
+                .edge_weights(index)
+                .filter_map(|edge| edge.is_sleeping().then_some(edge.id)),
+        );
 
         // Iterate over the edges and move sleeping contacts to active contacts.
-        for id in contact_ids {
+        for &id in &contact_ids {
             let edge = self
                 .edges
                 .edge_weight_mut(id.into())
                 .expect("edge should exist");
-
-            if !edge.is_touching() {
-                // Only wake touching contacts.
-                continue;
-            }
 
             let pair_index = edge.pair_index;
 
@@ -765,14 +769,23 @@ impl ContactGraph {
                 moved_edge.pair_index = pair_index;
             }
         }
+
+        // Restore the scratch buffer.
+        contact_ids.clear();
+        self.scratch_contact_ids = contact_ids;
     }
 
-    /// Transfers touching contacts of a body from the active contacts to the sleeping contacts,
+    /// Transfers the contacts of a body from the active contacts to the sleeping contacts,
     /// calling the given callback for each [`ContactPair`] that is moved to sleeping contacts.
+    ///
+    /// A contact is only moved to the sleeping set if `should_sleep` returns `true` for the
+    /// other body in the pair. This prevents a non-touching pair between this body and a still-awake
+    /// body from being put to sleep. A pair may sleep only once *both* of its bodies are asleep or immovable.
     #[inline]
-    pub fn sleep_entity_with<F>(&mut self, entity: Entity, mut pair_callback: F)
+    pub fn sleep_entity_with<F, S>(&mut self, entity: Entity, mut pair_callback: F, should_sleep: S)
     where
         F: FnMut(&mut ContactGraph, &ContactPair),
+        S: Fn(Option<Entity>) -> bool,
     {
         // Get the index of the entity in the graph.
         let Some(index) = self.entity_to_node(entity) else {
@@ -780,21 +793,28 @@ impl ContactGraph {
         };
 
         // Find all edges connected to the entity.
-        let contact_ids: Vec<ContactId> = self
-            .edges
-            .edge_weights(index)
-            .filter_map(|edge| (!edge.is_sleeping()).then_some(edge.id))
-            .collect();
+        let mut contact_ids = core::mem::take(&mut self.scratch_contact_ids);
+        contact_ids.extend(
+            self.edges
+                .edge_weights(index)
+                .filter_map(|edge| (!edge.is_sleeping()).then_some(edge.id)),
+        );
 
         // Iterate over the edges and move active contacts to sleeping contacts.
-        for id in contact_ids {
+        for &id in &contact_ids {
             let edge = self
                 .edges
                 .edge_weight_mut(id.into())
                 .expect("edge should exist");
 
-            if !edge.is_touching() {
-                // Only sleep touching contacts.
+            // Only sleep the contact if the other body is also asleep or immovable.
+            // Otherwise the pair must stay active so the narrow phase keeps updating it.
+            let other_body = if edge.collider1 == entity {
+                edge.body2
+            } else {
+                edge.body1
+            };
+            if !should_sleep(other_body) {
                 continue;
             }
 
@@ -828,6 +848,10 @@ impl ContactGraph {
                 moved_edge.pair_index = pair_index;
             }
         }
+
+        // Restore the scratch buffer.
+        contact_ids.clear();
+        self.scratch_contact_ids = contact_ids;
     }
 
     /// Clears all contact pairs and the contact graph.

--- a/src/dynamics/solver/islands/sleeping.rs
+++ b/src/dynamics/solver/islands/sleeping.rs
@@ -371,12 +371,14 @@ impl Command for SleepIslands {
                 state.0.get_mut(world).unwrap();
 
             let mut bodies_to_sleep = Vec::<(Entity, Sleeping)>::new();
+            let mut colliders_to_sleep = Vec::<Entity>::new();
 
+            // First, mark every island in this batch as sleeping and gather their bodies and colliders.
             for island_id in self.0 {
                 if let Some(island) = islands.get_mut(island_id) {
                     if island.is_sleeping {
                         // The island is already sleeping, no need to sleep it again.
-                        return;
+                        continue;
                     }
 
                     island.is_sleeping = true;
@@ -389,36 +391,46 @@ impl Command for SleepIslands {
                             continue;
                         };
 
-                        // Transfer the contact pairs to the sleeping set, and remove the body from the constraint graph.
                         if let Some(colliders) = colliders {
-                            for collider in colliders {
-                                contact_graph.sleep_entity_with(
-                                    collider,
-                                    |_graph, contact_pair| {
-                                        // Remove touching contacts from the constraint graph.
-                                        if !contact_pair.is_touching()
-                                            || !contact_pair.generates_constraints()
-                                        {
-                                            return;
-                                        }
-                                        if let (Some(body1), Some(body2)) =
-                                            (contact_pair.body1, contact_pair.body2)
-                                        {
-                                            constraint_graph.remove_contact(
-                                                contact_pair.contact_id,
-                                                body1,
-                                                body2,
-                                            );
-                                        }
-                                    },
-                                );
-                            }
+                            colliders_to_sleep.extend(colliders);
                         }
 
                         bodies_to_sleep.push((entity, Sleeping));
                         body = body_island.next;
                     }
                 }
+            }
+
+            // A pair may only be put to sleep once its other body is also asleep or immovable.
+            let is_other_body_asleep = |other_body: Option<Entity>| -> bool {
+                let Some(other) = other_body else {
+                    return true;
+                };
+                match bodies.get(other) {
+                    Ok((body_island, _, _)) => islands
+                        .get(body_island.island_id)
+                        .is_none_or(|island| island.is_sleeping),
+                    Err(_) => true,
+                }
+            };
+
+            // Transfer the contact pairs to the sleeping set, and remove touching contacts
+            // from the constraint graph.
+            for collider in colliders_to_sleep {
+                contact_graph.sleep_entity_with(
+                    collider,
+                    |_graph, contact_pair| {
+                        // Remove touching contacts from the constraint graph.
+                        if !contact_pair.is_touching() || !contact_pair.generates_constraints() {
+                            return;
+                        }
+                        if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2)
+                        {
+                            constraint_graph.remove_contact(contact_pair.contact_id, body1, body2);
+                        }
+                    },
+                    is_other_body_asleep,
+                );
             }
 
             // Batch insert `Sleeping` to the bodies.


### PR DESCRIPTION
# Objective

Currently, the narrow phase still updates non-touching contacts of sleeping bodies, because they are never moved to the sleeping set. This results in a lot of extra work for large scenes!

## Solution

Refactor `wake_entity_with` and `sleep_entity_with` to also transfer non-touching contacts. Also added a scratch buffer for contact IDs to avoid repeated allocations when waking/sleeping islands.

Note that Box2D handles this slightly differently with a third "disabled" set, but I think our approach is a bit simpler and functionally equivalent.