### PR TITLE
Contiguous Solver Bodies

### DIFF
--- a/migration-guides/0.7-to-main.md
+++ b/migration-guides/0.7-to-main.md
@@ -88,3 +88,9 @@ This involved some breaking changes:
 Additionally, the constraint graph and islands are no longer updated immediately
 after despawning colliders or bodies. If they must be made consistent instantly,
 consider using the `FlushContactStatusChangesQueue` command.
+
+## Solver
+
+Each `SolverBody` and `SolverBodyInertia` associated with awake dynamic and kinematic bodies
+is now stored in a `SolverBodies` resource instead of a component on the entity. The index
+of the solver body associated with a given entity is stored in the `SolverBodyIndex` component.

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     collision::collider::{ColliderAabbMargin, EnlargedAabb},
     data_structures::bit_vec::BitVec,
-    dynamics::solver::solver_body::SolverBody,
+    dynamics::solver::solver_body::SolverBodyIndex,
     prelude::*,
     schedule::LastPhysicsTick,
 };
@@ -664,7 +664,7 @@ fn update_solver_body_aabbs<C: AnyCollider>(
             &RigidBodyColliders,
             Option<&SpeculativeCcd>,
         ),
-        With<SolverBody>,
+        With<SolverBodyIndex>,
     >,
     mut colliders: ParamSet<(
         Query<

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -652,6 +652,8 @@ impl EnlargedProxiesBitVec {
 
 /// Updates the AABBs of the colliders of each [`SolverBody`] (awake dynamic and kinematic bodies)
 /// after the physics step.
+///
+/// [`SolverBody`]: crate::dynamics::solver::solver_body::SolverBody
 // TODO: Once dynamic an kinematic bodies have their own marker components,
 //       we should use those instead of `SolverBody`. Solver bodies should
 //       be an implementation detail of the solver.

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         joints::EntityConstraint,
         solver::{
             islands::{BodyIslandNode, PhysicsIslands},
-            solver_body::{SolverBody, SolverBodyFlags},
+            solver_body::{SolverBodies, SolverBodyFlags, SolverBodyIndex},
         },
     },
     prelude::*,
@@ -292,7 +292,8 @@ fn debug_render_colliders(
         Option<&DebugRender>,
     )>,
     sleeping: Query<(), With<Sleeping>>,
-    solver_bodies: Query<&SolverBody>,
+    body_indices: Query<&SolverBodyIndex>,
+    solver_bodies: Res<SolverBodies>,
     mut gizmos: Gizmos<PhysicsGizmos>,
     store: Res<GizmoConfigStore>,
 ) {
@@ -304,8 +305,9 @@ fn debug_render_colliders(
             let collider_rb = collider_rb.map_or(entity, |c| c.body);
 
             let ccd_color = (render_config.is_none())
-                .then(|| solver_bodies.get(collider_rb).ok())
+                .then(|| body_indices.get(collider_rb).ok().copied())
                 .flatten()
+                .and_then(|index| solver_bodies.get(index))
                 .and_then(|solver_body| {
                     if solver_body
                         .flags

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -591,7 +591,7 @@ struct CcdImpact {
 fn solve_continuous(
     colliders: Query<(&Collider, &Position, &Rotation)>,
     ccd_query: Query<CcdBodyQuery>,
-    mut solver_bodies: ResMut<SolverBodies>,
+    mut bodies: ResMut<SolverBodies>,
     trees: Res<ColliderTrees>,
     mut contact_graph: ResMut<ContactGraph>,
     time: Res<Time>,
@@ -604,10 +604,6 @@ fn solve_continuous(
         return;
     }
     let inv_dt = 1.0 / delta_secs;
-
-    // Shared, read-only access to the solver bodies for the parallel sweep phase below.
-    // Time-of-impact corrections are written back into the resource afterwards.
-    let bodies = &*solver_bodies;
 
     // Avian's approach to CCD is heavily inspired by Box2D by Erin Catto,
     // with some notable differences (as of Box2D 3.1.0):
@@ -869,7 +865,7 @@ fn solve_continuous(
             impact,
         } in results
         {
-            if let Some(solver_body) = solver_bodies.get_mut(index) {
+            if let Some(solver_body) = bodies.get_mut(index) {
                 // Note: This flag is only retained for debug rendering.
                 solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -215,7 +215,7 @@
 //! However, this comes at the cost of worse performance for the entire simulation.
 
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-use super::solver::solver_body::{SolverBody, SolverBodyFlags};
+use super::solver::solver_body::{SolverBodies, SolverBody, SolverBodyFlags, SolverBodyIndex};
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use crate::prelude::*;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
@@ -544,7 +544,7 @@ impl SpeculativeCcd {
 #[derive(QueryData)]
 struct CcdBodyQuery {
     entity: Entity,
-    body: &'static SolverBody,
+    index: &'static SolverBodyIndex,
     position: &'static Position,
     rotation: &'static Rotation,
     com: &'static ComputedCenterOfMass,
@@ -556,8 +556,8 @@ struct CcdBodyQuery {
 /// A time-of-impact result for a single fast body.
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 struct CcdResult {
-    /// The fast body that was swept.
-    entity: Entity,
+    /// The [`SolverBodyIndex`] of the fast body that was swept.
+    index: SolverBodyIndex,
     /// The time of impact fraction in `[0, 1]`,
     fraction: f32,
     /// Details of the earliest impact, if one was found.
@@ -589,7 +589,8 @@ struct CcdImpact {
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 fn solve_continuous(
     colliders: Query<(&Collider, &Position, &Rotation)>,
-    mut bodies: ParamSet<(Query<CcdBodyQuery>, Query<&mut SolverBody>)>,
+    ccd_query: Query<CcdBodyQuery>,
+    mut solver_bodies: ResMut<SolverBodies>,
     trees: Res<ColliderTrees>,
     mut contact_graph: ResMut<ContactGraph>,
     time: Res<Time>,
@@ -602,6 +603,10 @@ fn solve_continuous(
         return;
     }
     let inv_dt = 1.0 / delta_secs;
+
+    // Shared, read-only access to the solver bodies for the parallel sweep phase below.
+    // Time-of-impact corrections are written back into the resource afterwards.
+    let bodies = &*solver_bodies;
 
     // Avian's approach to CCD is heavily inspired by Box2D by Erin Catto,
     // with some notable differences (as of Box2D 3.1.0):
@@ -627,10 +632,14 @@ fn solve_continuous(
     // This runs in parallel over solver bodies. The order of TOI sweeps does not matter,
     // as each fast body only reads the trees and produces its own deterministic result.
     // This combines parts of `b2FinalizeBodiesTask` and `b2SolveContinuous` from Box2D.
-    let ccd_query = bodies.p0();
     ccd_query.par_iter().for_each(|fast| {
+        // Fetch the fast body's solver body state.
+        let Some(body) = bodies.get(*fast.index) else {
+            return;
+        };
+
         // Only dynamic bodies support CCD.
-        if !fast.body.flags.is_dynamic() {
+        if !body.flags.is_dynamic() {
             return;
         }
 
@@ -640,7 +649,6 @@ fn solve_continuous(
             return;
         }
 
-        let body = fast.body;
         let ccd_thickness = fast.size_metrics.ccd_thickness;
         let sweep_radius = fast.size_metrics.sweep_radius;
 
@@ -683,7 +691,7 @@ fn solve_continuous(
                 .get_or(|| RefCell::new(Vec::new()))
                 .borrow_mut()
                 .push(CcdResult {
-                    entity: fast.entity,
+                    index: *fast.index,
                     fraction,
                     impact,
                 });
@@ -785,18 +793,22 @@ fn solve_continuous(
                     let (motion2, mode2) = match proxy.body {
                         Some(body2_entity) => match ccd_query.get(body2_entity) {
                             Ok(body2) => {
-                                let target_com_world =
-                                    body2.position.0 + (body2.rotation * body2.com.0).real();
-                                (
-                                    collider_sweep_motion(
-                                        target_pos.0,
-                                        target_rot,
-                                        target_com_world,
-                                        body2.body,
-                                        inv_dt,
-                                    ),
-                                    body2.ccd.map_or(SweepMode::NonLinear, |ccd| ccd.mode),
-                                )
+                                if let Some(solver_body2) = bodies.get(*body2.index) {
+                                    let target_com_world =
+                                        body2.position.0 + (body2.rotation * body2.com.0).real();
+                                    (
+                                        collider_sweep_motion(
+                                            target_pos.0,
+                                            target_rot,
+                                            target_com_world,
+                                            solver_body2,
+                                            inv_dt,
+                                        ),
+                                        body2.ccd.map_or(SweepMode::NonLinear, |ccd| ccd.mode),
+                                    )
+                                } else {
+                                    (static_motion(target_pos.0, target_rot), SweepMode::Linear)
+                                }
                             }
                             Err(_) => (static_motion(target_pos.0, target_rot), SweepMode::Linear),
                         },
@@ -842,7 +854,7 @@ fn solve_continuous(
         .into_iter()
         .flat_map(|cell| cell.into_inner())
         .collect();
-    results.sort_unstable_by_key(|result| result.entity);
+    results.sort_unstable_by_key(|result| result.index);
 
     // Mark fast bodies and apply any time-of-impact corrections.
     //
@@ -850,14 +862,13 @@ fn solve_continuous(
     // and request a speculative distance to help ensure the contact is detected
     // by the discrete solver next timestep.
     if !results.is_empty() {
-        let mut body_query = bodies.p1();
         for CcdResult {
-            entity,
+            index,
             fraction,
             impact,
         } in results
         {
-            if let Ok(mut solver_body) = body_query.get_mut(entity) {
+            if let Some(solver_body) = solver_bodies.get_mut(index) {
                 // Note: This flag is only retained for debug rendering.
                 solver_body.flags.insert(SolverBodyFlags::IS_FAST);
 

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! See [`IntegratorPlugin`].
 
-use crate::prelude::*;
+use crate::{dynamics::solver::solver_body::SolverBodyFlags, prelude::*, utils::par_for_each};
 use bevy::{
     ecs::{intern::Interned, query::QueryData, schedule::ScheduleLabel},
     prelude::*,
@@ -511,8 +511,7 @@ fn clamp_velocities(
 
 /// Integrates the positions of bodies based on their velocities and the time step.
 pub fn integrate_positions(
-    mut solver_bodies: ResMut<SolverBodies>,
-    bodies: Query<&SolverBodyIndex, Without<CustomPositionIntegration>>,
+    mut bodies: ResMut<SolverBodies>,
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
@@ -520,17 +519,22 @@ pub fn integrate_positions(
 
     let delta_secs = time.delta_secs();
 
-    let access = solver_bodies.access();
+    par_for_each(bodies.bodies_mut(), 4096, |_index, body| {
+        // Skip bodies that have custom position integration.
+        if body
+            .flags
+            .contains(SolverBodyFlags::CUSTOM_POSITION_INTEGRATION)
+        {
+            return;
+        }
 
-    bodies.par_iter().for_each(|index| {
-        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
         let SolverBody {
             linear_velocity,
             angular_velocity,
             delta_position,
             delta_rotation,
             ..
-        } = unsafe { access.body_unchecked_mut(*index) };
+        } = body;
 
         *delta_position += *linear_velocity * delta_secs;
         #[cfg(feature = "2d")]

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use dynamics::solver::SolverDiagnostics;
 
-use super::solver::solver_body::SolverBody;
+use super::solver::solver_body::{SolverBodies, SolverBody, SolverBodyIndex};
 
 /// Integrates Newton's 2nd law of motion, applying forces and moving entities according to their velocities.
 ///
@@ -44,8 +44,8 @@ impl Default for IntegratorPlugin {
 
 impl Plugin for IntegratorPlugin {
     fn build(&self, app: &mut App) {
-        // Add `VelocityIntegrationData` to all `SolverBody`s.
-        app.register_required_components::<SolverBody, VelocityIntegrationData>();
+        // Add `VelocityIntegrationData` to all bodies that have a solver body.
+        app.register_required_components::<SolverBodyIndex, VelocityIntegrationData>();
 
         app.init_resource::<Gravity>();
 
@@ -311,7 +311,7 @@ pub fn pre_process_velocity_increments(
 
 /// Clears the velocity increments of bodies after the substepping loop.
 fn clear_velocity_increments(
-    mut bodies: Query<&mut VelocityIntegrationData, With<SolverBody>>,
+    mut bodies: Query<&mut VelocityIntegrationData, With<SolverBodyIndex>>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
     let start = crate::utils::Instant::now();
@@ -328,7 +328,7 @@ fn clear_velocity_increments(
 #[query_data(mutable)]
 #[doc(hidden)]
 pub struct VelocityIntegrationQuery {
-    solver_body: &'static mut SolverBody,
+    index: &'static SolverBodyIndex,
     integration: &'static mut VelocityIntegrationData,
     #[cfg(feature = "3d")]
     angular_inertia: &'static ComputedAngularInertia,
@@ -338,6 +338,7 @@ pub struct VelocityIntegrationQuery {
 
 /// Integrates the velocities of bodies by applying velocity increments and damping.
 pub fn integrate_velocities(
+    mut solver_bodies: ResMut<SolverBodies>,
     mut bodies: Query<
         VelocityIntegrationQuery,
         (RigidBodyActiveFilter, Without<CustomVelocityIntegration>),
@@ -350,32 +351,37 @@ pub fn integrate_velocities(
     #[cfg(feature = "3d")]
     let delta_secs = time.delta_secs();
 
-    bodies.par_iter_mut().for_each(|mut body| {
-        if body.solver_body.flags.is_kinematic() {
+    let access = solver_bodies.access();
+
+    bodies.par_iter_mut().for_each(|body| {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let solver_body = unsafe { access.body_unchecked_mut(*body.index) };
+
+        if solver_body.flags.is_kinematic() {
             // Skip kinematic bodies.
             return;
         }
 
         // Apply velocity damping.
-        body.solver_body.linear_velocity *= body.integration.linear_damping_rhs;
-        body.solver_body.angular_velocity *= body.integration.angular_damping_rhs;
+        solver_body.linear_velocity *= body.integration.linear_damping_rhs;
+        solver_body.angular_velocity *= body.integration.angular_damping_rhs;
 
         // Apply velocity increments.
-        body.solver_body.linear_velocity += body.integration.linear_increment;
-        body.solver_body.angular_velocity += body.integration.angular_increment;
+        solver_body.linear_velocity += body.integration.linear_increment;
+        solver_body.angular_velocity += body.integration.angular_increment;
 
         #[cfg(feature = "3d")]
         {
-            if body.solver_body.is_gyroscopic() {
+            if solver_body.is_gyroscopic() {
                 // TODO: Should this be opt-in with a `GyroscopicMotion` component?
                 // TODO: It's a bit unfortunate that this has to run in the substepping loop
                 //       rather than pre-computing the velocity increments once per time step.
                 //       This needs to be done because the gyroscopic torque relies on up-to-date rotations
                 //       and world-space angular inertia tensors. Omitting the change in orientation would
                 //       lead to worse accuracy and angular momentum not being conserved.
-                let rotation = body.solver_body.delta_rotation * Rot::from(*body.rotation);
+                let rotation = solver_body.delta_rotation * Rot::from(*body.rotation);
                 solve_gyroscopic_torque(
-                    &mut body.solver_body.angular_velocity,
+                    &mut solver_body.angular_velocity,
                     rotation,
                     body.angular_inertia,
                     delta_secs,
@@ -462,16 +468,21 @@ pub fn solve_gyroscopic_torque(
 //       that only some bodies have clamped velocities.
 /// Clamps the velocities of bodies to [`MaxLinearSpeed`] and [`MaxAngularSpeed`].
 fn clamp_velocities(
+    mut solver_bodies: ResMut<SolverBodies>,
     mut bodies: ParamSet<(
-        Query<(&mut SolverBody, &MaxLinearSpeed)>,
-        Query<(&mut SolverBody, &MaxAngularSpeed)>,
+        Query<(&SolverBodyIndex, &MaxLinearSpeed)>,
+        Query<(&SolverBodyIndex, &MaxAngularSpeed)>,
     )>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
     let start = crate::utils::Instant::now();
 
+    let access = solver_bodies.access();
+
     // Clamp linear velocity.
-    bodies.p0().iter_mut().for_each(|(mut body, max_speed)| {
+    bodies.p0().iter().for_each(|(index, max_speed)| {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
         let linear_speed_squared = body.linear_velocity.length_squared();
         if linear_speed_squared > max_speed.0 * max_speed.0 {
             body.linear_velocity *= max_speed.0 / linear_speed_squared.sqrt();
@@ -479,7 +490,9 @@ fn clamp_velocities(
     });
 
     // Clamp angular velocity.
-    bodies.p1().iter_mut().for_each(|(mut body, max_speed)| {
+    bodies.p1().iter().for_each(|(index, max_speed)| {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
         #[cfg(feature = "2d")]
         if body.angular_velocity.abs() > max_speed.0 {
             body.angular_velocity = max_speed.copysign(body.angular_velocity);
@@ -498,7 +511,8 @@ fn clamp_velocities(
 
 /// Integrates the positions of bodies based on their velocities and the time step.
 pub fn integrate_positions(
-    mut solver_bodies: Query<&mut SolverBody, Without<CustomPositionIntegration>>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    bodies: Query<&SolverBodyIndex, Without<CustomPositionIntegration>>,
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
@@ -506,14 +520,17 @@ pub fn integrate_positions(
 
     let delta_secs = time.delta_secs();
 
-    solver_bodies.par_iter_mut().for_each(|body| {
+    let access = solver_bodies.access();
+
+    bodies.par_iter().for_each(|index| {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
         let SolverBody {
             linear_velocity,
             angular_velocity,
             delta_position,
             delta_rotation,
             ..
-        } = body.into_inner();
+        } = unsafe { access.body_unchecked_mut(*index) };
 
         *delta_position += *linear_velocity * delta_secs;
         #[cfg(feature = "2d")]

--- a/src/dynamics/rigid_body/forces/plugin.rs
+++ b/src/dynamics/rigid_body/forces/plugin.rs
@@ -106,7 +106,11 @@ fn apply_constant_forces(
 /// Applies [`ConstantTorque`] to the accumulated torques.
 fn apply_constant_torques(
     solver_bodies: Res<SolverBodies>,
-    mut bodies: Query<(&SolverBodyIndex, &mut VelocityIntegrationData, &ConstantTorque)>,
+    mut bodies: Query<(
+        &SolverBodyIndex,
+        &mut VelocityIntegrationData,
+        &ConstantTorque,
+    )>,
 ) {
     bodies
         .iter_mut()

--- a/src/dynamics/rigid_body/forces/plugin.rs
+++ b/src/dynamics/rigid_body/forces/plugin.rs
@@ -5,7 +5,7 @@ use crate::{
         },
         solver::{
             SolverDiagnostics,
-            solver_body::{SolverBody, SolverBodyInertia},
+            solver_body::{SolverBodies, SolverBodyIndex},
         },
     },
     prelude::*,
@@ -105,15 +105,15 @@ fn apply_constant_forces(
 
 /// Applies [`ConstantTorque`] to the accumulated torques.
 fn apply_constant_torques(
-    mut bodies: Query<(
-        &mut VelocityIntegrationData,
-        &SolverBodyInertia,
-        &ConstantTorque,
-    )>,
+    solver_bodies: Res<SolverBodies>,
+    mut bodies: Query<(&SolverBodyIndex, &mut VelocityIntegrationData, &ConstantTorque)>,
 ) {
     bodies
         .iter_mut()
-        .for_each(|(mut integration, inertia, constant_torque)| {
+        .for_each(|(index, mut integration, constant_torque)| {
+            let Some(inertia) = solver_bodies.get_inertia(*index) else {
+                return;
+            };
             integration.angular_increment +=
                 inertia.effective_inv_angular_inertia() * constant_torque.0;
         })
@@ -205,8 +205,9 @@ fn apply_constant_local_angular_acceleration(
 ///
 /// This should run in the substepping loop, just before [`IntegrationSystems::Velocity`].
 fn apply_local_acceleration(
-    mut bodies: Query<
-        (&mut SolverBody, &AccumulatedLocalAcceleration, &Rotation),
+    mut solver_bodies: ResMut<SolverBodies>,
+    bodies: Query<
+        (&SolverBodyIndex, &AccumulatedLocalAcceleration, &Rotation),
         Without<CustomVelocityIntegration>,
     >,
     mut diagnostics: ResMut<SolverDiagnostics>,
@@ -216,26 +217,27 @@ fn apply_local_acceleration(
 
     let delta_secs = time.delta_secs();
 
-    bodies
-        .iter_mut()
-        .for_each(|(mut body, acceleration, rotation)| {
-            let rotation = body.delta_rotation * Rot::from(*rotation);
-            let locked_axes = body.flags.locked_axes();
+    let access = solver_bodies.access();
 
-            // Compute the world space velocity increments with locked axes applied.
-            let world_linear_acceleration =
-                locked_axes.apply_to_vec(rotation * acceleration.linear);
-            #[cfg(feature = "3d")]
-            let world_angular_acceleration =
-                locked_axes.apply_to_vec(rotation * acceleration.angular);
+    bodies.iter().for_each(|(index, acceleration, rotation)| {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
 
-            // Apply acceleration.
-            body.linear_velocity += world_linear_acceleration * delta_secs;
-            #[cfg(feature = "3d")]
-            {
-                body.angular_velocity += world_angular_acceleration * delta_secs;
-            }
-        });
+        let rotation = body.delta_rotation * Rot::from(*rotation);
+        let locked_axes = body.flags.locked_axes();
+
+        // Compute the world space velocity increments with locked axes applied.
+        let world_linear_acceleration = locked_axes.apply_to_vec(rotation * acceleration.linear);
+        #[cfg(feature = "3d")]
+        let world_angular_acceleration = locked_axes.apply_to_vec(rotation * acceleration.angular);
+
+        // Apply acceleration.
+        body.linear_velocity += world_linear_acceleration * delta_secs;
+        #[cfg(feature = "3d")]
+        {
+            body.angular_velocity += world_angular_acceleration * delta_secs;
+        }
+    });
 
     diagnostics.integrate_velocities += start.elapsed();
 }

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -103,7 +103,6 @@ pub struct ContactConstraint {
 
 impl ContactConstraint {
     /// Generates a new [`ContactConstraint`] from the given bodies and contact manifold.
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn generate(
         body_index1: SolverBodyIndex,
         body_index2: SolverBodyIndex,

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -9,19 +9,13 @@ pub use tangent_part::ContactTangentPart;
 use core::cmp::Ordering;
 
 use crate::{
-    collision::contact_types::ContactId,
-    dynamics::solver::{BodyQueryItem, ContactSoftnessCoefficients},
-    prelude::*,
+    collision::contact_types::ContactId, dynamics::solver::ContactSoftnessCoefficients, prelude::*,
 };
 #[cfg(feature = "serialize")]
 use bevy::reflect::{ReflectDeserialize, ReflectSerialize};
-use bevy::{
-    ecs::entity::{Entity, EntityMapper, MapEntities},
-    reflect::Reflect,
-    utils::default,
-};
+use bevy::{reflect::Reflect, utils::default};
 
-use super::solver_body::{SolverBody, SolverBodyInertia};
+use super::solver_body::{SolverBody, SolverBodyIndex, SolverBodyInertia};
 
 // TODO: One-body constraint version
 /// Data and logic for solving a single contact point for a [`ContactConstraint`].
@@ -62,10 +56,12 @@ pub struct ContactConstraintPoint {
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
 pub struct ContactConstraint {
-    /// The first rigid body entity in the contact.
-    pub body1: Entity,
-    /// The second rigid body entity in the contact.
-    pub body2: Entity,
+    /// The [`SolverBodyIndex`] of the first body in the contact,
+    /// or [`SolverBodyIndex::INVALID`] if it is static or sleeping.
+    pub body_index1: SolverBodyIndex,
+    /// The [`SolverBodyIndex`] of the second body in the contact,
+    /// or [`SolverBodyIndex::INVALID`] if it is static or sleeping.
+    pub body_index2: SolverBodyIndex,
     /// The relative dominance of the bodies.
     ///
     /// If the relative dominance is positive, the first body is dominant
@@ -107,21 +103,20 @@ pub struct ContactConstraint {
 
 impl ContactConstraint {
     /// Generates a new [`ContactConstraint`] from the given bodies and contact manifold.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn generate(
-        body1_entity: Entity,
-        body2_entity: Entity,
-        body1: BodyQueryItem,
-        body2: BodyQueryItem,
+        body_index1: SolverBodyIndex,
+        body_index2: SolverBodyIndex,
+        inertia1: &SolverBodyInertia,
+        inertia2: &SolverBodyInertia,
+        linear_velocity1: Vector,
+        linear_velocity2: Vector,
         contact_id: ContactId,
         manifold: &ContactManifold,
         manifold_index: usize,
         warm_start_enabled: bool,
         softness: &ContactSoftnessCoefficients,
     ) -> Self {
-        // Get the solver body inertia if it exists, or use a dummy inertia for static bodies.
-        let inertia1 = body1.inertia.unwrap_or(&SolverBodyInertia::DUMMY);
-        let inertia2 = body2.inertia.unwrap_or(&SolverBodyInertia::DUMMY);
-
         // Compute the relative dominance of the bodies.
         let relative_dominance = inertia1.dominance() - inertia2.dominance();
 
@@ -155,11 +150,8 @@ impl ContactConstraint {
 
         let effective_inverse_mass_sum = inv_mass1 + inv_mass2;
 
-        let tangents = compute_tangent_directions(
-            manifold.normal,
-            body1.linear_velocity.0,
-            body2.linear_velocity.0,
-        );
+        let tangents =
+            compute_tangent_directions(manifold.normal, linear_velocity1, linear_velocity2);
 
         let mut points = Vec::with_capacity(manifold.points.len());
 
@@ -201,8 +193,8 @@ impl ContactConstraint {
         }
 
         ContactConstraint {
-            body1: body1_entity,
-            body2: body2_entity,
+            body_index1,
+            body_index2,
             relative_dominance,
             friction: manifold.friction,
             restitution: manifold.restitution,
@@ -445,12 +437,5 @@ fn compute_tangent_directions(
             .unwrap_or(force_direction.any_orthonormal_vector());
         let bitangent = force_direction.cross(tangent);
         [tangent, bitangent]
-    }
-}
-
-impl MapEntities for ContactConstraint {
-    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.body1 = entity_mapper.get_mapped(self.body1);
-        self.body2 = entity_mapper.get_mapped(self.body2);
     }
 }

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -264,14 +264,13 @@ impl ContactConstraint {
     }
 
     /// Solves the [`ContactConstraint`], applying an impulse to the given bodies.
-    pub fn solve(
+    pub fn solve<const USE_BIAS: bool>(
         &mut self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
         inertia1: &SolverBodyInertia,
         inertia2: &SolverBodyInertia,
         delta_secs: f32,
-        use_bias: bool,
         max_overlap_solve_speed: f32,
     ) {
         let inv_mass1 = inertia1.effective_inv_mass();
@@ -298,11 +297,10 @@ impl ContactConstraint {
             let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
 
             // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
-            let impulse_magnitude = point.normal_part.solve_impulse(
+            let impulse_magnitude = point.normal_part.solve_impulse::<USE_BIAS>(
                 separation,
                 relative_velocity,
                 self.normal,
-                use_bias,
                 max_overlap_solve_speed,
                 delta_secs,
             );
@@ -317,39 +315,42 @@ impl ContactConstraint {
             body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
         }
 
-        let tangent_directions = self.tangent_directions();
+        // Friction impulses, only during the relaxation stage.
+        // Applying friction during the bias stage does not meaningfully improve quality for the cost.
+        if !USE_BIAS {
+            let tangent_directions = self.tangent_directions();
 
-        // Friction
-        for point in self.points.iter_mut() {
-            let Some(ref mut friction_part) = point.tangent_part else {
-                continue;
-            };
+            for point in self.points.iter_mut() {
+                let Some(ref mut friction_part) = point.tangent_part else {
+                    continue;
+                };
 
-            // Fixed anchors
-            let r1 = point.anchor1;
-            let r2 = point.anchor2;
+                // Fixed anchors
+                let r1 = point.anchor1;
+                let r2 = point.anchor2;
 
-            // Relative velocity at contact point
-            let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
+                // Relative velocity at contact point
+                let relative_velocity = body2.velocity_at_point(r2) - body1.velocity_at_point(r1);
 
-            // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
-            let impulse = friction_part.solve_impulse(
-                tangent_directions,
-                relative_velocity,
-                #[cfg(feature = "2d")]
-                self.tangent_speed,
-                #[cfg(feature = "3d")]
-                self.tangent_velocity,
-                self.friction,
-                point.normal_part.impulse,
-            );
+                // Compute the incremental impulse. The clamping and impulse accumulation is handled by the method.
+                let impulse = friction_part.solve_impulse(
+                    tangent_directions,
+                    relative_velocity,
+                    #[cfg(feature = "2d")]
+                    self.tangent_speed,
+                    #[cfg(feature = "3d")]
+                    self.tangent_velocity,
+                    self.friction,
+                    point.normal_part.impulse,
+                );
 
-            // Apply the impulse.
-            body1.linear_velocity -= impulse * inv_mass1;
-            body1.angular_velocity -= inv_angular_inertia1 * cross(r1, impulse);
+                // Apply the impulse.
+                body1.linear_velocity -= impulse * inv_mass1;
+                body1.angular_velocity -= inv_angular_inertia1 * cross(r1, impulse);
 
-            body2.linear_velocity += impulse * inv_mass2;
-            body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
+                body2.linear_velocity += impulse * inv_mass2;
+                body2.angular_velocity += inv_angular_inertia2 * cross(r2, impulse);
+            }
         }
     }
 

--- a/src/dynamics/solver/contact/normal_part.rs
+++ b/src/dynamics/solver/contact/normal_part.rs
@@ -111,12 +111,11 @@ impl ContactNormalPart {
 
     /// Solves the non-penetration constraint, updating the total impulse in `self` and returning
     /// the incremental impulse to apply to each body.
-    pub fn solve_impulse(
+    pub fn solve_impulse<const USE_BIAS: bool>(
         &mut self,
         separation: f32,
         relative_velocity: Vector,
         normal: Vector,
-        use_bias: bool,
         max_overlap_solve_speed: f32,
         delta_secs: f32,
     ) -> f32 {
@@ -127,7 +126,7 @@ impl ContactNormalPart {
         let mut impulse = if separation > 0.0 {
             // Speculative contact: Push back the part of the velocity that would cause penetration.
             -self.effective_mass * (normal_speed + separation / delta_secs)
-        } else if use_bias {
+        } else if USE_BIAS {
             // Contact using bias: Incorporate softness parameters.
             //
             // 1. Velocity bias: Allows the constraint to solve overlap by boosting

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -60,7 +60,7 @@ use crate::{
     data_structures::stable_vec::StableVec,
     dynamics::{
         joints::joint_graph::{JointGraph, JointId},
-        solver::solver_body::SolverBody,
+        solver::solver_body::SolverBodyIndex,
     },
     prelude::{
         ContactGraph, PhysicsSchedule, RigidBody, RigidBodyColliders, RigidBodyDisabled,
@@ -77,8 +77,8 @@ impl Plugin for IslandPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PhysicsIslands>();
 
-        // Insert `BodyIslandNode` for each `SolverBody`.
-        app.register_required_components::<SolverBody, BodyIslandNode>();
+        // Insert `BodyIslandNode` for each body that has a solver body.
+        app.register_required_components::<SolverBodyIndex, BodyIslandNode>();
 
         // Add `BodyIslandNode` for each dynamic and kinematic rigid body
         // when the associated rigid body is enabled.

--- a/src/dynamics/solver/islands/sleeping.rs
+++ b/src/dynamics/solver/islands/sleeping.rs
@@ -33,7 +33,7 @@ use crate::{
         solver::{
             constraint_graph::ConstraintGraph,
             islands::{BodyIslandNode, IslandId, PhysicsIslands},
-            solver_body::SolverBody,
+            solver_body::{SolverBodies, SolverBodyIndex},
         },
     },
     prelude::*,
@@ -48,9 +48,9 @@ impl Plugin for IslandSleepingPlugin {
         app.init_resource::<AwakeIslandBitVec>();
         app.init_resource::<TimeToSleep>();
 
-        // Insert `SleepThreshold` and `SleepTimer` for each `SolverBody`.
-        app.register_required_components::<SolverBody, SleepThreshold>();
-        app.register_required_components::<SolverBody, SleepTimer>();
+        // Insert `SleepThreshold` and `SleepTimer` for each body that has a solver body.
+        app.register_required_components::<SolverBodyIndex, SleepThreshold>();
+        app.register_required_components::<SolverBodyIndex, SleepTimer>();
 
         // Set up cached system states for sleeping and waking bodies or islands.
         let cached_system_state1 = CachedBodySleepingSystemState(SystemState::new(app.world_mut()));
@@ -186,11 +186,12 @@ fn wake_islands_with_sleeping_disabled(
 fn update_sleeping_states(
     mut awake_island_bit_vec: ResMut<AwakeIslandBitVec>,
     mut islands: ResMut<PhysicsIslands>,
+    solver_bodies: Res<SolverBodies>,
     mut query: Query<
         (
             &mut SleepTimer,
             &SleepThreshold,
-            &SolverBody,
+            &SolverBodyIndex,
             &BodyIslandNode,
         ),
         (Without<Sleeping>, Without<SleepingDisabled>),
@@ -205,7 +206,10 @@ fn update_sleeping_states(
     islands.split_candidate_sleep_timer = 0.0;
 
     // TODO: This would be nice to do in parallel.
-    for (mut sleep_timer, sleep_threshold, solver_body, island_data) in query.iter_mut() {
+    for (mut sleep_timer, sleep_threshold, index, island_data) in query.iter_mut() {
+        let Some(solver_body) = solver_bodies.get(*index) else {
+            continue;
+        };
         let lin_vel_squared = solver_body.linear_velocity.length_squared();
         #[cfg(feature = "2d")]
         let ang_vel_squared = solver_body.angular_velocity * solver_body.angular_velocity;

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -13,7 +13,9 @@ use crate::{
             islands::{BodyIslandNode, IslandId, PhysicsIslands, WakeIslands},
             schedule::SubstepSolverSystems,
             softness_parameters::{SoftnessCoefficients, SoftnessParameters},
-            solver_body::{SolverBody, SolverBodyInertia},
+            solver_body::{
+                SolverBodies, SolverBodiesAccess, SolverBody, SolverBodyIndex, SolverBodyInertia,
+            },
         },
     },
     prelude::*,
@@ -654,7 +656,7 @@ pub struct ContactConstraints(pub Vec<ContactConstraint>);
 pub(super) struct BodyQuery {
     pub(super) rb: Read<RigidBody>,
     pub(super) linear_velocity: Read<LinearVelocity>,
-    pub(super) inertia: Option<Read<SolverBodyInertia>>,
+    pub(super) index: Option<Read<SolverBodyIndex>>,
 }
 
 fn prepare_contact_constraints(
@@ -662,6 +664,7 @@ fn prepare_contact_constraints(
     mut constraint_graph: ResMut<ConstraintGraph>,
     mut diagnostics: ResMut<SolverDiagnostics>,
     bodies: Query<BodyQuery, RigidBodyActiveFilter>,
+    solver_bodies: Res<SolverBodies>,
     narrow_phase_config: Res<NarrowPhaseConfig>,
     contact_softness: Res<ContactSoftnessCoefficients>,
 ) {
@@ -718,11 +721,24 @@ fn prepare_contact_constraints(
                 continue;
             }
 
+            // Look up the solver body indices and inertias, falling back to dummy inertia
+            // for static bodies without an associated solver body.
+            let index1 = body1.index.copied().unwrap_or(SolverBodyIndex::INVALID);
+            let index2 = body2.index.copied().unwrap_or(SolverBodyIndex::INVALID);
+            let inertia1 = solver_bodies
+                .get_inertia(index1)
+                .unwrap_or(&SolverBodyInertia::DUMMY);
+            let inertia2 = solver_bodies
+                .get_inertia(index2)
+                .unwrap_or(&SolverBodyInertia::DUMMY);
+
             let constraint = ContactConstraint::generate(
-                body1_entity,
-                body2_entity,
-                body1,
-                body2,
+                index1,
+                index2,
+                inertia1,
+                inertia2,
+                body1.linear_velocity.0,
+                body2.linear_velocity.0,
                 contact_pair.contact_id,
                 manifold,
                 manifold_index,
@@ -748,19 +764,21 @@ fn prepare_contact_constraints(
 ///
 /// See [`SubstepSolverSystems::WarmStart`] for more information.
 fn warm_start(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia)>,
+    mut solver_bodies: ResMut<SolverBodies>,
     mut constraint_graph: ResMut<ConstraintGraph>,
     solver_config: Res<SolverConfig>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
     let start = crate::utils::Instant::now();
 
+    let access = solver_bodies.access();
+
     // Warm start overflow constraints serially. They have lower priority, so they are solved first.
     for constraint in constraint_graph.colors[COLOR_OVERFLOW_INDEX]
         .contact_constraints
         .iter_mut()
     {
-        warm_start_internal(&bodies, constraint, solver_config.warm_start_coefficient);
+        warm_start_internal(&access, constraint, solver_config.warm_start_coefficient);
     }
 
     // Warm start constraints in each color in parallel.
@@ -771,7 +789,7 @@ fn warm_start(
         .filter(|color| !color.contact_constraints.is_empty())
     {
         crate::utils::par_for_each(&mut color.contact_constraints, 64, |_i, constraint| {
-            warm_start_internal(&bodies, constraint, solver_config.warm_start_coefficient);
+            warm_start_internal(&access, constraint, solver_config.warm_start_coefficient);
         });
     }
 
@@ -779,7 +797,7 @@ fn warm_start(
 }
 
 fn warm_start_internal(
-    bodies: &Query<(&mut SolverBody, &SolverBodyInertia)>,
+    access: &SolverBodiesAccess,
     constraint: &mut ContactConstraint,
     warm_start_coefficient: f32,
 ) {
@@ -791,13 +809,19 @@ fn warm_start_internal(
     let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
     let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-    // Get the solver bodies for the two colliding entities.
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body1) } {
-        body1 = body.into_inner();
+    // Get the solver bodies for the two colliding bodies. A dummy body is used
+    // for static bodies without an associated solver body.
+    //
+    // SAFETY: Constraint graph coloring guarantees that the two bodies are distinct, and that no
+    //         other constraint solved in parallel within this color touches the same bodies.
+    let (b1, b2) =
+        unsafe { access.get_pair_unchecked_mut(constraint.body_index1, constraint.body_index2) };
+    if let Some((body, inertia)) = b1 {
+        body1 = body;
         inertia1 = inertia;
     }
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body2) } {
-        body2 = body.into_inner();
+    if let Some((body, inertia)) = b2 {
+        body2 = body;
         inertia2 = inertia;
     }
 
@@ -826,7 +850,7 @@ fn warm_start_internal(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 fn solve_contacts<const USE_BIAS: bool>(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia)>,
+    mut solver_bodies: ResMut<SolverBodies>,
     mut constraint_graph: ResMut<ConstraintGraph>,
     solver_config: Res<SolverConfig>,
     length_unit: Res<PhysicsLengthUnit>,
@@ -838,13 +862,15 @@ fn solve_contacts<const USE_BIAS: bool>(
     let delta_secs = time.delta_secs();
     let max_overlap_solve_speed = solver_config.max_overlap_solve_speed * length_unit.0;
 
+    let access = solver_bodies.access();
+
     // Solve overflow constraints serially. They have lower priority, so they are solved first.
     for constraint in constraint_graph.colors[COLOR_OVERFLOW_INDEX]
         .contact_constraints
         .iter_mut()
     {
         solve_contacts_internal::<USE_BIAS>(
-            &bodies,
+            &access,
             constraint,
             max_overlap_solve_speed,
             delta_secs,
@@ -860,7 +886,7 @@ fn solve_contacts<const USE_BIAS: bool>(
     {
         crate::utils::par_for_each(&mut color.contact_constraints, 64, |_i, constraint| {
             solve_contacts_internal::<USE_BIAS>(
-                &bodies,
+                &access,
                 constraint,
                 max_overlap_solve_speed,
                 delta_secs,
@@ -876,7 +902,7 @@ fn solve_contacts<const USE_BIAS: bool>(
 }
 
 fn solve_contacts_internal<const USE_BIAS: bool>(
-    bodies: &Query<(&mut SolverBody, &SolverBodyInertia)>,
+    access: &SolverBodiesAccess,
     constraint: &mut ContactConstraint,
     max_overlap_solve_speed: f32,
     delta_secs: f32,
@@ -887,13 +913,19 @@ fn solve_contacts_internal<const USE_BIAS: bool>(
     let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
     let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-    // Get the solver bodies for the two colliding entities.
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body1) } {
-        body1 = body.into_inner();
+    // Get the solver bodies for the two colliding bodies. A dummy body is used
+    // for static bodies without an associated solver body.
+    //
+    // SAFETY: Constraint graph coloring guarantees that the two bodies are distinct, and that no
+    //         other constraint solved in parallel within this color touches the same bodies.
+    let (b1, b2) =
+        unsafe { access.get_pair_unchecked_mut(constraint.body_index1, constraint.body_index2) };
+    if let Some((body, inertia)) = b1 {
+        body1 = body;
         inertia1 = inertia;
     }
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body2) } {
-        body2 = body.into_inner();
+    if let Some((body, inertia)) = b2 {
+        body2 = body;
         inertia2 = inertia;
     }
 
@@ -925,7 +957,7 @@ fn solve_contacts_internal<const USE_BIAS: bool>(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 fn solve_restitution(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia)>,
+    mut solver_bodies: ResMut<SolverBodies>,
     mut constraint_graph: ResMut<ConstraintGraph>,
     solver_config: Res<SolverConfig>,
     length_unit: Res<PhysicsLengthUnit>,
@@ -936,13 +968,15 @@ fn solve_restitution(
     // The restitution threshold determining the speed required for restitution to be applied.
     let threshold = solver_config.restitution_threshold * length_unit.0;
 
+    let access = solver_bodies.access();
+
     // Solve restitution for overflow constraints serially. They have lower priority, so they are solved first.
     for constraint in constraint_graph.colors[COLOR_OVERFLOW_INDEX]
         .contact_constraints
         .iter_mut()
     {
         solve_restitution_internal(
-            &bodies,
+            &access,
             constraint,
             threshold,
             solver_config.restitution_iterations,
@@ -958,7 +992,7 @@ fn solve_restitution(
     {
         crate::utils::par_for_each(&mut color.contact_constraints, 64, |_i, constraint| {
             solve_restitution_internal(
-                &bodies,
+                &access,
                 constraint,
                 threshold,
                 solver_config.restitution_iterations,
@@ -970,7 +1004,7 @@ fn solve_restitution(
 }
 
 fn solve_restitution_internal(
-    bodies: &Query<(&mut SolverBody, &SolverBodyInertia)>,
+    access: &SolverBodiesAccess,
     constraint: &mut ContactConstraint,
     threshold: f32,
     iterations: usize,
@@ -987,13 +1021,19 @@ fn solve_restitution_internal(
     let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
     let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-    // Get the solver bodies for the two colliding entities.
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body1) } {
-        body1 = body.into_inner();
+    // Get the solver bodies for the two colliding bodies. A dummy body is used
+    // for static bodies without an associated solver body.
+    //
+    // SAFETY: Constraint graph coloring guarantees that the two bodies are distinct, and that no
+    //         other constraint solved in parallel within this color touches the same bodies.
+    let (b1, b2) =
+        unsafe { access.get_pair_unchecked_mut(constraint.body_index1, constraint.body_index2) };
+    if let Some((body, inertia)) = b1 {
+        body1 = body;
         inertia1 = inertia;
     }
-    if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(constraint.body2) } {
-        body2 = body.into_inner();
+    if let Some((body, inertia)) = b2 {
+        body2 = body;
         inertia2 = inertia;
     }
 
@@ -1054,11 +1094,14 @@ fn store_contact_impulses(
 /// Applies velocity corrections caused by joint damping.
 #[allow(clippy::type_complexity)]
 pub fn joint_damping<T: Component + EntityConstraint<2>>(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia)>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    index_query: Query<&SolverBodyIndex>,
     joints: Query<(&T, &JointDamping)>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
+
+    let access = solver_bodies.access();
 
     let mut dummy_body1 = SolverBody::DUMMY;
     let mut dummy_body2 = SolverBody::DUMMY;
@@ -1066,16 +1109,32 @@ pub fn joint_damping<T: Component + EntityConstraint<2>>(
     for (joint, damping) in &joints {
         let entities = joint.entities();
 
+        // Map the two jointed entities to their solver body indices, using an invalid index
+        // for static bodies without an associated solver body.
+        let index1 = index_query
+            .get(entities[0])
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+        let index2 = index_query
+            .get(entities[1])
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+
+        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-        // Get the solver bodies for the two jointed entities.
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entities[0]) } {
-            body1 = body.into_inner();
+        // Get the solver bodies for the two jointed bodies.
+        //
+        // SAFETY: The two jointed bodies are distinct, and joints are processed serially here.
+        let (b1, b2) = unsafe { access.get_pair_unchecked_mut(index1, index2) };
+        if let Some((body, inertia)) = b1 {
+            body1 = body;
             inertia1 = inertia;
         }
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entities[1]) } {
-            body2 = body.into_inner();
+        if let Some((body, inertia)) = b2 {
+            body2 = body;
             inertia2 = inertia;
         }
 

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -904,13 +904,12 @@ fn solve_contacts_internal<const USE_BIAS: bool>(
         _ => {}
     }
 
-    constraint.solve(
+    constraint.solve::<USE_BIAS>(
         body1,
         body2,
         inertia1,
         inertia2,
         delta_secs,
-        USE_BIAS,
         max_overlap_solve_speed,
     );
 }

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -1119,7 +1119,9 @@ pub fn joint_damping<T: Component + EntityConstraint<2>>(
             .copied()
             .unwrap_or(SolverBodyIndex::INVALID);
 
-        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+        if index1 == index2 {
+            continue;
+        }
 
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -6,10 +6,14 @@
 //!
 //! - [`SolverBody`]: The body state used by the solver.
 //! - [`SolverBodyInertia`]: The inertial properties of a body used by the solver.
+//! - [`SolverBodyIndex`]: A component storing the index of a body in the [`SolverBodies`] resource.
+//! - [`SolverBodies`]: A resource storing [`SolverBody`]s contiguously for awake, active bodies.
 
 mod plugin;
 
 pub use plugin::SolverBodyPlugin;
+
+use core::marker::PhantomData;
 
 use bevy::prelude::*;
 
@@ -24,8 +28,9 @@ use crate::{SymmetricTensor, math::Vector, prelude::LockedAxes};
 /// designed to improve memory locality and performance.
 ///
 /// Only awake dynamic bodies and kinematic bodies have an associated solver body,
-/// stored as a component on the body entity. Static bodies and sleeping dynamic bodies
-/// do not move, so they instead use a "dummy state" with [`SolverBody::default()`].
+/// stored contiguously in the [`SolverBodies`] resource and indexed by a [`SolverBodyIndex`]
+/// component on the body entity. Static bodies and sleeping dynamic bodies do not move,
+/// so they instead use a "dummy state" with [`SolverBody::default()`].
 ///
 /// # Representation
 ///
@@ -52,10 +57,10 @@ use crate::{SymmetricTensor, math::Vector, prelude::LockedAxes};
 /// wide SIMD types via scatter/gather operations in the future when SIMD optimizations
 /// are implemented.
 // TODO: Is there a better layout for 3D?
-#[derive(Component, Clone, Debug, Default, Reflect)]
+#[derive(Clone, Debug, Default, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, Debug)]
+#[reflect(Debug)]
 pub struct SolverBody {
     /// The linear velocity of the body.
     ///
@@ -217,10 +222,10 @@ The API abstracts over this difference in representation to reduce complexity.
 /// and flags indicating whether the body is static or has locked axes.
 ///
 /// 16 bytes in 2D and 32 bytes in 3D.
-#[derive(Component, Clone, Debug, Reflect)]
+#[derive(Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, Debug)]
+#[reflect(Debug)]
 pub struct SolverBodyInertia {
     /// The effective inverse mass of the body,
     /// taking into account any locked axes.
@@ -522,5 +527,269 @@ impl SolverBodyInertia {
     #[inline]
     pub fn flags(&self) -> InertiaFlags {
         self.flags
+    }
+}
+
+/// A component storing the index of an entity's [`SolverBody`] in the [`SolverBodies`] resource.
+///
+/// Only awake dynamic and kinematic bodies have an associated solver body.
+/// Static bodies and sleeping dynamic bodies do not have a solver body, and instead
+/// use a "dummy state" with [`SolverBody::default()`] and [`SolverBodyInertia::default()`].
+///
+/// This component is added, removed, and updated automatically by the solver plugin,
+/// and should not be modified by users.
+#[derive(Component, Clone, Copy, Debug, Deref, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
+#[reflect(Component, Debug, PartialEq, Hash)]
+pub struct SolverBodyIndex(pub u32);
+
+impl SolverBodyIndex {
+    /// An invalid index used to indicate that a body has no associated [`SolverBody`],
+    /// such as a static body. The solver substitutes a dummy state in this case.
+    pub const INVALID: Self = Self(u32::MAX);
+
+    /// Returns `true` if the index refers to a valid [`SolverBody`] in the [`SolverBodies`] resource.
+    #[inline]
+    pub fn is_valid(&self) -> bool {
+        self.0 != u32::MAX
+    }
+}
+
+impl Default for SolverBodyIndex {
+    fn default() -> Self {
+        Self::INVALID
+    }
+}
+
+/// A resource storing [solver bodies](SolverBody) and their [inertial properties](SolverBodyInertia)
+/// contiguously for awake, active rigid bodies.
+///
+/// Each entity with a solver body stores an index into this resource in a [`SolverBodyIndex`] component.
+#[derive(Resource, Default)]
+pub struct SolverBodies {
+    // TODO: Use `UniqueEntityVec`.
+    entities: Vec<Entity>,
+    bodies: Vec<SolverBody>,
+    inertias: Vec<SolverBodyInertia>,
+}
+
+impl SolverBodies {
+    /// Creates a new empty collection of solver bodies.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            entities: Vec::new(),
+            bodies: Vec::new(),
+            inertias: Vec::new(),
+        }
+    }
+
+    /// Returns the number of solver bodies.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bodies.len()
+    }
+
+    /// Returns `true` if there are no solver bodies.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bodies.is_empty()
+    }
+
+    /// Returns `true` if the given [`SolverBodyIndex`] refers to a body in this collection.
+    #[inline]
+    pub fn contains_index(&self, index: SolverBodyIndex) -> bool {
+        (index.0 as usize) < self.bodies.len()
+    }
+
+    /// Returns `true` if the given entity has a solver body in this collection.
+    #[inline]
+    pub fn contains_entity(&self, entity: Entity) -> bool {
+        self.entities.contains(&entity)
+    }
+
+    /// Returns the [`Entity`] associated with the given solver body index, if any.
+    #[inline]
+    pub fn get_entity(&self, index: SolverBodyIndex) -> Option<Entity> {
+        self.entities.get(index.0 as usize).copied()
+    }
+
+    /// Returns a reference to the [`SolverBody`] with the given index, if it exists.
+    #[inline]
+    pub fn get(&self, index: SolverBodyIndex) -> Option<&SolverBody> {
+        self.bodies.get(index.0 as usize)
+    }
+
+    /// Returns a mutable reference to the [`SolverBody`] with the given index, if it exists.
+    #[inline]
+    pub fn get_mut(&mut self, index: SolverBodyIndex) -> Option<&mut SolverBody> {
+        self.bodies.get_mut(index.0 as usize)
+    }
+
+    /// Returns a reference to the [`SolverBodyInertia`] with the given index, if it exists.
+    #[inline]
+    pub fn get_inertia(&self, index: SolverBodyIndex) -> Option<&SolverBodyInertia> {
+        self.inertias.get(index.0 as usize)
+    }
+
+    /// Returns a mutable reference to the [`SolverBodyInertia`] with the given index, if it exists.
+    #[inline]
+    pub fn get_inertia_mut(&mut self, index: SolverBodyIndex) -> Option<&mut SolverBodyInertia> {
+        self.inertias.get_mut(index.0 as usize)
+    }
+
+    /// Returns an iterator over mutable references to the solver bodies.
+    #[inline]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut SolverBody> {
+        self.bodies.iter_mut()
+    }
+
+    /// Adds a new solver body for the given entity, returning its [`SolverBodyIndex`].
+    #[inline]
+    pub fn push(
+        &mut self,
+        entity: Entity,
+        body: SolverBody,
+        inertia: SolverBodyInertia,
+    ) -> SolverBodyIndex {
+        let index = SolverBodyIndex(self.bodies.len() as u32);
+        self.entities.push(entity);
+        self.bodies.push(body);
+        self.inertias.push(inertia);
+        index
+    }
+
+    /// Removes the solver body with the given index, swapping in the last body to fill the gap.
+    ///
+    /// Returns the entity whose body was moved into `index`, so that its [`SolverBodyIndex`]
+    /// component can be updated. Returns `None` if the removed body was the last one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    #[inline]
+    pub fn swap_remove(&mut self, index: SolverBodyIndex) -> Option<Entity> {
+        self.entities.swap_remove(index.0 as usize);
+        self.bodies.swap_remove(index.0 as usize);
+        self.inertias.swap_remove(index.0 as usize);
+        // TODO: Do this differently
+        // If the removed body was not the last one, a body was swapped into its slot.
+        self.entities.get(index.0 as usize).copied()
+    }
+
+    /// Clears all solver bodies.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.entities.clear();
+        self.bodies.clear();
+        self.inertias.clear();
+    }
+
+    /// Returns a [`SolverBodiesAccess`] that allows obtaining mutable references to solver bodies
+    /// from parallel closures via raw pointers.
+    ///
+    /// This allows the solver to hand out mutable references to disjoint bodies concurrently,
+    /// which is sound as long as the caller ensures that no two closures access the same body
+    /// at the same time. This is guaranteed by constraint graph coloring.
+    #[inline]
+    pub fn access(&mut self) -> SolverBodiesAccess<'_> {
+        SolverBodiesAccess {
+            bodies: self.bodies.as_mut_ptr(),
+            inertias: self.inertias.as_mut_ptr(),
+            len: self.bodies.len(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Mutable disjoint access to the bodies and inertias of a [`SolverBodies`] resource
+/// for use inside the parallel solver.
+///
+/// The caller is responsible for ensuring that no two closures access the same body
+/// at the same time. This is guaranteed by constraint graph coloring and each
+/// [`SolverBodyIndex`] being unique to a single body.
+pub struct SolverBodiesAccess<'a> {
+    bodies: *mut SolverBody,
+    inertias: *mut SolverBodyInertia,
+    len: usize,
+    _marker: PhantomData<&'a mut SolverBodies>,
+}
+
+// SAFETY: The caller is responsible for only accessing disjoint indices concurrently.
+unsafe impl Send for SolverBodiesAccess<'_> {}
+// SAFETY: The caller is responsible for only accessing disjoint indices concurrently.
+unsafe impl Sync for SolverBodiesAccess<'_> {}
+
+impl SolverBodiesAccess<'_> {
+    /// Returns the number of solver bodies.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if there are no solver bodies.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns a mutable reference to the [`SolverBody`] with the given index.
+    ///
+    /// # Safety
+    ///
+    /// The index must be in bounds, and no other reference to the same body may be held concurrently.
+    #[inline]
+    #[expect(clippy::mut_from_ref)]
+    pub unsafe fn body_unchecked_mut(&self, index: SolverBodyIndex) -> &mut SolverBody {
+        debug_assert!((index.0 as usize) < self.len);
+        unsafe { &mut *self.bodies.add(index.0 as usize) }
+    }
+
+    /// Returns a mutable reference to the [`SolverBodyInertia`] with the given index.
+    ///
+    /// # Safety
+    ///
+    /// The index must be in bounds, and no other reference to the same inertia may be held concurrently.
+    #[inline]
+    #[expect(clippy::mut_from_ref)]
+    pub unsafe fn inertia_unchecked_mut(&self, index: SolverBodyIndex) -> &mut SolverBodyInertia {
+        debug_assert!((index.0 as usize) < self.len);
+        unsafe { &mut *self.inertias.add(index.0 as usize) }
+    }
+
+    /// Returns mutable body references and inertia references for the two given indices.
+    ///
+    /// An [`SolverBodyIndex::INVALID`] index yields `None` for that body, in which case the caller
+    /// should substitute [`SolverBody::DUMMY`] and [`SolverBodyInertia::DUMMY`].
+    ///
+    /// # Safety
+    ///
+    /// If both indices are valid, they must be different. Valid indices must be in bounds,
+    /// and no other references to the same bodies may be held concurrently.
+    #[inline]
+    #[expect(clippy::mut_from_ref)]
+    pub unsafe fn get_pair_unchecked_mut(
+        &self,
+        a: SolverBodyIndex,
+        b: SolverBodyIndex,
+    ) -> (
+        Option<(&mut SolverBody, &SolverBodyInertia)>,
+        Option<(&mut SolverBody, &SolverBodyInertia)>,
+    ) {
+        debug_assert!(!a.is_valid() || !b.is_valid() || a != b);
+        unsafe {
+            let first = a.is_valid().then(|| {
+                (
+                    &mut *self.bodies.add(a.0 as usize),
+                    &*self.inertias.add(a.0 as usize),
+                )
+            });
+            let second = b.is_valid().then(|| {
+                (
+                    &mut *self.bodies.add(b.0 as usize),
+                    &*self.inertias.add(b.0 as usize),
+                )
+            });
+            (first, second)
+        }
     }
 }

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -158,12 +158,14 @@ bitflags::bitflags! {
         const IS_KINEMATIC = 1 << 6;
         /// Set if gyroscopic motion is enabled.
         const GYROSCOPIC_MOTION = 1 << 7;
+        /// Set if the body has a custom position integration implementation.
+        const CUSTOM_POSITION_INTEGRATION = 1 << 8;
         /// Set during the continuous collision stage if the body moved fast enough
         /// to be treated as a "fast body" and have its motion swept. Transient.
-        const IS_FAST = 1 << 8;
+        const IS_FAST = 1 << 9;
         /// Set during the continuous collision stage if the body's motion was stopped
         /// at a time of impact. Transient.
-        const HAD_TIME_OF_IMPACT = 1 << 9;
+        const HAD_TIME_OF_IMPACT = 1 << 10;
     }
 }
 
@@ -593,6 +595,36 @@ impl SolverBodies {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.bodies.is_empty()
+    }
+
+    /// Returns a slice of the entities that have solver bodies.
+    #[inline]
+    pub fn entities(&self) -> &[Entity] {
+        &self.entities
+    }
+
+    /// Returns a slice of the solver bodies.
+    #[inline]
+    pub fn bodies(&self) -> &[SolverBody] {
+        &self.bodies
+    }
+
+    /// Returns a mutable slice of the solver bodies.
+    #[inline]
+    pub fn bodies_mut(&mut self) -> &mut [SolverBody] {
+        &mut self.bodies
+    }
+
+    /// Returns a slice of the solver body inertias.
+    #[inline]
+    pub fn inertias(&self) -> &[SolverBodyInertia] {
+        &self.inertias
+    }
+
+    /// Returns a mutable slice of the solver body inertias.
+    #[inline]
+    pub fn inertias_mut(&mut self) -> &mut [SolverBodyInertia] {
+        &mut self.inertias
     }
 
     /// Returns `true` if the given [`SolverBodyIndex`] refers to a body in this collection.

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -542,6 +542,8 @@ impl SolverBodyInertia {
 /// and should not be modified by users.
 #[derive(Component, Clone, Copy, Debug, Deref, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
 #[reflect(Component, Debug, PartialEq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct SolverBodyIndex(pub u32);
 
 impl SolverBodyIndex {

--- a/src/dynamics/solver/solver_body/plugin.rs
+++ b/src/dynamics/solver/solver_body/plugin.rs
@@ -370,7 +370,7 @@ fn writeback_solver_bodies(
 #[cfg(feature = "3d")]
 pub(crate) fn update_solver_body_angular_inertia(
     mut solver_bodies: ResMut<SolverBodies>,
-    query: Query<(&SolverBodyIndex, &ComputedAngularInertia, &Rotation)>,
+    mut query: Query<(&SolverBodyIndex, &ComputedAngularInertia, &Rotation)>,
 ) {
     let access = solver_bodies.access();
 

--- a/src/dynamics/solver/solver_body/plugin.rs
+++ b/src/dynamics/solver/solver_body/plugin.rs
@@ -1,9 +1,9 @@
 use bevy::{
-    ecs::{entity_disabling::Disabled, query::QueryFilter, world::DeferredWorld},
+    ecs::{entity_disabling::Disabled, query::QueryFilter},
     prelude::*,
 };
 
-use super::{SolverBody, SolverBodyInertia};
+use super::{SolverBodies, SolverBody, SolverBodyIndex, SolverBodyInertia};
 use crate::{
     AngularVelocity, LinearVelocity, PhysicsSchedule, Position, RigidBody, RigidBodyActiveFilter,
     RigidBodyDisabled, Rot, Rotation, Sleeping, SolverSystems, Vector,
@@ -21,7 +21,7 @@ use crate::{
     prelude::SubstepSchedule,
 };
 
-/// A plugin for managing solver bodies.
+/// A plugin for managing solver bodies stored in the [`SolverBodies`] resource.
 ///
 /// A [`SolverBody`] is created for each dynamic and kinematic rigid body when:
 ///
@@ -36,49 +36,63 @@ use crate::{
 /// 2. The rigid body is disabled by adding [`Disabled`]/[`RigidBodyDisabled`].
 /// 3. The rigid body is put to sleep.
 /// 4. The rigid body is set to be static.
+///
+/// Each body's position in the [`SolverBodies`] resource is tracked by a [`SolverBodyIndex`]
+/// component, which is only present while the body has an associated solver body.
 pub struct SolverBodyPlugin;
 
 impl Plugin for SolverBodyPlugin {
     fn build(&self, app: &mut App) {
-        // Add or remove solver bodies when `RigidBody` component is added or replaced.
+        app.init_resource::<SolverBodies>();
+
+        // Add or remove solver bodies when the `RigidBody` component is added or replaced.
         app.add_observer(on_insert_rigid_body);
 
         // Add a solver body for each dynamic and kinematic rigid body
         // when the associated rigid body is enabled or woken up.
         app.add_observer(
             |trigger: On<Remove, RigidBodyDisabled>,
-             rb_query: Query<&RigidBody, Without<Sleeping>>,
+             rb_query: Query<(&RigidBody, Has<SolverBodyIndex>), Without<Sleeping>>,
+             solver_bodies: ResMut<SolverBodies>,
              commands: Commands| {
-                add_solver_body::<Without<Sleeping>>(In(trigger.entity), rb_query, commands);
+                add_solver_body::<Without<Sleeping>>(
+                    In(trigger.entity),
+                    rb_query,
+                    solver_bodies,
+                    commands,
+                );
             },
         );
         app.add_observer(
             |trigger: On<Remove, Disabled>,
              rb_query: Query<
-                &RigidBody,
+                (&RigidBody, Has<SolverBodyIndex>),
                 (
                     // The body still has `Disabled` at this point,
-                    // and we need to include in the query to match against the entity.
+                    // and we need to include it in the query to match against the entity.
                     With<Disabled>,
                     Without<RigidBodyDisabled>,
                     Without<Sleeping>,
                 ),
             >,
+             solver_bodies: ResMut<SolverBodies>,
              commands: Commands| {
                 add_solver_body::<(
                     With<Disabled>,
                     Without<RigidBodyDisabled>,
                     Without<Sleeping>,
-                )>(In(trigger.entity), rb_query, commands);
+                )>(In(trigger.entity), rb_query, solver_bodies, commands);
             },
         );
         app.add_observer(
             |trigger: On<Remove, Sleeping>,
-             rb_query: Query<&RigidBody, Without<RigidBodyDisabled>>,
+             rb_query: Query<(&RigidBody, Has<SolverBodyIndex>), Without<RigidBodyDisabled>>,
+             solver_bodies: ResMut<SolverBodies>,
              commands: Commands| {
                 add_solver_body::<Without<RigidBodyDisabled>>(
                     In(trigger.entity),
                     rb_query,
+                    solver_bodies,
                     commands,
                 );
             },
@@ -86,16 +100,21 @@ impl Plugin for SolverBodyPlugin {
 
         // Remove solver bodies when their associated rigid body is removed.
         app.add_observer(
-            |trigger: On<Remove, RigidBody>, deferred_world: DeferredWorld| {
-                remove_solver_body(In(trigger.entity), deferred_world);
+            |trigger: On<Remove, RigidBody>,
+             index_query: Query<&mut SolverBodyIndex>,
+             solver_bodies: ResMut<SolverBodies>,
+             commands: Commands| {
+                remove_solver_body(In(trigger.entity), index_query, solver_bodies, commands);
             },
         );
 
         // Remove solver bodies when their associated rigid body is disabled or put to sleep.
         app.add_observer(
             |trigger: On<Add, (Disabled, RigidBodyDisabled, Sleeping)>,
-             deferred_world: DeferredWorld| {
-                remove_solver_body(In(trigger.entity), deferred_world);
+             index_query: Query<&mut SolverBodyIndex>,
+             solver_bodies: ResMut<SolverBodies>,
+             commands: Commands| {
+                remove_solver_body(In(trigger.entity), index_query, solver_bodies, commands);
             },
         );
 
@@ -132,58 +151,85 @@ impl Plugin for SolverBodyPlugin {
 
 fn on_insert_rigid_body(
     trigger: On<Insert, RigidBody>,
-    bodies: Query<(&RigidBody, Has<SolverBody>), RigidBodyActiveFilter>,
+    bodies: Query<(&RigidBody, Has<SolverBodyIndex>), RigidBodyActiveFilter>,
+    index_query: Query<&mut SolverBodyIndex>,
+    mut solver_bodies: ResMut<SolverBodies>,
     mut commands: Commands,
 ) {
-    let Ok((rb, has_solver_body)) = bodies.get(trigger.entity) else {
+    let entity = trigger.entity;
+    let Ok((rb, has_solver_body)) = bodies.get(entity) else {
         return;
     };
 
     if rb.is_static() && has_solver_body {
-        // Remove the solver body if the rigid body is static.
-        commands
-            .entity(trigger.entity)
-            .try_remove::<(SolverBody, SolverBodyInertia)>();
+        // Remove the solver body if the rigid body is now static.
+        remove_solver_body_inner(entity, index_query, &mut solver_bodies, &mut commands);
     } else if !rb.is_static() && !has_solver_body {
         // Create a new solver body if the rigid body is dynamic or kinematic.
-        commands
-            .entity(trigger.entity)
-            .try_insert((SolverBody::default(), SolverBodyInertia::default()));
+        add_solver_body_inner(entity, &mut solver_bodies, &mut commands);
     }
 }
 
 fn add_solver_body<F: QueryFilter>(
     In(entity): In<Entity>,
-    mut rb_query: Query<&RigidBody, F>,
+    rb_query: Query<(&RigidBody, Has<SolverBodyIndex>), F>,
+    mut solver_bodies: ResMut<SolverBodies>,
     mut commands: Commands,
 ) {
-    if let Ok(rb) = rb_query.get_mut(entity) {
-        if rb.is_static() {
+    if let Ok((rb, has_solver_body)) = rb_query.get(entity) {
+        if rb.is_static() || has_solver_body {
             return;
         }
 
-        // Create a new solver body if the rigid body is dynamic or kinematic.
-        commands
-            .entity(entity)
-            .try_insert((SolverBody::default(), SolverBodyInertia::default()));
+        add_solver_body_inner(entity, &mut solver_bodies, &mut commands);
     }
 }
 
-fn remove_solver_body(In(entity): In<Entity>, mut deferred_world: DeferredWorld) {
-    let entity_ref = deferred_world.entity(entity);
-    if entity_ref.contains::<SolverBody>() {
-        deferred_world
-            .commands()
-            .entity(entity)
-            .try_remove::<(SolverBody, SolverBodyInertia)>();
+/// Pushes a new solver body for `entity` and inserts its [`SolverBodyIndex`] component.
+fn add_solver_body_inner(entity: Entity, solver_bodies: &mut SolverBodies, commands: &mut Commands) {
+    let index = solver_bodies.push(entity, SolverBody::default(), SolverBodyInertia::default());
+    commands.entity(entity).try_insert(index);
+}
+
+fn remove_solver_body(
+    In(entity): In<Entity>,
+    index_query: Query<&mut SolverBodyIndex>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    mut commands: Commands,
+) {
+    remove_solver_body_inner(entity, index_query, &mut solver_bodies, &mut commands);
+}
+
+/// Swap-removes the solver body of `entity` from the [`SolverBodies`] resource, fixes up the
+/// [`SolverBodyIndex`] of the body swapped into its slot, and removes the index component.
+fn remove_solver_body_inner(
+    entity: Entity,
+    mut index_query: Query<&mut SolverBodyIndex>,
+    solver_bodies: &mut SolverBodies,
+    commands: &mut Commands,
+) {
+    let Ok(index) = index_query.get(entity).copied() else {
+        return;
+    };
+    if !index.is_valid() {
+        return;
     }
+
+    // Swap-remove the body. If another body was swapped into this slot, update its index.
+    if let Some(swapped_entity) = solver_bodies.swap_remove(index)
+        && let Ok(mut swapped_index) = index_query.get_mut(swapped_entity)
+    {
+        *swapped_index = index;
+    }
+
+    commands.entity(entity).try_remove::<SolverBodyIndex>();
 }
 
 fn prepare_solver_bodies(
-    mut query: Query<(
+    mut solver_bodies: ResMut<SolverBodies>,
+    query: Query<(
         &RigidBody,
-        &mut SolverBody,
-        &mut SolverBodyInertia,
+        &SolverBodyIndex,
         &LinearVelocity,
         &AngularVelocity,
         &Rotation,
@@ -193,12 +239,13 @@ fn prepare_solver_bodies(
         Option<&Dominance>,
     )>,
 ) {
+    let access = solver_bodies.access();
+
     #[allow(unused_variables)]
-    query.par_iter_mut().for_each(
+    query.par_iter().for_each(
         |(
             rb,
-            mut solver_body,
-            mut inertial_properties,
+            index,
             linear_velocity,
             angular_velocity,
             rotation,
@@ -207,6 +254,11 @@ fn prepare_solver_bodies(
             locked_axes,
             dominance,
         )| {
+            // SAFETY: Each entity has a unique, valid solver body index, so the writes below
+            //         target disjoint bodies and inertias.
+            let solver_body = unsafe { access.body_unchecked_mut(*index) };
+            let inertial_properties = unsafe { access.inertia_unchecked_mut(*index) };
+
             solver_body.linear_velocity = linear_velocity.0;
             solver_body.angular_velocity = angular_velocity.0;
             solver_body.delta_position = Vector::ZERO;
@@ -262,8 +314,9 @@ fn prepare_solver_bodies(
 /// Writes back solver body data to rigid bodies.
 #[allow(clippy::type_complexity)]
 fn writeback_solver_bodies(
+    solver_bodies: Res<SolverBodies>,
     mut query: Query<(
-        &SolverBody,
+        &SolverBodyIndex,
         &mut Position,
         &mut Rotation,
         &ComputedCenterOfMass,
@@ -275,7 +328,11 @@ fn writeback_solver_bodies(
     let start = bevy::platform::time::Instant::now();
 
     query.par_iter_mut().for_each(
-        |(solver_body, mut pos, mut rot, com, mut lin_vel, mut ang_vel)| {
+        |(index, mut pos, mut rot, com, mut lin_vel, mut ang_vel)| {
+            let Some(solver_body) = solver_bodies.get(*index) else {
+                return;
+            };
+
             // Write back the position and rotation deltas,
             // rotating the body around its center of mass.
             let old_world_com = *rot * com.0;
@@ -296,11 +353,17 @@ fn writeback_solver_bodies(
 
 #[cfg(feature = "3d")]
 pub(crate) fn update_solver_body_angular_inertia(
-    mut query: Query<(&mut SolverBodyInertia, &ComputedAngularInertia, &Rotation)>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    query: Query<(&SolverBodyIndex, &ComputedAngularInertia, &Rotation)>,
 ) {
+    let access = solver_bodies.access();
+
     query
-        .par_iter_mut()
-        .for_each(|(mut inertia, angular_inertia, rotation)| {
+        .par_iter()
+        .for_each(|(index, angular_inertia, rotation)| {
+            // SAFETY: Each entity has a unique, valid solver body index, so the writes below
+            //         target disjoint inertias.
+            let inertia = unsafe { access.inertia_unchecked_mut(*index) };
             inertia.update_effective_inv_angular_inertia(angular_inertia, rotation.0);
         });
 }
@@ -323,7 +386,10 @@ mod tests {
     }
 
     fn has_solver_body(app: &App, entity: Entity) -> bool {
-        app.world().get::<SolverBody>(entity).is_some()
+        app.world()
+            .resource::<SolverBodies>()
+            .contains_entity(entity)
+            && app.world().get::<SolverBodyIndex>(entity).is_some()
     }
 
     #[test]

--- a/src/dynamics/solver/solver_body/plugin.rs
+++ b/src/dynamics/solver/solver_body/plugin.rs
@@ -7,7 +7,10 @@ use super::{SolverBodies, SolverBody, SolverBodyIndex, SolverBodyInertia};
 use crate::{
     AngularVelocity, LinearVelocity, PhysicsSchedule, Position, RigidBody, RigidBodyActiveFilter,
     RigidBodyDisabled, Rot, Rotation, Sleeping, SolverSystems, Vector,
-    dynamics::solver::{SolverDiagnostics, solver_body::SolverBodyFlags},
+    dynamics::{
+        integrator::CustomPositionIntegration,
+        solver::{SolverDiagnostics, solver_body::SolverBodyFlags},
+    },
     math::ToRealPrecision,
     prelude::{
         AppDiagnosticsExt, ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, Dominance,
@@ -186,7 +189,11 @@ fn add_solver_body<F: QueryFilter>(
 }
 
 /// Pushes a new solver body for `entity` and inserts its [`SolverBodyIndex`] component.
-fn add_solver_body_inner(entity: Entity, solver_bodies: &mut SolverBodies, commands: &mut Commands) {
+fn add_solver_body_inner(
+    entity: Entity,
+    solver_bodies: &mut SolverBodies,
+    commands: &mut Commands,
+) {
     let index = solver_bodies.push(entity, SolverBody::default(), SolverBodyInertia::default());
     commands.entity(entity).try_insert(index);
 }
@@ -237,6 +244,7 @@ fn prepare_solver_bodies(
         &ComputedAngularInertia,
         Option<&LockedAxes>,
         Option<&Dominance>,
+        Has<CustomPositionIntegration>,
     )>,
 ) {
     let access = solver_bodies.access();
@@ -253,6 +261,7 @@ fn prepare_solver_bodies(
             angular_inertia,
             locked_axes,
             dominance,
+            custom_position_integration,
         )| {
             // SAFETY: Each entity has a unique, valid solver body index, so the writes below
             //         target disjoint bodies and inertias.
@@ -279,6 +288,10 @@ fn prepare_solver_bodies(
             solver_body
                 .flags
                 .set(SolverBodyFlags::IS_KINEMATIC, rb.is_kinematic());
+            solver_body.flags.set(
+                SolverBodyFlags::CUSTOM_POSITION_INTEGRATION,
+                custom_position_integration,
+            );
 
             #[cfg(feature = "3d")]
             {
@@ -327,8 +340,9 @@ fn writeback_solver_bodies(
 ) {
     let start = bevy::platform::time::Instant::now();
 
-    query.par_iter_mut().for_each(
-        |(index, mut pos, mut rot, com, mut lin_vel, mut ang_vel)| {
+    query
+        .par_iter_mut()
+        .for_each(|(index, mut pos, mut rot, com, mut lin_vel, mut ang_vel)| {
             let Some(solver_body) = solver_bodies.get(*index) else {
                 return;
             };
@@ -345,8 +359,7 @@ fn writeback_solver_bodies(
             // Write back velocities.
             lin_vel.0 = solver_body.linear_velocity;
             ang_vel.0 = solver_body.angular_velocity;
-        },
-    );
+        });
 
     diagnostics.finalize += start.elapsed();
 }

--- a/src/dynamics/solver/xpbd/plugin.rs
+++ b/src/dynamics/solver/xpbd/plugin.rs
@@ -7,7 +7,7 @@ use crate::{
         solver::{
             SolverConfig,
             schedule::SubstepSolverSystems,
-            solver_body::{SolverBody, SolverBodyInertia},
+            solver_body::{SolverBodies, SolverBody, SolverBodyIndex, SolverBodyInertia},
             xpbd::{XpbdConstraint, XpbdConstraintSolverData},
         },
     },
@@ -74,17 +74,21 @@ impl Plugin for XpbdSolverPlugin {
         app.add_systems(
             SubstepSchedule,
             (
-                |mut query: Query<
+                |solver_bodies: Res<SolverBodies>,
+                 mut query: Query<
                     (
-                        &SolverBody,
+                        &SolverBodyIndex,
                         &mut PreSolveDeltaPosition,
                         &mut PreSolveDeltaRotation,
                     ),
                     Without<RigidBodyDisabled>,
                 >| {
-                    for (body, mut pre_solve_delta_position, mut pre_solve_delta_rotation) in
+                    for (index, mut pre_solve_delta_position, mut pre_solve_delta_rotation) in
                         &mut query
                     {
+                        let Some(body) = solver_bodies.get(*index) else {
+                            continue;
+                        };
                         // Store the previous delta translation and rotation for XPBD velocity updates.
                         pre_solve_delta_position.0 = body.delta_position;
                         pre_solve_delta_rotation.0 = body.delta_rotation;
@@ -161,7 +165,8 @@ pub fn prepare_xpbd_joint<
 pub fn solve_xpbd_joint<
     C: Component<Mutability = Mutable> + EntityConstraint<2> + XpbdConstraint<2>,
 >(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia), Without<RigidBodyDisabled>>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    index_query: Query<&SolverBodyIndex, Without<RigidBodyDisabled>>,
     mut joints: Query<(&mut C, &mut C::SolverData), (Without<RigidBody>, Without<JointDisabled>)>,
     time: Res<Time>,
 ) where
@@ -169,22 +174,38 @@ pub fn solve_xpbd_joint<
 {
     let delta_secs = time.delta_secs();
 
+    let access = solver_bodies.access();
+
     let mut dummy_body1 = SolverBody::default();
     let mut dummy_body2 = SolverBody::default();
 
     for (mut joint, mut solver_data) in &mut joints {
         let [entity1, entity2] = joint.entities();
 
+        let index1 = index_query
+            .get(entity1)
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+        let index2 = index_query
+            .get(entity2)
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+
+        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-        // Get the solver bodies for the two colliding entities.
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entity1) } {
-            body1 = body.into_inner();
+        // Get the solver bodies for the two jointed bodies.
+        //
+        // SAFETY: The two jointed bodies are distinct, and joints are processed serially here.
+        let (b1, b2) = unsafe { access.get_pair_unchecked_mut(index1, index2) };
+        if let Some((body, inertia)) = b1 {
+            body1 = body;
             inertia1 = inertia;
         }
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entity2) } {
-            body2 = body.into_inner();
+        if let Some((body, inertia)) = b2 {
+            body2 = body;
             inertia2 = inertia;
         }
 
@@ -211,7 +232,8 @@ pub fn solve_xpbd_joint<
 pub fn warm_start_xpbd_motors<
     C: Component<Mutability = Mutable> + EntityConstraint<2> + XpbdConstraint<2>,
 >(
-    bodies: Query<(&mut SolverBody, &SolverBodyInertia), Without<RigidBodyDisabled>>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    index_query: Query<&SolverBodyIndex, Without<RigidBodyDisabled>>,
     mut joints: Query<(&C, &mut C::SolverData), (Without<RigidBody>, Without<JointDisabled>)>,
     time: Res<Time>,
     solver_config: Res<SolverConfig>,
@@ -220,21 +242,36 @@ pub fn warm_start_xpbd_motors<
 {
     let delta_secs = time.delta_secs();
 
+    let access = solver_bodies.access();
+
     let mut dummy_body1 = SolverBody::default();
     let mut dummy_body2 = SolverBody::default();
 
     for (joint, mut solver_data) in &mut joints {
         let [entity1, entity2] = joint.entities();
 
+        let index1 = index_query
+            .get(entity1)
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+        let index2 = index_query
+            .get(entity2)
+            .copied()
+            .unwrap_or(SolverBodyIndex::INVALID);
+
+        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
 
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entity1) } {
-            body1 = body.into_inner();
+        // SAFETY: The two jointed bodies are distinct, and joints are processed serially here.
+        let (b1, b2) = unsafe { access.get_pair_unchecked_mut(index1, index2) };
+        if let Some((body, inertia)) = b1 {
+            body1 = body;
             inertia1 = inertia;
         }
-        if let Ok((body, inertia)) = unsafe { bodies.get_unchecked(entity2) } {
-            body2 = body.into_inner();
+        if let Some((body, inertia)) = b2 {
+            body2 = body;
             inertia2 = inertia;
         }
 
@@ -257,12 +294,17 @@ pub fn warm_start_xpbd_motors<
 
 /// Updates the linear velocity of all dynamic bodies based on the change in position from the XPBD solver.
 fn project_linear_velocity(
-    mut bodies: Query<(&mut SolverBody, &PreSolveDeltaPosition), RigidBodyActiveFilter>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaPosition), RigidBodyActiveFilter>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
 
-    for (mut body, pre_solve_delta_pos) in &mut bodies {
+    let access = solver_bodies.access();
+
+    for (index, pre_solve_delta_pos) in &bodies {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
         // v = (x - x_prev) / h
         let new_lin_vel = (body.delta_position - pre_solve_delta_pos.0) / delta_secs;
         body.linear_velocity += new_lin_vel;
@@ -272,12 +314,17 @@ fn project_linear_velocity(
 /// Updates the angular velocity of all dynamic bodies based on the change in rotation from the XPBD solver.
 #[cfg(feature = "2d")]
 fn project_angular_velocity(
-    mut bodies: Query<(&mut SolverBody, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
 
-    for (mut body, pre_solve_delta_rot) in &mut bodies {
+    let access = solver_bodies.access();
+
+    for (index, pre_solve_delta_rot) in &bodies {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
         let new_ang_vel = pre_solve_delta_rot.angle_to(body.delta_rotation) / delta_secs;
         body.angular_velocity += new_ang_vel;
     }
@@ -286,12 +333,17 @@ fn project_angular_velocity(
 /// Updates the angular velocity of all dynamic bodies based on the change in rotation from the XPBD solver.
 #[cfg(feature = "3d")]
 fn project_angular_velocity(
-    mut bodies: Query<(&mut SolverBody, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
+    mut solver_bodies: ResMut<SolverBodies>,
+    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
 
-    for (mut body, pre_solve_delta_rot) in &mut bodies {
+    let access = solver_bodies.access();
+
+    for (index, pre_solve_delta_rot) in &bodies {
+        // SAFETY: Each entity has a unique solver body index, so the accessed bodies are disjoint.
+        let body = unsafe { access.body_unchecked_mut(*index) };
         let delta_rot = body.delta_rotation.mul_quat(pre_solve_delta_rot.inverse());
 
         let mut new_ang_vel = 2.0 * delta_rot.xyz() / delta_secs;

--- a/src/dynamics/solver/xpbd/plugin.rs
+++ b/src/dynamics/solver/xpbd/plugin.rs
@@ -191,7 +191,9 @@ pub fn solve_xpbd_joint<
             .copied()
             .unwrap_or(SolverBodyIndex::INVALID);
 
-        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+        if index1 == index2 {
+            continue;
+        }
 
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);
@@ -259,7 +261,9 @@ pub fn warm_start_xpbd_motors<
             .copied()
             .unwrap_or(SolverBodyIndex::INVALID);
 
-        debug_assert_ne!(index1, index2, "Joint connects the same body to itself");
+        if index1 == index2 {
+            continue;
+        }
 
         let (mut body1, mut inertia1) = (&mut dummy_body1, &SolverBodyInertia::DUMMY);
         let (mut body2, mut inertia2) = (&mut dummy_body2, &SolverBodyInertia::DUMMY);

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0xa1a76fa5;
+    let expected = 0x19c4b0ff;
 
     assert!(
         hash == expected,

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x19c4b0ff;
+    let expected = 0xcbf094ff;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

For upcoming solver optimizations (SIMD, multi-threading changes), we can't reasonably query the ECS for the solver bodies. The `Query::get_unchecked` lookup is a genuine bottleneck, and has several layers of indirection, where we need maximally fast body lookups via direct vector indexing and/or raw pointers, especially for efficient body gather/scatter.

## Solution

Store each `SolverBody` in a contiguous `SolverBodies` resource instead of as a component on the entity. Inertias are stored similarly in their own vec alongside the `SolverBody` vec. Entities are mapped to their associated solver body with a `SolverBodyIndex` component.

This design roughly matches the original solver body implementation in #735, except (unsafe) access in parallel contexts is internally handled via pointers with a `SolverBodiesAccess` struct. The original design did not allow mutable access to disjoint bodies in multiple parallel contexts simultaneously, which was not suitable for our graph coloring parallelism approach.