### PR TITLE
Opt out of cargo build-dir layout v2 in CI test job

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -92,6 +92,10 @@ jobs:
                 os: ${{ fromJSON((github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Cross-Platform')) && '["windows-latest","macos-latest","ubuntu-latest"]' || '["ubuntu-latest"]') }}
         env:
             RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only -Zthreads=0
+            # Keep the old cargo build-dir layout on nightly until cargo-nextest
+            # supports layout v2 (rust-lang/cargo#17258); without this, test
+            # binaries fail to load libbevy_dylib.so during test listing.
+            __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: "1"
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
         steps:


### PR DESCRIPTION
# Objective

Since cargo nightly 2026-07-30, cargo enables its new build-dir layout by default (rust-lang/cargo#17258). cargo-nextest does not support the new layout yet: it builds the runtime library search path from the old target/debug[/deps] convention, so with bevy/dynamic_linking every test binary fails to load libbevy_dylib.so and test listing aborts. This currently breaks the Test Suite job on every PR.

## Solution

Set cargo's temporary opt-out env var `__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT` in the test job to keep the old layout until a nextest release supports layout v2.

AI assisted

## Testing

CI should now succeed, unlike #1040 


Reported on the nextest side as https://github.com/nextest-rs/nextest/issues/3512