### PR TITLE
Expose hit feature IDs in raycast results

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -39,6 +39,10 @@ default-collider = []
 parry-f32 = ["dep:parry2d", "default-collider"]
 parry-f64 = ["f64", "dep:parry2d-f64", "default-collider"]
 
+# Adds the hit feature ID (e.g. the triangle index of trimesh colliders)
+# to `RayHitData` in raycasting.
+ray-hit-feature-id = []
+
 # Enables the XPBD constraint solver for joints.
 xpbd_joints = []
 

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -40,6 +40,10 @@ default-collider = []
 parry-f32 = ["dep:parry3d", "default-collider"]
 parry-f64 = ["f64", "dep:parry3d-f64", "default-collider"]
 
+# Adds the hit feature ID (e.g. the triangle index of trimesh colliders)
+# to `RayHitData` in raycasting.
+ray-hit-feature-id = []
+
 # Enables the XPBD constraint solver for joints.
 xpbd_joints = []
 

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -678,13 +678,77 @@ impl Collider {
         max_distance: f32,
         solid: bool,
     ) -> Option<(f32, Vector)> {
-        let hit = self.shape_scaled().cast_ray_and_get_normal(
+        let hit = self.ray_intersection(
+            translation,
+            rotation,
+            ray_origin,
+            ray_direction,
+            max_distance,
+            solid,
+        );
+        hit.map(|hit| (hit.time_of_impact.f32(), hit.normal.f32()))
+    }
+
+    /// Computes the distance, normal, and [feature ID](PackedFeatureId) between the given ray
+    /// and `self` transformed by `translation` and `rotation`.
+    ///
+    /// The returned tuple is in the format `(distance, normal, feature)`.
+    /// For triangle meshes, the feature typically identifies the hit face (triangle index).
+    ///
+    /// Note that for triangle meshes, a hit on the back face of triangle `i` is reported
+    /// as `face(i + triangle_count)` rather than `face(i)`, following parry's convention.
+    ///
+    /// # Arguments
+    ///
+    /// - `ray_origin`: Where the ray is cast from.
+    /// - `ray_direction`: What direction the ray is cast in.
+    /// - `max_distance`: The maximum distance the ray can travel.
+    /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    #[cfg(feature = "ray-hit-feature-id")]
+    pub fn cast_ray_with_feature(
+        &self,
+        translation: RVector,
+        rotation: impl Into<Rot>,
+        ray_origin: RVector,
+        ray_direction: Vector,
+        max_distance: f32,
+        solid: bool,
+    ) -> Option<(f32, Vector, PackedFeatureId)> {
+        let hit = self.ray_intersection(
+            translation,
+            rotation,
+            ray_origin,
+            ray_direction,
+            max_distance,
+            solid,
+        );
+        hit.map(|hit| {
+            (
+                hit.time_of_impact.f32(),
+                hit.normal.f32(),
+                PackedFeatureId::from(parry::shape::PackedFeatureId::from(hit.feature)),
+            )
+        })
+    }
+
+    /// Casts a ray against `self` transformed by `translation` and `rotation`,
+    /// returning the full parry intersection data.
+    fn ray_intersection(
+        &self,
+        translation: RVector,
+        rotation: impl Into<Rot>,
+        ray_origin: RVector,
+        ray_direction: Vector,
+        max_distance: f32,
+        solid: bool,
+    ) -> Option<parry::query::RayIntersection> {
+        self.shape_scaled().cast_ray_and_get_normal(
             &make_pose(translation, rotation),
             &parry::query::Ray::new(ray_origin, ray_direction.real()),
             max_distance.real(),
             solid,
-        );
-        hit.map(|hit| (hit.time_of_impact.f32(), hit.normal.f32()))
+        )
     }
 
     /// Tests whether the given ray intersects `self` transformed by `translation` and `rotation`.

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -104,7 +104,7 @@ pub mod prelude {
     };
     pub use super::contact_types::{
         Collisions, ContactEdge, ContactGraph, ContactManifold, ContactPair, ContactPairFlags,
-        ContactPoint,
+        ContactPoint, PackedFeatureId,
     };
     pub use super::hooks::{ActiveCollisionHooks, CollisionHooks};
     #[expect(deprecated)]

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -22,6 +22,8 @@
 //!
 //! For each hit during raycasting, the hit entity, a distance, and a normal will be stored in [`RayHitData`].
 //! The distance is the distance from the ray origin to the point of intersection, indicating how far the ray travelled.
+//! With the `ray-hit-feature-id` feature enabled, the [`PackedFeatureId`](crate::prelude::PackedFeatureId)
+//! of the hit (e.g. the triangle index of a triangle mesh collider) is stored as well.
 //!
 //! There are two ways to perform raycasts.
 //!

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -401,6 +401,17 @@ pub struct RayHitData {
 
     /// The normal at the point of intersection, expressed in world space.
     pub normal: Vector,
+
+    /// The [feature ID](PackedFeatureId) of the part of the collider that was hit by the ray.
+    ///
+    /// For triangle mesh colliders, this is typically a face identifying the index of the
+    /// hit triangle. For shapes that do not identify features, this may be
+    /// [`PackedFeatureId::UNKNOWN`].
+    ///
+    /// Note that for triangle meshes, a hit on the back face of triangle `i` is reported
+    /// as `face(i + triangle_count)` rather than `face(i)`, following parry's convention.
+    #[cfg(feature = "ray-hit-feature-id")]
+    pub feature: PackedFeatureId,
 }
 
 impl MapEntities for RayHitData {

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -197,7 +197,20 @@ impl SpatialQuery<'_, '_> {
                     return f32::MAX;
                 };
 
+                #[cfg(not(feature = "ray-hit-feature-id"))]
                 let Some((distance, normal)) = collider.cast_ray(
+                    position.0,
+                    *rotation,
+                    origin,
+                    *direction,
+                    max_distance,
+                    solid,
+                ) else {
+                    return f32::MAX;
+                };
+
+                #[cfg(feature = "ray-hit-feature-id")]
+                let Some((distance, normal, feature)) = collider.cast_ray_with_feature(
                     position.0,
                     *rotation,
                     origin,
@@ -214,6 +227,8 @@ impl SpatialQuery<'_, '_> {
                         entity: proxy.collider,
                         normal,
                         distance,
+                        #[cfg(feature = "ray-hit-feature-id")]
+                        feature,
                     });
                 }
 
@@ -374,7 +389,20 @@ impl SpatialQuery<'_, '_> {
                     return true;
                 };
 
+                #[cfg(not(feature = "ray-hit-feature-id"))]
                 let Some((distance, normal)) = collider.cast_ray(
+                    position.0,
+                    *rotation,
+                    origin,
+                    *direction,
+                    max_distance,
+                    solid,
+                ) else {
+                    return true;
+                };
+
+                #[cfg(feature = "ray-hit-feature-id")]
+                let Some((distance, normal, feature)) = collider.cast_ray_with_feature(
                     position.0,
                     *rotation,
                     origin,
@@ -389,6 +417,8 @@ impl SpatialQuery<'_, '_> {
                     entity: proxy.collider,
                     normal,
                     distance,
+                    #[cfg(feature = "ray-hit-feature-id")]
+                    feature,
                 })
             });
         });

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -213,3 +213,52 @@ fn no_ambiguity_errors() {
     .finish();
     app.update();
 }
+
+#[test]
+#[cfg(all(
+    feature = "3d",
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64"),
+    feature = "ray-hit-feature-id"
+))]
+fn raycast_returns_trimesh_face_index() {
+    use bevy::ecs::system::RunSystemOnce;
+
+    let mut app = create_app();
+
+    app.add_systems(Startup, |mut commands: Commands| {
+        // A quad made of two triangles lying on the XZ plane, wound so that
+        // the front faces point up (+Y).
+        commands.spawn((
+            RigidBody::Static,
+            Collider::trimesh(
+                vec![
+                    RVector::new(0.0, 0.0, 0.0),
+                    RVector::new(1.0, 0.0, 0.0),
+                    RVector::new(1.0, 0.0, 1.0),
+                    RVector::new(0.0, 0.0, 1.0),
+                ],
+                vec![[0, 2, 1], [0, 3, 2]],
+            ),
+        ));
+    });
+
+    tick_app(&mut app, 1.0 / 60.0);
+
+    // The point (0.25, 1, 0.75) lies above the second triangle ([0, 2, 3]).
+    let hit = app
+        .world_mut()
+        .run_system_once(|spatial_query: SpatialQuery| {
+            spatial_query.cast_ray(
+                RVector::new(0.25, 1.0, 0.75),
+                Dir::NEG_Y,
+                10.0,
+                true,
+                &SpatialQueryFilter::default(),
+            )
+        })
+        .expect("raycast system should run")
+        .expect("ray should hit the trimesh");
+
+    assert_eq!(hit.feature, PackedFeatureId::face(1));
+}


### PR DESCRIPTION
## Motivation

Raycasting against triangle mesh colliders currently discards the hit
feature ID computed by parry (`RayIntersection::feature`), so there is no
way to know which triangle was hit.

One concrete use case is 3D Tiles / glTF feature metadata picking
(batch tables, EXT_mesh_features, EXT_structural_metadata): the standard
CPU picking flow used by Cesium for Unreal takes the hit **face index**
from the collision raycast, uses it to look up the `_FEATURE_ID` attribute,
and then queries the property table. I am implementing the same flow in a
[mini Cesium written in Rust with Bevy](https://community.cesium.com/t/experimenting-with-a-mini-cesium-implementation-in-rust/46753).

## Changes

All changes are gated behind a new **opt-in** cargo feature
`ray-hit-feature-id` (avian2d and avian3d). With the feature disabled,
nothing changes — no API, layout, or behavior difference.

- `RayHitData` gains a `feature: PackedFeatureId` field
  (`#[cfg(feature = "ray-hit-feature-id")]`).
- `Collider::cast_ray` is **unchanged**. Its parry call is factored into a
  private `ray_intersection` helper, reused by the new
  `Collider::cast_ray_with_feature` method that also returns the
  `PackedFeatureId` (converted from parry's `FeatureId`).
- `SpatialQuery::cast_ray_predicate` / `ray_hits_callback` (and therefore
  `cast_ray`, `ray_hits`, and the `RayCaster` component) fill in the
  feature ID when the feature is enabled.
- `PackedFeatureId` is now re-exported from the collision prelude.
- New test `raycast_returns_trimesh_face_index`: casts a ray at a
  two-triangle quad and asserts the reported face index.

## Notes

- For triangle meshes, parry reports a **back-face** hit on triangle `i`
  as `face(i + triangle_count)`; this convention is documented on
  `RayHitData::feature` and `Collider::cast_ray_with_feature`.
- Shapes that don't identify features report `PackedFeatureId::UNKNOWN`.

## Testing

- `cargo clippy -p avian3d/avian2d (--features ray-hit-feature-id) --lib -- -D warnings`
- `cargo test -p avian3d (--features ray-hit-feature-id) --lib`
  — all pass, with and without the feature.
