### PR TITLE
Skip friction for solver bias stage

### DIFF
--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -285,7 +285,7 @@ impl ContactConstraint {
             let r1 = body1.delta_rotation * point.anchor1;
             let r2 = body2.delta_rotation * point.anchor2;
 
-            // Compute current saparation.
+            // Compute current separation.
             let delta_separation = delta_translation + (r2 - r1);
             let separation = delta_separation.dot(self.normal) + point.initial_separation;
 

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -264,14 +264,13 @@ impl ContactConstraint {
     }
 
     /// Solves the [`ContactConstraint`], applying an impulse to the given bodies.
-    pub fn solve(
+    pub fn solve<const USE_BIAS: bool>(
         &mut self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
         inertia1: &SolverBodyInertia,
         inertia2: &SolverBodyInertia,
         delta_secs: f32,
-        use_bias: bool,
         max_overlap_solve_speed: f32,
     ) {
         let inv_mass1 = inertia1.effective_inv_mass();
@@ -298,11 +297,10 @@ impl ContactConstraint {
             let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
 
             // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
-            let impulse_magnitude = point.normal_part.solve_impulse(
+            let impulse_magnitude = point.normal_part.solve_impulse::<USE_BIAS>(
                 separation,
                 relative_velocity,
                 self.normal,
-                use_bias,
                 max_overlap_solve_speed,
                 delta_secs,
             );
@@ -317,39 +315,42 @@ impl ContactConstraint {
             body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
         }
 
-        let tangent_directions = self.tangent_directions();
+        // Friction impulses, only during the relaxation stage.
+        // Applying friction during the bias stage does not meaningfully improve quality for the cost.
+        if !USE_BIAS {
+            let tangent_directions = self.tangent_directions();
 
-        // Friction
-        for point in self.points.iter_mut() {
-            let Some(ref mut friction_part) = point.tangent_part else {
-                continue;
-            };
+            for point in self.points.iter_mut() {
+                let Some(ref mut friction_part) = point.tangent_part else {
+                    continue;
+                };
 
-            // Fixed anchors
-            let r1 = point.anchor1;
-            let r2 = point.anchor2;
+                // Fixed anchors
+                let r1 = point.anchor1;
+                let r2 = point.anchor2;
 
-            // Relative velocity at contact point
-            let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
+                // Relative velocity at contact point
+                let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
 
-            // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
-            let impulse = friction_part.solve_impulse(
-                tangent_directions,
-                relative_velocity,
-                #[cfg(feature = "2d")]
-                self.tangent_speed,
-                #[cfg(feature = "3d")]
-                self.tangent_velocity,
-                self.friction,
-                point.normal_part.impulse,
-            );
+                // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
+                let impulse = friction_part.solve_impulse(
+                    tangent_directions,
+                    relative_velocity,
+                    #[cfg(feature = "2d")]
+                    self.tangent_speed,
+                    #[cfg(feature = "3d")]
+                    self.tangent_velocity,
+                    self.friction,
+                    point.normal_part.impulse,
+                );
 
-            // Apply the impulse.
-            body1.linear_velocity -= impulse * inv_mass1;
-            body1.angular_velocity -= inv_angular_inertia1 * cross(r1, impulse);
+                // Apply the impulse.
+                body1.linear_velocity -= impulse * inv_mass1;
+                body1.angular_velocity -= inv_angular_inertia1 * cross(r1, impulse);
 
-            body2.linear_velocity += impulse * inv_mass2;
-            body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
+                body2.linear_velocity += impulse * inv_mass2;
+                body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
+            }
         }
     }
 

--- a/src/dynamics/solver/contact/normal_part.rs
+++ b/src/dynamics/solver/contact/normal_part.rs
@@ -111,12 +111,11 @@ impl ContactNormalPart {
 
     /// Solves the non-penetration constraint, updating the total impulse in `self` and returning
     /// the incremental impulse to apply to each body.
-    pub fn solve_impulse(
+    pub fn solve_impulse<const USE_BIAS: bool>(
         &mut self,
         separation: f32,
         relative_velocity: Vector,
         normal: Vector,
-        use_bias: bool,
         max_overlap_solve_speed: f32,
         delta_secs: f32,
     ) -> f32 {
@@ -127,7 +126,7 @@ impl ContactNormalPart {
         let mut impulse = if separation > 0.0 {
             // Speculative contact: Push back the part of the velocity that would cause penetration.
             -self.effective_mass * (normal_speed + separation / delta_secs)
-        } else if use_bias {
+        } else if USE_BIAS {
             // Contact using bias: Incorporate softness parameters.
             //
             // 1. Velocity bias: Allows the constraint to solve overlap by boosting

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -904,13 +904,12 @@ fn solve_contacts_internal<const USE_BIAS: bool>(
         _ => {}
     }
 
-    constraint.solve(
+    constraint.solve::<USE_BIAS>(
         body1,
         body2,
         inertia1,
         inertia2,
         delta_secs,
-        USE_BIAS,
         max_overlap_solve_speed,
     );
 }

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0xa1a76fa5;
+    let expected = 0x19c4b0ff;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

It is enough to only apply friction during the relaxation stage and skip it for the contact solver bias stage. This is an easy, essentially free optimization. Box2D added the same optimization in https://github.com/erincatto/box2d/pull/1050.

## Solution

Skip friction during the bias stage.

## Performance

Previously, Solve Constraints and Relax Velocities had approximately the same cost. Now, Solve Constraints is meaningfully cheaper.

<img width="328" height="63" alt="Performance timings" src="https://github.com/user-attachments/assets/328774c4-5c5e-4b2a-8143-b9381c5eac23" />