### PR TITLE
Optimize miscellaneous systems

### DIFF
--- a/src/dynamics/joints/joint_graph/plugin.rs
+++ b/src/dynamics/joints/joint_graph/plugin.rs
@@ -1,6 +1,8 @@
 use core::marker::PhantomData;
 
 use super::{JointGraph, JointGraphEdge, JointId};
+#[cfg(feature = "xpbd_joints")]
+use crate::dynamics::solver::xpbd::XpbdVelocityProjection;
 use crate::{
     collision::contact_types::ContactId,
     data_structures::pair_key::PairKey,
@@ -133,6 +135,7 @@ fn add_joint_to_graph<
     query: Query<(&T, Has<JointCollisionDisabled>), F>,
     mut joint_graph: ResMut<JointGraph>,
     mut joint_graph_changes: MessageWriter<JointGraphChange>,
+    #[cfg(feature = "xpbd_joints")] mut commands: Commands,
 ) {
     let entity = trigger.event_target();
 
@@ -146,6 +149,12 @@ fn add_joint_to_graph<
     let joint_edge = JointGraphEdge::new(entity, body1, body2, collision_disabled);
     let joint_id = joint_graph.add_joint(joint_edge);
 
+    // The bodies are now constrained, so the XPBD solver must project their velocities.
+    #[cfg(feature = "xpbd_joints")]
+    for body in [body1, body2] {
+        commands.entity(body).try_insert(XpbdVelocityProjection);
+    }
+
     // Record the change.
     joint_graph_changes.write(JointGraphChange::Added(joint_id));
 }
@@ -154,6 +163,7 @@ fn remove_joint_from_graph<E: EntityEvent, B: Bundle>(
     trigger: On<E, B>,
     mut joint_graph: ResMut<JointGraph>,
     mut joint_graph_changes: MessageWriter<JointGraphChange>,
+    #[cfg(feature = "xpbd_joints")] mut commands: Commands,
 ) {
     let entity = trigger.event_target();
 
@@ -163,9 +173,19 @@ fn remove_joint_from_graph<E: EntityEvent, B: Bundle>(
 
     // Record the change.
     joint_graph_changes.write(JointGraphChange::Removed(joint.id));
+    #[cfg(feature = "xpbd_joints")]
+    let bodies = [joint.body1, joint.body2];
 
     // Remove the joint from the joint graph.
     joint_graph.remove_joint(entity);
+
+    // Stop projecting XPBD velocities for bodies that are no longer constrained by any joint.
+    #[cfg(feature = "xpbd_joints")]
+    for body in bodies {
+        if joint_graph.joints_of(body).next().is_none() {
+            commands.entity(body).try_remove::<XpbdVelocityProjection>();
+        }
+    }
 }
 
 fn on_add_joint(mut world: DeferredWorld, ctx: HookContext) {
@@ -277,6 +297,7 @@ fn on_change_joint_entities<T: Component + EntityConstraint<2>>(
     query: Query<(Entity, &T), Changed<T>>,
     mut joint_graph: ResMut<JointGraph>,
     mut joint_graph_changes: MessageWriter<JointGraphChange>,
+    #[cfg(feature = "xpbd_joints")] mut commands: Commands,
 ) {
     for (entity, joint) in &query {
         let [body1, body2] = joint.entities();
@@ -286,6 +307,8 @@ fn on_change_joint_entities<T: Component + EntityConstraint<2>>(
 
         if body1 != old_edge.body1 || body2 != old_edge.body2 {
             let old_id = old_edge.id;
+            #[cfg(feature = "xpbd_joints")]
+            let old_bodies = [old_edge.body1, old_edge.body2];
 
             // Remove the old joint edge.
             if let Some(mut edge) = joint_graph.remove_joint(entity) {
@@ -301,6 +324,19 @@ fn on_change_joint_entities<T: Component + EntityConstraint<2>>(
 
                 // Record the addition.
                 joint_graph_changes.write(JointGraphChange::Added(joint_id));
+
+                // Move XPBD velocity projection over to the new bodies.
+                #[cfg(feature = "xpbd_joints")]
+                {
+                    for body in [body1, body2] {
+                        commands.entity(body).try_insert(XpbdVelocityProjection);
+                    }
+                    for body in old_bodies {
+                        if joint_graph.joints_of(body).next().is_none() {
+                            commands.entity(body).try_remove::<XpbdVelocityProjection>();
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -71,7 +71,7 @@ pub mod solver;
 pub mod prelude {
     pub(crate) use super::rigid_body::mass_properties::{ComputeMassProperties, MassProperties};
     #[cfg(feature = "xpbd_joints")]
-    pub use super::solver::xpbd::XpbdSolverPlugin;
+    pub use super::solver::xpbd::{XpbdSolverPlugin, XpbdVelocityProjection};
     #[expect(deprecated)]
     pub use super::{
         ccd::{CcdFilter, CcdPlugin, SpeculativeCcd, SweepMode, SweptCcd},

--- a/src/dynamics/rigid_body/body_size_metrics.rs
+++ b/src/dynamics/rigid_body/body_size_metrics.rs
@@ -16,6 +16,7 @@ use crate::{
     dynamics::rigid_body::mass_properties::components::ComputedCenterOfMass,
     math::ToRealPrecision,
     schedule::{PhysicsSchedule, PhysicsStepSystems},
+    utils::{MIN_PAR_ITER_ENTITIES, ParallelQueryForEach},
 };
 
 /// Size metrics associated with a [`RigidBody`] and its colliders.
@@ -97,35 +98,35 @@ fn update_body_size_metrics<C: AnyCollider>(
     bodies.par_for_each_mut(
         MIN_PAR_ITER_ENTITIES,
         |(mut size_metrics, rb_colliders, com)| {
-        if !com.is_changed()
-            && !rb_colliders
-                .iter()
-                .any(|collider_entity| changed_colliders.contains(collider_entity))
-        {
-            // Neither the center of mass nor any of the colliders have changed.
+            if !com.is_changed()
+                && !rb_colliders
+                    .iter()
+                    .any(|collider_entity| changed_colliders.contains(collider_entity))
+            {
+                // Neither the center of mass nor any of the colliders have changed.
                 return;
-        }
+            }
 
-        let mut ccd_thickness: f32 = f32::INFINITY;
-        let mut sweep_radius: f32 = 0.0;
+            let mut ccd_thickness: f32 = f32::INFINITY;
+            let mut sweep_radius: f32 = 0.0;
 
-        // Find the minimum CCD thickness and maximum sweep radius.
-        for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
-            // Compute the CCD thickness
-            let ctx = ColliderContext::new(entity, &context);
-            let thickness = collider.ccd_thickness_with_context(ctx);
-            ccd_thickness = ccd_thickness.min(thickness);
+            // Find the minimum CCD thickness and maximum sweep radius.
+            for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
+                // Compute the CCD thickness
+                let ctx = ColliderContext::new(entity, &context);
+                let thickness = collider.ccd_thickness_with_context(ctx);
+                ccd_thickness = ccd_thickness.min(thickness);
 
-            // Compute the sweep radius
-            let ctx = ColliderContext::new(entity, &context);
-            let point = com.0 - collider_transform.translation;
+                // Compute the sweep radius
+                let ctx = ColliderContext::new(entity, &context);
+                let point = com.0 - collider_transform.translation;
                 let distance_to_com =
                     collider.max_distance_to_point_with_context(point.real(), ctx);
-            sweep_radius = sweep_radius.max(distance_to_com);
-        }
+                sweep_radius = sweep_radius.max(distance_to_com);
+            }
 
-        size_metrics.ccd_thickness = ccd_thickness;
-        size_metrics.sweep_radius = sweep_radius;
+            size_metrics.ccd_thickness = ccd_thickness;
+            size_metrics.sweep_radius = sweep_radius;
         },
     );
 }

--- a/src/dynamics/rigid_body/body_size_metrics.rs
+++ b/src/dynamics/rigid_body/body_size_metrics.rs
@@ -94,14 +94,16 @@ fn update_body_size_metrics<C: AnyCollider>(
 ) {
     let context = context.into_inner();
 
-    for (mut size_metrics, rb_colliders, com) in bodies.iter_mut() {
+    bodies.par_for_each_mut(
+        MIN_PAR_ITER_ENTITIES,
+        |(mut size_metrics, rb_colliders, com)| {
         if !com.is_changed()
             && !rb_colliders
                 .iter()
                 .any(|collider_entity| changed_colliders.contains(collider_entity))
         {
             // Neither the center of mass nor any of the colliders have changed.
-            continue;
+                return;
         }
 
         let mut ccd_thickness: f32 = f32::INFINITY;
@@ -117,11 +119,13 @@ fn update_body_size_metrics<C: AnyCollider>(
             // Compute the sweep radius
             let ctx = ColliderContext::new(entity, &context);
             let point = com.0 - collider_transform.translation;
-            let distance_to_com = collider.max_distance_to_point_with_context(point.real(), ctx);
+                let distance_to_com =
+                    collider.max_distance_to_point_with_context(point.real(), ctx);
             sweep_radius = sweep_radius.max(distance_to_com);
         }
 
         size_metrics.ccd_thickness = ccd_thickness;
         size_metrics.sweep_radius = sweep_radius;
-    }
+        },
+    );
 }

--- a/src/dynamics/solver/islands/sleeping.rs
+++ b/src/dynamics/solver/islands/sleeping.rs
@@ -270,16 +270,20 @@ fn sleep_islands(
     }
 
     // Sleep islands.
-    let sleep_buffer = sleep_buffer.clone();
-    commands.queue(|world: &mut World| {
-        SleepIslands(sleep_buffer).apply(world);
-    });
+    if !sleep_buffer.is_empty() {
+        let sleep_buffer = sleep_buffer.clone();
+        commands.queue(|world: &mut World| {
+            SleepIslands(sleep_buffer).apply(world);
+        });
+    }
 
     // Wake islands.
-    let wake_buffer = wake_buffer.clone();
-    commands.queue(|world: &mut World| {
-        WakeIslands(wake_buffer).apply(world);
-    });
+    if !wake_buffer.is_empty() {
+        let wake_buffer = wake_buffer.clone();
+        commands.queue(|world: &mut World| {
+            WakeIslands(wake_buffer).apply(world);
+        });
+    }
 
     // Reset the awake island bit vector.
     awake_island_bit_vec.set_bit_count_and_clear(islands.len());
@@ -370,6 +374,9 @@ pub struct SleepIslands(pub Vec<IslandId>);
 impl Command for SleepIslands {
     type Out = ();
     fn apply(self, world: &mut World) {
+        if self.0.is_empty() {
+            return;
+        }
         world.try_resource_scope(|world, mut state: Mut<CachedIslandSleepingSystemState>| {
             let (bodies, mut islands, mut contact_graph, mut constraint_graph) =
                 state.0.get_mut(world).unwrap();
@@ -486,6 +493,9 @@ pub struct WakeIslands(pub Vec<IslandId>);
 impl Command for WakeIslands {
     type Out = ();
     fn apply(self, world: &mut World) {
+        if self.0.is_empty() {
+            return;
+        }
         world.try_resource_scope(|world, mut state: Mut<CachedIslandWakingSystemState>| {
             let (mut bodies, mut islands, mut contact_graph, mut constraint_graph) =
                 state.0.get_mut(world).unwrap();

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -173,6 +173,12 @@
 //! of [`JointGraphPlugin`](crate::dynamics::joints::joint_graph::JointGraphPlugin) for the constraint type.
 //! This is required for sleeping and the `JointCollisionDisabled` component to work.
 //!
+//! The [`JointGraphPlugin`](crate::dynamics::joints::joint_graph::JointGraphPlugin) also inserts
+//! [`XpbdVelocityProjection`] on the bodies it connects. Only bodies with that component have their
+//! velocities updated from the position corrections applied by XPBD constraints, so if your constraint
+//! is *not* registered in the joint graph, insert [`XpbdVelocityProjection`] on the participating
+//! bodies yourself.
+//!
 //! You can find a working example of a custom constraint
 //! [here](https://github.com/avianphysics/avian/blob/main/crates/avian3d/examples/custom_constraint.rs).
 //!
@@ -289,8 +295,8 @@
 
 mod plugin;
 pub use plugin::{
-    XpbdSolverPlugin, XpbdSolverSystems, prepare_xpbd_joint, solve_xpbd_joint,
-    warm_start_xpbd_motors,
+    XpbdSolverPlugin, XpbdSolverSystems, XpbdVelocityProjection, prepare_xpbd_joint,
+    solve_xpbd_joint, warm_start_xpbd_motors,
 };
 
 pub mod joints;

--- a/src/dynamics/solver/xpbd/plugin.rs
+++ b/src/dynamics/solver/xpbd/plugin.rs
@@ -20,6 +20,8 @@ pub struct XpbdSolverPlugin;
 
 impl Plugin for XpbdSolverPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<XpbdVelocityProjection>();
+
         app.register_required_components::<FixedJoint, FixedJointSolverData>();
         app.register_required_components::<RevoluteJoint, RevoluteJointSolverData>();
         #[cfg(feature = "3d")]
@@ -74,26 +76,7 @@ impl Plugin for XpbdSolverPlugin {
         app.add_systems(
             SubstepSchedule,
             (
-                |solver_bodies: Res<SolverBodies>,
-                 mut query: Query<
-                    (
-                        &SolverBodyIndex,
-                        &mut PreSolveDeltaPosition,
-                        &mut PreSolveDeltaRotation,
-                    ),
-                    Without<RigidBodyDisabled>,
-                >| {
-                    for (index, mut pre_solve_delta_position, mut pre_solve_delta_rotation) in
-                        &mut query
-                    {
-                        let Some(body) = solver_bodies.get(*index) else {
-                            continue;
-                        };
-                        // Store the previous delta translation and rotation for XPBD velocity updates.
-                        pre_solve_delta_position.0 = body.delta_position;
-                        pre_solve_delta_rotation.0 = body.delta_rotation;
-                    }
-                },
+                store_pre_solve_deltas,
                 solve_xpbd_joint::<FixedJoint>,
                 solve_xpbd_joint::<RevoluteJoint>,
                 #[cfg(feature = "3d")]
@@ -140,6 +123,22 @@ pub enum XpbdSolverSystems {
     /// Performs velocity updates after XPBD constraint solving.
     VelocityProjection,
 }
+
+/// A marker component for [rigid bodies](RigidBody) whose velocities should be projected
+/// from the position corrections applied by XPBD constraints.
+///
+/// The XPBD solver only stores pre-solve deltas and projects velocities for bodies with this
+/// component, so bodies that no XPBD constraint touches are skipped entirely.
+///
+/// This is inserted and removed automatically for the bodies of joints in the [`JointGraph`].
+/// If you implement a [custom XPBD constraint](crate::dynamics::solver::xpbd#custom-constraints)
+/// that is not registered in the joint graph, insert this component on the participating bodies
+/// yourself, or the constraint will have no effect on their velocities.
+///
+/// [`JointGraph`]: crate::dynamics::joints::joint_graph::JointGraph
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default, PartialEq)]
+pub struct XpbdVelocityProjection;
 
 /// Iterates through the XPBD joints of a given type and solves them.
 pub fn prepare_xpbd_joint<
@@ -296,10 +295,34 @@ pub fn warm_start_xpbd_motors<
     }
 }
 
+/// Stores the delta position and rotation of each body before XPBD constraints are solved.
+fn store_pre_solve_deltas(
+    solver_bodies: Res<SolverBodies>,
+    mut query: Query<
+        (
+            &SolverBodyIndex,
+            &mut PreSolveDeltaPosition,
+            &mut PreSolveDeltaRotation,
+        ),
+        (With<XpbdVelocityProjection>, Without<RigidBodyDisabled>),
+    >,
+) {
+    for (index, mut pre_solve_delta_position, mut pre_solve_delta_rotation) in &mut query {
+        let Some(body) = solver_bodies.get(*index) else {
+            continue;
+        };
+        pre_solve_delta_position.0 = body.delta_position;
+        pre_solve_delta_rotation.0 = body.delta_rotation;
+    }
+}
+
 /// Updates the linear velocity of all dynamic bodies based on the change in position from the XPBD solver.
 fn project_linear_velocity(
     mut solver_bodies: ResMut<SolverBodies>,
-    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaPosition), RigidBodyActiveFilter>,
+    bodies: Query<
+        (&SolverBodyIndex, &PreSolveDeltaPosition),
+        (With<XpbdVelocityProjection>, RigidBodyActiveFilter),
+    >,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
@@ -319,7 +342,10 @@ fn project_linear_velocity(
 #[cfg(feature = "2d")]
 fn project_angular_velocity(
     mut solver_bodies: ResMut<SolverBodies>,
-    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
+    bodies: Query<
+        (&SolverBodyIndex, &PreSolveDeltaRotation),
+        (With<XpbdVelocityProjection>, RigidBodyActiveFilter),
+    >,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();
@@ -338,7 +364,10 @@ fn project_angular_velocity(
 #[cfg(feature = "3d")]
 fn project_angular_velocity(
     mut solver_bodies: ResMut<SolverBodies>,
-    bodies: Query<(&SolverBodyIndex, &PreSolveDeltaRotation), RigidBodyActiveFilter>,
+    bodies: Query<
+        (&SolverBodyIndex, &PreSolveDeltaRotation),
+        (With<XpbdVelocityProjection>, RigidBodyActiveFilter),
+    >,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_secs();

--- a/src/physics_transform/mod.rs
+++ b/src/physics_transform/mod.rs
@@ -16,12 +16,14 @@ mod tests;
 use crate::{
     prelude::*,
     schedule::{LastPhysicsTick, is_changed_after_tick},
+    utils::{MIN_PAR_ITER_ENTITIES, ParallelQueryForEach},
 };
 use approx::AbsDiffEq;
 use bevy::{
     ecs::{
         change_detection::Tick, intern::Interned, schedule::ScheduleLabel, system::SystemChangeTick,
     },
+    math::Affine3A,
     prelude::*,
     transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
@@ -201,38 +203,97 @@ pub fn transform_to_position(
 
     // If the `GlobalTransform` translation and `Position` differ by less than 0.01 mm, we ignore the change.
     let distance_tolerance = length_unit.real() * 1e-5;
-    // If the `GlobalTransform` rotation and `Rotation` differ by less than 0.1 degrees, we ignore the change.
-    let rotation_tolerance = 0.1f32.to_radians();
 
-    for (global_transform, mut position, mut rotation) in &mut query {
-        let global_transform = global_transform.compute_transform();
-        #[cfg(feature = "2d")]
-        let transform_translation = global_transform.translation.truncate().real();
-        #[cfg(feature = "3d")]
-        let transform_translation = global_transform.translation.real();
-        let transform_rotation = Rotation::from(global_transform.rotation);
+    let last_physics_tick = last_physics_tick.0;
 
-        let position_changed = !position.is_added()
-            && is_changed_after_tick(
-                Ref::from(position.reborrow()),
-                last_physics_tick.0,
-                this_run,
-            );
-        if !position_changed && position.abs_diff_ne(&transform_translation, distance_tolerance) {
-            position.0 = transform_translation;
+    query.par_for_each_mut(
+        MIN_PAR_ITER_ENTITIES,
+        |(global_transform, mut position, mut rotation)| {
+            let affine = global_transform.affine();
+
+            let position_changed = !position.is_added()
+                && is_changed_after_tick(
+                    Ref::from(position.reborrow()),
+                    last_physics_tick,
+                    this_run,
+                );
+            if !position_changed {
+                #[cfg(feature = "2d")]
+                let transform_translation = affine.translation.truncate().real();
+                #[cfg(feature = "3d")]
+                let transform_translation = Vec3::from(affine.translation).real();
+
+                if position.abs_diff_ne(&transform_translation, distance_tolerance) {
+                    position.0 = transform_translation;
+                }
+            }
+
+            let rotation_changed = !rotation.is_added()
+                && is_changed_after_tick(
+                    Ref::from(rotation.reborrow()),
+                    last_physics_tick,
+                    this_run,
+                );
+            if !rotation_changed {
+                let transform_rotation = rotation_from_affine(&affine);
+                // The rotations differ by more than the tolerance if the cosine of the angle
+                // between them is smaller than the cosine of the tolerance angle.
+                if cos_angle_between(*rotation, transform_rotation) < ROTATION_COS_TOLERANCE {
+                    *rotation = transform_rotation;
+                }
+            }
+        },
+    );
+}
+
+/// The cosine of the angle below which a difference between the `GlobalTransform` rotation
+/// and [`Rotation`] is ignored. This corresponds to an angle of 0.1 degrees.
+const ROTATION_COS_TOLERANCE: f32 = 0.999_998_5;
+
+/// Returns the cosine of the angle between two rotations.
+///
+/// This is a cheaper alternative to `Rotation::angle_between`,
+/// as it avoids inverse trigonometric functions.
+#[inline]
+fn cos_angle_between(a: Rotation, b: Rotation) -> f32 {
+    #[cfg(feature = "2d")]
+    {
+        a.cos * b.cos + a.sin * b.sin
+    }
+    #[cfg(feature = "3d")]
+    {
+        // The angle between two unit quaternions is `2 * acos(|dot|)`,
+        // and `cos(2 * acos(x)) == 2 * x^2 - 1`.
+        let dot = a.dot(b.0);
+        2.0 * dot * dot - 1.0
+    }
+}
+
+/// Extracts the [`Rotation`] from the affine transform of a `GlobalTransform`.
+///
+/// This is equivalent to `Rotation::from(global_transform.compute_transform().rotation)`,
+/// but avoids the full scale-rotation-translation decomposition, which is comparatively expensive.
+#[inline]
+fn rotation_from_affine(affine: &Affine3A) -> Rotation {
+    let mat = affine.matrix3;
+
+    let det_sign = mat.determinant().signum();
+
+    #[cfg(feature = "2d")]
+    {
+        let x_axis = Vec2::new(mat.x_axis.x, mat.x_axis.y) * det_sign;
+        let x_axis = x_axis.normalize_or(Vec2::X);
+        Rotation {
+            cos: x_axis.x,
+            sin: x_axis.y,
         }
-
-        let rotation_changed = !rotation.is_added()
-            && is_changed_after_tick(
-                Ref::from(rotation.reborrow()),
-                last_physics_tick.0,
-                this_run,
-            );
-        if !rotation_changed
-            && rotation.angle_between(transform_rotation).abs() > rotation_tolerance
-        {
-            *rotation = transform_rotation;
-        }
+    }
+    #[cfg(feature = "3d")]
+    {
+        let x_axis = (mat.x_axis * det_sign).normalize_or(Vec3A::X);
+        let y_axis = mat.y_axis.normalize_or(Vec3A::Y);
+        let z_axis = mat.z_axis.normalize_or(Vec3A::Z);
+        Rotation(Quat::from_mat3a(&Mat3A::from_cols(x_axis, y_axis, z_axis)))
     }
 }
 

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0xcbf094ff;
+    let expected = 0x63c9e1ff;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

With 5050 dynamic bodies in 2D, the "Other" diagnostic is hovering around 0.3 ms. This should be considerably smaller.

## Solution

Optimize XPBD velocity projection, body size metric computation, and some other misc. logic. Also optimize `transform_to_position`, which is not included in our diagnostics, but still has a meaningful cost.

The "Other" diagnostic in the earlier example is now 0.13 ms. Could still be improved, but nonetheless a lot better!