### PR TITLE
Contact Recycling

### DIFF
--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -164,8 +164,22 @@ pub struct ContactPair {
     ///
     /// The speculative distance is reset to zero each timestep.
     pub speculative_distance: f32,
+    /// A cache of data used for recycling contacts across timesteps.
+    pub recycling_cache: Option<ContactRecyclingCache>,
     /// Flag indicating the status and type of the contact pair.
     pub flags: ContactPairFlags,
+}
+
+/// A cache of data used for recycling contacts across timesteps.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct ContactRecyclingCache {
+    /// The cached rotation of the first collider from the previous timestep.
+    pub rotation1: Rot,
+    /// The cached rotation of the second collider from the previous timestep.
+    pub rotation2: Rot,
+    /// The cached relative pose of the two colliders from the previous timestep.
+    pub relative_pose: Isometry,
 }
 
 /// Flags indicating the status and type of a [contact pair](ContactPair).
@@ -212,6 +226,7 @@ impl ContactPair {
             manifolds: Vec::new(),
             manifold_count_change: 0,
             speculative_distance: 0.0,
+            recycling_cache: None,
             flags: ContactPairFlags::empty(),
         }
     }
@@ -606,6 +621,13 @@ pub struct ContactPoint {
     ///
     /// [speculative collision]: crate::dynamics::ccd#speculative-collision
     pub penetration: f32,
+    /// The original penetration depth computed by the narrow phase.
+    ///
+    /// The current [`penetration`](Self::penetration) may be updated by contact recycling
+    /// without computing the full contact manifolds again. The base penetration is stored
+    /// as a reference so that the updated penetration can be computed using the relative
+    /// motion of the two colliders.
+    pub base_penetration: f32,
     /// The total normal impulse applied to the first body at this contact point.
     /// The unit is typically N⋅s or kg⋅m/s.
     ///
@@ -660,6 +682,7 @@ impl ContactPoint {
             anchor2,
             point: world_point,
             penetration,
+            base_penetration: penetration,
             normal_impulse: 0.0,
             normal_speed: 0.0,
             warm_start_normal_impulse: 0.0,
@@ -700,6 +723,7 @@ impl ContactPoint {
             anchor2: self.anchor1,
             point: self.point,
             penetration: self.penetration,
+            base_penetration: self.base_penetration,
             normal_impulse: -self.normal_impulse,
             normal_speed: self.normal_speed,
             warm_start_normal_impulse: -self.warm_start_normal_impulse,

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -178,8 +178,10 @@ pub struct ContactRecyclingCache {
     pub rotation1: Rot,
     /// The cached rotation of the second collider from the previous timestep.
     pub rotation2: Rot,
-    /// The cached relative pose of the two colliders from the previous timestep.
-    pub relative_pose: Isometry,
+    /// The cached relative translation of the two colliders from the previous timestep.
+    pub relative_translation: Vector,
+    /// The cached relative rotation of the two colliders from the previous timestep.
+    pub relative_rotation: Rot,
 }
 
 /// Flags indicating the status and type of a [contact pair](ContactPair).

--- a/src/collision/diagnostics.rs
+++ b/src/collision/diagnostics.rs
@@ -17,6 +17,8 @@ pub struct CollisionDiagnostics {
     pub narrow_phase: Duration,
     /// The number of contacts.
     pub contact_count: u32,
+    /// The number of contacts that were recycled from the previous timestep.
+    pub recycled_count: u32,
 }
 
 impl PhysicsDiagnostics for CollisionDiagnostics {
@@ -28,7 +30,10 @@ impl PhysicsDiagnostics for CollisionDiagnostics {
     }
 
     fn counter_paths(&self) -> Vec<(&'static DiagnosticPath, u32)> {
-        vec![(Self::CONTACT_COUNT, self.contact_count)]
+        vec![
+            (Self::CONTACT_COUNT, self.contact_count),
+            (Self::RECYCLED_COUNT, self.recycled_count),
+        ]
     }
 }
 
@@ -37,5 +42,6 @@ impl_diagnostic_paths! {
         BROAD_PHASE: "avian/collision/broad_phase",
         NARROW_PHASE: "avian/collision/update_contacts",
         CONTACT_COUNT: "avian/collision/contact_count",
+        RECYCLED_COUNT: "avian/collision/recycled_count",
     }
 }

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -187,6 +187,25 @@ pub struct NarrowPhaseConfig {
     /// Default: `0.02`
     pub contact_tolerance: f32,
 
+    /// The distance at which contact points can be recycled from the previous frame
+    /// to the current frame.
+    ///
+    /// Setting this to zero will disable contact recycling.
+    ///
+    /// This is implicitly scaled by the [`PhysicsLengthUnit`].
+    ///
+    /// Default: `0.05`
+    pub recycle_distance: f32,
+
+    /// The cosine of the angle between the previous contact normal and the current contact normal
+    /// at which contact points can be recycled from the previous frame to the current frame.
+    ///
+    /// This is a value between `-1.0` and `1.0`, where `1.0` means the normals are identical,
+    /// and `-1.0` means the normals are opposite.
+    ///
+    /// Default: `0.98` (approximately 11.5 degrees)
+    pub recycle_angle_cos: f32,
+
     /// If `true`, the current contacts will be matched with the previous contacts
     /// based on feature IDs or contact positions, and the contact impulses from
     /// the previous frame will be copied over for the new contacts.
@@ -203,6 +222,8 @@ impl Default for NarrowPhaseConfig {
         Self {
             // TODO: Investigate if this could be smaller
             contact_tolerance: 0.02,
+            recycle_distance: 0.05,
+            recycle_angle_cos: 0.98,
             match_contacts: true,
         }
     }

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -197,14 +197,12 @@ pub struct NarrowPhaseConfig {
     /// Default: `0.05`
     pub recycle_distance: f32,
 
-    /// The cosine of the angle between the previous contact normal and the current contact normal
+    /// The angle (in radians) between the previous contact normal and the current contact normal
     /// at which contact points can be recycled from the previous frame to the current frame.
     ///
-    /// This is a value between `-1.0` and `1.0`, where `1.0` means the normals are identical,
-    /// and `-1.0` means the normals are opposite.
-    ///
-    /// Default: `0.98` (approximately 11.5 degrees)
-    pub recycle_angle_cos: f32,
+    #[cfg_attr(feature = "2d", doc = "Default: `0.2` (approximately 11.5 degrees)")]
+    #[cfg_attr(feature = "3d", doc = "Default: 0.175 (approximately 10 degrees)")]
+    pub recycle_angle: f32,
 
     /// If `true`, the current contacts will be matched with the previous contacts
     /// based on feature IDs or contact positions, and the contact impulses from
@@ -223,7 +221,11 @@ impl Default for NarrowPhaseConfig {
             // TODO: Investigate if this could be smaller
             contact_tolerance: 0.02,
             recycle_distance: 0.05,
-            recycle_angle_cos: 0.98,
+            // NOTE: These defaults are from Box2D and Box3D
+            #[cfg(feature = "2d")]
+            recycle_angle: 0.2,
+            #[cfg(feature = "3d")]
+            recycle_angle: 0.175,
             match_contacts: true,
         }
     }

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -9,6 +9,8 @@ use crate::{
     data_structures::{bit_vec::BitVec, pair_key::PairKey},
     prelude::*,
 };
+#[cfg(feature = "3d")]
+use bevy::math::ops::FloatPow;
 use bevy::{
     ecs::{
         query::QueryData,
@@ -382,6 +384,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         let contact_tolerance = length_unit * self.config.contact_tolerance;
         let recycle_distance = length_unit * self.config.recycle_distance;
         let recycle_distance_non_touching = recycle_distance.min(contact_tolerance);
+        #[cfg(feature = "2d")]
+        let recycle_angle_cos = ops::cos(self.config.recycle_angle);
+        #[cfg(feature = "3d")]
+        let recycle_angular_distance = ops::cos(self.config.recycle_angle * 0.5).squared();
         let inv_delta_secs = delta_secs.recip();
 
         // Contact bit vecs must be sized based on the full contact capacity,
@@ -554,9 +560,17 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // This is inspired by persistent contact manifolds used in some physics engines,
                 // but allows larger relative motion, and has fewer tuning parameters (distance and angle).
                 // This has a huge impact on the performance and stability of stacks and resting bodies.
-                if recycle_distance > 0.0
-                    && let Some(cache) = contacts.recycling_cache.as_ref()
-                {
+                'recycle: {
+                    if recycle_distance <= 0.0 {
+                        // Recycling is disabled.
+                        break 'recycle;
+                    }
+
+                    let Some(cache) = contacts.recycling_cache.as_ref() else {
+                        // No previous contact data to recycle.
+                        break 'recycle;
+                    };
+
                     #[cfg(feature = "2d")]
                     {
                         let cos1 = body_rot1.cos * cache.rotation1.cos
@@ -564,55 +578,98 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                         let cos2 = body_rot2.cos * cache.rotation2.cos
                             + body_rot2.sin * cache.rotation2.sin;
                         let min_cos = cos1.min(cos2);
-
-                        let sweep_radius1 = if is_static1 {
-                            0.0
-                        } else {
-                            size_metrics1.sweep_radius
-                        };
-                        let sweep_radius2 = if is_static2 {
-                            0.0
-                        } else {
-                            size_metrics2.sweep_radius
-                        };
-                        let max_extent = sweep_radius1.max(sweep_radius2);
-                        let distance = pos12_1.distance(cache.relative_pose.translation);
-                        let delta_rotation = rot12_1.inverse() * cache.relative_pose.rotation;
-
-                        let tolerance = if was_touching {
-                            recycle_distance
-                        } else {
-                            recycle_distance_non_touching
-                        };
-
-                        if min_cos > self.config.recycle_angle_cos
-                            && distance + max_extent * delta_rotation.sin.abs() < tolerance
-                        {
-                            let delta_rot1 = body_rot1 * cache.rotation1.inverse();
-                            let delta_rot2 = body_rot2 * cache.rotation2.inverse();
-                            let com12 = world_com2 - world_com1 + pos12;
-
-                            contacts.manifolds.iter_mut().for_each(|manifold| {
-                                manifold.points.iter_mut().for_each(|point| {
-                                    // Keep anchors but update separation. This eliminates jitter.
-                                    let r1 = delta_rot1 * point.anchor1;
-                                    let r2 = delta_rot2 * point.anchor2;
-                                    let delta_separation = com12 + (r2 - r1);
-                                    point.penetration = point.base_penetration
-                                        - delta_separation.dot(manifold.normal);
-                                });
-                            });
-
-                            return;
+                        if min_cos <= recycle_angle_cos {
+                            // The relative rotation has changed too much.
+                            break 'recycle;
                         }
                     }
+                    #[cfg(feature = "3d")]
+                    {
+                        let angle1 = body_rot1.dot(cache.rotation1);
+                        let angle2 = body_rot2.dot(cache.rotation2);
+                        let min_angle = (angle1 * angle1).min(angle2 * angle2);
+                        if min_angle <= recycle_angular_distance {
+                            // The relative rotation has changed too much.
+                            break 'recycle;
+                        }
+                    }
+
+                    let sweep_radius1 = if is_static1 {
+                        0.0
+                    } else {
+                        size_metrics1.sweep_radius
+                    };
+                    let sweep_radius2 = if is_static2 {
+                        0.0
+                    } else {
+                        size_metrics2.sweep_radius
+                    };
+                    let max_extent = sweep_radius1.max(sweep_radius2);
+                    let distance_squared = pos12_1.distance_squared(cache.relative_translation);
+
+                    let tolerance = if was_touching {
+                        recycle_distance
+                    } else {
+                        recycle_distance_non_touching
+                    };
+
+                    #[cfg(feature = "2d")]
+                    {
+                        let distance = distance_squared.sqrt();
+                        let delta_rotation = rot12_1.inverse() * cache.relative_rotation;
+                        if distance + max_extent * delta_rotation.sin.abs() >= tolerance {
+                            // The relative motion is too large.
+                            break 'recycle;
+                        }
+                    }
+                    #[cfg(feature = "3d")]
+                    {
+                        if distance_squared >= tolerance * tolerance {
+                            // The relative motion is too large.
+                            break 'recycle;
+                        } else {
+                            // Check the maximum motion along the arc of the relative rotation.
+                            let distance = distance_squared.sqrt();
+                            let slack = tolerance - distance;
+                            let delta_rotation = cache.relative_rotation.inverse() * rot12_1;
+                            // TODO: Use a Vec3 max_extent and a symmetric cross product
+                            let arc = delta_rotation.chord_length() * max_extent;
+                            if arc >= slack {
+                                // The relative motion is too large.
+                                break 'recycle;
+                            }
+                        }
+                    }
+
+                    // The relative motion is small enough for contact recycling!
+                    let delta_rot1 = body_rot1 * cache.rotation1.inverse();
+                    let delta_rot2 = body_rot2 * cache.rotation2.inverse();
+                    #[cfg(feature = "3d")]
+                    let delta_rot1 = Mat3::from_quat(delta_rot1);
+                    #[cfg(feature = "3d")]
+                    let delta_rot2 = Mat3::from_quat(delta_rot2);
+                    let com12 = world_com2 - world_com1 + pos12;
+
+                    contacts.manifolds.iter_mut().for_each(|manifold| {
+                        manifold.points.iter_mut().for_each(|point| {
+                            // Keep anchors but update separation. This eliminates jitter.
+                            let r1 = delta_rot1 * point.anchor1;
+                            let r2 = delta_rot2 * point.anchor2;
+                            let delta_separation = com12 + (r2 - r1);
+                            point.penetration =
+                                point.base_penetration - delta_separation.dot(manifold.normal);
+                        });
+                    });
+
+                    return;
                 }
 
                 // Update the recycling cache for the next frame.
                 contacts.recycling_cache = Some(ContactRecyclingCache {
                     rotation1: body_rot1,
                     rotation2: body_rot2,
-                    relative_pose: Isometry::new(pos12_1, rot12_1),
+                    relative_translation: pos12_1,
+                    relative_rotation: rot12_1,
                 });
 
                 // If either collider is a sensor or either body is disabled, no constraints should be generated.

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -4,7 +4,7 @@ use core::cell::RefCell;
 use crate::{
     collision::{
         collider::EnlargedAabb,
-        contact_types::{ContactEdgeFlags, ContactId},
+        contact_types::{ContactEdgeFlags, ContactId, ContactRecyclingCache},
     },
     data_structures::{bit_vec::BitVec, pair_key::PairKey},
     prelude::*,
@@ -49,6 +49,7 @@ struct RigidBodyQuery {
     restitution: Option<Read<Restitution>>,
     collision_margin: Option<Read<CollisionMargin>>,
     speculative_ccd: Option<Read<SpeculativeCcd>>,
+    size_metrics: Read<BodySizeMetrics>,
 }
 
 /// A system parameter for managing the narrow phase.
@@ -379,6 +380,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     {
         let length_unit = self.length_unit.0;
         let contact_tolerance = length_unit * self.config.contact_tolerance;
+        let recycle_distance = length_unit * self.config.recycle_distance;
+        let recycle_distance_non_touching = recycle_distance.min(contact_tolerance);
         let inv_delta_secs = delta_secs.recip();
 
         // Contact bit vecs must be sized based on the full contact capacity,
@@ -464,6 +467,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
             } else {
                 // The AABBs overlap. Compute contacts.
 
+                let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
+
                 let body1_bundle = collider1
                     .of
                     .and_then(|&ColliderOf { body }| self.body_query.get(body).ok());
@@ -477,11 +482,14 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     is_static1,
                     collider_offset1,
                     world_com1,
+                    body_pos1,
+                    body_rot1,
                     lin_vel1,
                     ang_vel1,
                     rb_friction1,
                     rb_collision_margin1,
                     speculative_ccd1,
+                    size_metrics1,
                 ) = body1_bundle
                     .as_ref()
                     .map(|body| {
@@ -489,11 +497,14 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.rb.is_static(),
                             (collider1.position.0 - body.position.0).f32(),
                             body.rotation * body.center_of_mass.0,
+                            body.position.0,
+                            Rot::from(*body.rotation),
                             body.linear_velocity.0,
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
                             body.speculative_ccd.copied(),
+                            *body.size_metrics,
                         )
                     })
                     .unwrap_or_default();
@@ -501,11 +512,14 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     is_static2,
                     collider_offset2,
                     world_com2,
+                    body_pos2,
+                    body_rot2,
                     lin_vel2,
                     ang_vel2,
                     rb_friction2,
                     rb_collision_margin2,
                     speculative_ccd2,
+                    size_metrics2,
                 ) = body2_bundle
                     .as_ref()
                     .map(|body| {
@@ -513,11 +527,14 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             body.rb.is_static(),
                             (collider2.position.0 - body.position.0).f32(),
                             body.rotation * body.center_of_mass.0,
+                            body.position.0,
+                            Rot::from(*body.rotation),
                             body.linear_velocity.0,
                             body.angular_velocity.0,
                             body.friction,
                             body.collision_margin,
                             body.speculative_ccd.copied(),
+                            *body.size_metrics,
                         )
                     })
                     .unwrap_or_default();
@@ -526,6 +543,77 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // when processing status changes for the constraint graph.
                 contacts.flags.set(ContactPairFlags::STATIC1, is_static1);
                 contacts.flags.set(ContactPairFlags::STATIC2, is_static2);
+
+                // Compute the relative pose of the bodies in the local space of the first body.
+                let inv_rot1 = body_rot1.inverse();
+                let pos12 = (body_pos2 - body_pos1).f32();
+                let rot12_1 = inv_rot1 * body_rot2;
+                let pos12_1 = inv_rot1 * pos12;
+
+                // Contact recycling optimization, based on Box2D/Box3D by Erin Catto.
+                // This is inspired by persistent contact manifolds used in some physics engines,
+                // but allows larger relative motion, and has fewer tuning parameters (distance and angle).
+                // This has a huge impact on the performance and stability of stacks and resting bodies.
+                if recycle_distance > 0.0
+                    && let Some(cache) = contacts.recycling_cache.as_ref()
+                {
+                    #[cfg(feature = "2d")]
+                    {
+                        let cos1 = body_rot1.cos * cache.rotation1.cos
+                            + body_rot1.sin * cache.rotation1.sin;
+                        let cos2 = body_rot2.cos * cache.rotation2.cos
+                            + body_rot2.sin * cache.rotation2.sin;
+                        let min_cos = cos1.min(cos2);
+
+                        let sweep_radius1 = if is_static1 {
+                            0.0
+                        } else {
+                            size_metrics1.sweep_radius
+                        };
+                        let sweep_radius2 = if is_static2 {
+                            0.0
+                        } else {
+                            size_metrics2.sweep_radius
+                        };
+                        let max_extent = sweep_radius1.max(sweep_radius2);
+                        let distance = pos12_1.distance(cache.relative_pose.translation);
+                        let delta_rotation = rot12_1.inverse() * cache.relative_pose.rotation;
+
+                        let tolerance = if was_touching {
+                            recycle_distance
+                        } else {
+                            recycle_distance_non_touching
+                        };
+
+                        if min_cos > self.config.recycle_angle_cos
+                            && distance + max_extent * delta_rotation.sin.abs() < tolerance
+                        {
+                            let delta_rot1 = body_rot1 * cache.rotation1.inverse();
+                            let delta_rot2 = body_rot2 * cache.rotation2.inverse();
+                            let com12 = world_com2 - world_com1 + pos12;
+
+                            contacts.manifolds.iter_mut().for_each(|manifold| {
+                                manifold.points.iter_mut().for_each(|point| {
+                                    // Keep anchors but update separation. This eliminates jitter.
+                                    let r1 = delta_rot1 * point.anchor1;
+                                    let r2 = delta_rot2 * point.anchor2;
+                                    let delta_separation = com12 + (r2 - r1);
+                                    point.penetration = point.base_penetration
+                                        - delta_separation.dot(manifold.normal);
+                                });
+                            });
+
+                            return;
+                        }
+                    }
+                }
+
+                // Update the recycling cache for the next frame.
+                contacts.recycling_cache = Some(ContactRecyclingCache {
+                    rotation1: body_rot1,
+                    rotation2: body_rot2,
+                    relative_pose: Isometry::new(pos12_1, rot12_1),
+                });
 
                 // If either collider is a sensor or either body is disabled, no constraints should be generated.
                 let is_disabled = body1_bundle.is_none()
@@ -619,8 +707,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // The maximum distance at which contacts are detected.
                 let max_contact_distance = collision_margin_sum + speculative_distance;
 
-                let was_touching = contacts.flags.contains(ContactPairFlags::TOUCHING);
-
                 // Save the old manifolds for warm starting.
                 let old_manifolds = contacts.manifolds.clone();
 
@@ -664,6 +750,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                         // Add the collision margin to the penetration depth.
                         point.penetration += collision_margin_sum;
+
+                        // Store the base penetration depth for contact recycling.
+                        point.base_penetration = point.penetration;
 
                         // Compute the relative velocity along the contact normal.
                         #[cfg(feature = "2d")]

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x2be8edf3;
+    let expected = 0xa1a76fa5;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Earlier this year, Box2D added [contact recycling](https://github.com/erincatto/box2d/pull/1038), which _significantly_ improves contact stability and performance for stacking scenarios and resting contacts, more than any other implementation that I have seen in the past. We should take notes from them and implement contact recycling in Avian too!

## Solution

Implement contact recycling based on the implementation in Box2D/Box3D. Credit for this algorithm goes to Erin Catto :)

---

## Showcase

### Stability

With contact recycling, a 100 cube stack is easily stable with just 4 substeps:

<img width="1079" height="1923" alt="100 cube stack" src="https://github.com/user-attachments/assets/0b3b1754-ac41-482c-afca-5522aad9b603" />

Without contact recycling, even 40 substeps isn't enough unless other solver parameters are also tuned.

### Performance

A 10x10x10 cube stack without contact recycling takes the narrow phase ~1.38 ms:

<img width="331" height="588" alt="Before" src="https://github.com/user-attachments/assets/20c06e46-fdab-4398-8d9a-9d4798d76277" />

and with contact recycling, it takes just ~0.4 ms:

<img width="331" height="588" alt="After" src="https://github.com/user-attachments/assets/7eddb7e8-2a75-4ea7-833e-f86bd84a0837" />

Note: The solver is struggling quite hard here; lots of optimizations are coming in the near future!