### PR TITLE
Fix velocity_projection bench never compiling

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -166,4 +166,4 @@ jobs:
             - name: Run cargo fmt
               run: cargo fmt --all -- --check
             - name: Run cargo clippy
-              run: cargo clippy --locked --all-targets
+              run: cargo clippy --locked --all-targets --features avian2d/test,avian3d/test

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -65,6 +65,9 @@ diagnostic_ui = ["bevy_diagnostic", "bevy/bevy_ui"]
 # Enables additional correctness checks and validation at the cost of worse performance.
 validate = []
 
+# Exposes internal testing utilities. Only intended for use by benchmarks.
+test = []
+
 [lib]
 name = "avian2d"
 path = "../../src/lib.rs"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -67,6 +67,9 @@ diagnostic_ui = ["bevy_diagnostic", "bevy/bevy_ui"]
 # Enables additional correctness checks and validation at the cost of worse performance.
 validate = []
 
+# Exposes internal testing utilities. Only intended for use by benchmarks.
+test = []
+
 [lib]
 name = "avian3d"
 path = "../../src/lib.rs"

--- a/crates/avian3d/benches/velocity_projection.rs
+++ b/crates/avian3d/benches/velocity_projection.rs
@@ -1,12 +1,9 @@
-use bevy_math::{Dir3, Vec3};
+use bevy_math::Dir3;
 use core::hint::black_box;
 use criterion::{BenchmarkId, Criterion, PlotConfiguration, criterion_group, criterion_main};
 
-use avian3d::{
-    character_controller::move_and_slide::{
-        project_velocity, project_velocity_bruteforce, test::QuasiRandomDirection,
-    },
-    math::PI,
+use avian3d::character_controller::move_and_slide::{
+    project_velocity, project_velocity_bruteforce, test::QuasiRandomDirection,
 };
 
 fn bench_velocity_projection(c: &mut Criterion) {

--- a/src/character_controller/velocity_project.rs
+++ b/src/character_controller/velocity_project.rs
@@ -308,7 +308,7 @@ impl SimplicialCone {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 pub mod test {
     //! Tests for velocity projection, notably the [`QuasiRandomDirection`] type used
     //! in testing and benchmarking functions on uniformly distributed input directions.
@@ -316,6 +316,7 @@ pub mod test {
     //! This is used because the velocity projection edge cases may show up for relatively small
     //! subsets of input directions, both in terms of correctness and performance.
 
+    #[cfg(test)]
     use super::DOT_EPSILON;
     use crate::prelude::*;
     use core::f32::consts::PI;


### PR DESCRIPTION
# Objective

Remove invalid-feature warning on every build

## Solution

The velocity_projection bench target required a "test" feature that was never declared, so cargo skipped the bench and printed an invalid-feature warning on every build. Since the bench never compiled, it had also bit-rotted: it imported the since-removed avian3d::math::PI along with an unused Vec3.

Declare the test feature in avian2d and avian3d, gate the shared test utilities module on cfg(any(test, feature = "test")) so benches can use QuasiRandomDirection, and drop the stale bench imports. The bench now compiles and runs with: cargo bench -p avian3d --features test

I kept the `test` feature name from the bench's original `required-features`, but can rename it to something like `test-util` if you prefer, since `cfg(any(test, feature = "test"))` is confusing.

AI assisted 

## Testing

The CI clippy step now runs cargo clippy --locked --all-targets --features avian2d/test,avian3d/test, which compiles and lints the bench on every PR. Verified locally with CI's deny-warnings flags