### PR TITLE
Optimize large scenes and bulk spawning (1 million+)

### DIFF
--- a/src/collider_tree/mod.rs
+++ b/src/collider_tree/mod.rs
@@ -34,7 +34,9 @@ pub use obvhs_ext::Bvh2Ext;
 pub(crate) use obvhs_ext::obvhs_ray;
 pub use optimization::{ColliderTreeOptimization, TreeOptimizationMode};
 pub use proxy_key::{ColliderTreeProxyKey, ColliderTreeType, ProxyId};
-pub use tree::{ColliderTree, ColliderTreeProxy, ColliderTreeProxyFlags, ColliderTreeWorkspace};
+pub use tree::{
+    ColliderTree, ColliderTreeProxy, ColliderTreeProxyFlags, ColliderTreeWorkspace, MovedProxyList,
+};
 pub use update::{MovedProxies, update_moved_collider_aabbs};
 
 use optimization::ColliderTreeOptimizationPlugin;

--- a/src/collider_tree/obvhs_ext.rs
+++ b/src/collider_tree/obvhs_ext.rs
@@ -71,6 +71,122 @@ impl SweepHit {
     }
 }
 
+/// Finds the sibling with the cheapest SAH cost for `aabb` using a greedy top-down descent.
+fn find_sibling_greedy(bvh: &Bvh2, aabb: &Aabb) -> usize {
+    // This is based on `b2FindBestSibling` in Box2D by Erin Catto.
+
+    let center = aabb.center();
+    let area = aabb.half_area();
+
+    let root = &bvh.nodes[0];
+
+    // Area of current node
+    let mut area_base = root.aabb().half_area();
+
+    // Area of inflated node
+    let mut direct_cost = root.aabb().union(aabb).half_area();
+
+    // Area that pairing with the current node would add to all of its ancestors
+    let mut inherited_cost = 0.0;
+
+    let mut best_sibling = 0;
+    let mut best_cost = direct_cost;
+
+    let mut node_id = 0;
+
+    // Descend the tree from the root, following a single greedy path.
+    while !bvh.nodes[node_id].is_leaf() {
+        let left_id = bvh.nodes[node_id].first_index as usize;
+        let right_id = left_id + 1;
+
+        // Cost of creating a new parent for `aabb` and this node
+        let cost = direct_cost + inherited_cost;
+        if cost < best_cost {
+            best_sibling = node_id;
+            best_cost = cost;
+        }
+
+        // The children see the cost this node would inherit as well.
+        inherited_cost += direct_cost - area_base;
+
+        // Evaluate each child.
+        let mut evaluate = |child_id: usize| {
+            let child = &bvh.nodes[child_id];
+            let child_area = child.aabb().half_area();
+            let child_direct_cost = child.aabb().union(aabb).half_area();
+
+            if child.is_leaf() {
+                // Cost of creating a new parent for `aabb` and this child
+                let cost = child_direct_cost + inherited_cost;
+                if cost < best_cost {
+                    best_sibling = child_id;
+                    best_cost = cost;
+                }
+                (f32::MAX, child_area, child_direct_cost)
+            } else {
+                // The child is an internal node.
+                // Compute a lower bound on the cost of inserting anywhere in its subtree.
+                let lower_cost = inherited_cost + child_direct_cost + (area - child_area).min(0.0);
+                (lower_cost, child_area, child_direct_cost)
+            }
+        };
+
+        let (mut left_lower_cost, left_area, left_direct_cost) = evaluate(left_id);
+        let (mut right_lower_cost, right_area, right_direct_cost) = evaluate(right_id);
+
+        let left_is_leaf = bvh.nodes[left_id].is_leaf();
+        let right_is_leaf = bvh.nodes[right_id].is_leaf();
+
+        if left_is_leaf && right_is_leaf {
+            break;
+        }
+
+        // Neither subtree can beat the best sibling found so far.
+        if best_cost <= left_lower_cost && best_cost <= right_lower_cost {
+            break;
+        }
+
+        if left_lower_cost == right_lower_cost && !left_is_leaf {
+            // The bounds give no clear choice, which happens when both children
+            // fully contain `aabb`. Fall back to the child whose center is closest.
+            left_lower_cost = (bvh.nodes[left_id].aabb().center() - center).length_squared();
+            right_lower_cost = (bvh.nodes[right_id].aabb().center() - center).length_squared();
+        }
+
+        // Descend into the more promising child.
+        if left_lower_cost < right_lower_cost && !left_is_leaf {
+            node_id = left_id;
+            area_base = left_area;
+            direct_cost = left_direct_cost;
+        } else {
+            node_id = right_id;
+            area_base = right_area;
+            direct_cost = right_direct_cost;
+        }
+    }
+
+    best_sibling
+}
+
+/// Points the primitives of `node` at `node_id` as their new location in `Bvh2::nodes`.
+#[inline]
+fn update_primitives_to_nodes_for_node(
+    node: &Bvh2Node,
+    node_id: usize,
+    primitive_indices: &[u32],
+    primitives_to_nodes: &mut [u32],
+) {
+    // Copied from OBVHS
+    if !primitives_to_nodes.is_empty() {
+        let start = node.first_index;
+        let end = start + node.prim_count;
+        for node_prim_id in start..end {
+            let direct_prim_id = primitive_indices[node_prim_id as usize];
+            primitives_to_nodes[direct_prim_id as usize] = node_id as u32;
+        }
+    }
+}
+
 /// Extension trait for [`obvhs::bvh2::Bvh2`] to add additional traversal methods.
 pub trait Bvh2Ext {
     /// Traverse the BVH by sweeping an AABB along a velocity vector. Returns the closest intersected primitive.
@@ -189,9 +305,84 @@ pub trait Bvh2Ext {
         closest_leaf: &mut Option<(u32, f32)>,
         visit_fn: F,
     );
+
+    /// Inserts a primitive into the BVH, picking the sibling to pair it with using
+    /// a greedy top-down descent from the root.
+    ///
+    /// This is cheaper than [`Bvh2::insert_primitive`], but can leave the resulting tree
+    /// with slightly lower quality.
+    ///
+    /// Returns the index of the node the primitive was inserted into.
+    fn insert_primitive_greedy(&mut self, aabb: Aabb, primitive_id: u32) -> usize;
 }
 
 impl Bvh2Ext for Bvh2 {
+    fn insert_primitive_greedy(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
+        self.init_primitives_to_nodes_if_uninit();
+        self.init_parents_if_uninit();
+
+        if self.primitives_to_nodes.len() <= primitive_id as usize {
+            self.primitives_to_nodes
+                .resize(primitive_id as usize + 1, INVALID_ID);
+        }
+
+        // Claim a slot in `primitive_indices` for the new primitive.
+        let first_index = if let Some(free_slot) = self.primitive_indices_freelist.pop() {
+            self.primitive_indices[free_slot as usize] = primitive_id;
+            free_slot
+        } else {
+            self.primitive_indices.push(primitive_id);
+            self.primitive_indices.len() as u32 - 1
+        };
+
+        let new_node = Bvh2Node::new(aabb, 1, first_index);
+
+        // If the BVH is empty, the new node becomes the root.
+        if self.nodes.is_empty() {
+            self.nodes.push(new_node);
+            self.parents.clear();
+            self.parents.push(0);
+            self.primitives_to_nodes[primitive_id as usize] = 0;
+            return 0;
+        }
+
+        // Find the sibling to pair the new node with.
+        let sibling_id = find_sibling_greedy(self, &aabb);
+        let sibling = self.nodes[sibling_id];
+
+        // To avoid gaps or rearranging the BVH, the new parent takes the sibling's slot,
+        // and the sibling and the new node are appended to the end of the node list.
+        let new_sibling_id = self.nodes.len() as u32;
+        self.nodes[sibling_id] = Bvh2Node::new(aabb.union(sibling.aabb()), 0, new_sibling_id);
+
+        if sibling.is_leaf() {
+            // Tell the sibling's primitives where their node went.
+            update_primitives_to_nodes_for_node(
+                &sibling,
+                new_sibling_id as usize,
+                &self.primitive_indices,
+                &mut self.primitives_to_nodes,
+            );
+        } else {
+            // Tell the sibling's children where their parent went.
+            self.parents[sibling.first_index as usize] = new_sibling_id;
+            self.parents[sibling.first_index as usize + 1] = new_sibling_id;
+        }
+
+        self.nodes.push(sibling);
+        let new_node_id = self.nodes.len();
+        self.nodes.push(new_node);
+        self.parents.push(sibling_id as u32);
+        self.parents.push(sibling_id as u32);
+
+        self.primitives_to_nodes[primitive_id as usize] = new_node_id as u32;
+
+        // Work up the tree updating the AABBs, since we just added a node.
+        self.refit_from_fast(sibling_id);
+
+        new_node_id
+    }
+
     #[inline(always)]
     fn sweep_traverse<F: FnMut(&Sweep, usize) -> f32>(
         &self,

--- a/src/collider_tree/tree.rs
+++ b/src/collider_tree/tree.rs
@@ -4,13 +4,12 @@ use bevy::{
 };
 use obvhs::{
     aabb::Aabb,
-    bvh2::{Bvh2, insertion_removal::SiblingInsertionCandidate, reinsertion::ReinsertionOptimizer},
-    faststack::HeapStack,
+    bvh2::{Bvh2, reinsertion::ReinsertionOptimizer},
     ploc::{PlocBuilder, PlocSearchDistance, SortPrecision, rebuild::compute_rebuild_path_flags},
 };
 
 use crate::{
-    collider_tree::ProxyId,
+    collider_tree::{Bvh2Ext, ProxyId},
     data_structures::stable_vec::StableVec,
     prelude::{ActiveCollisionHooks, CollisionLayers},
 };
@@ -30,9 +29,81 @@ pub struct ColliderTree {
     ///
     /// This is used during tree optimization to determine
     /// which proxies need to be reinserted or rebuilt.
-    pub moved_proxies: Vec<ProxyId>,
+    pub moved_proxies: MovedProxyList,
     /// A workspace for reusing allocations across tree operations.
     pub workspace: ColliderTreeWorkspace,
+}
+
+/// A set of [`ProxyId`]s that have moved since the last update, in insertion order.
+///
+/// Supports constant-time insertion, removal, and membership tests by keeping
+/// a sparse index from [`ProxyId`] to the position of the ID in the dense list.
+#[derive(Clone, Default, Debug)]
+pub struct MovedProxyList {
+    /// The moved proxy IDs, in insertion order.
+    proxies: Vec<ProxyId>,
+    /// Maps a [`ProxyId`] to its index in `proxies`, or [`PROXY_NOT_PRESENT`] if it is not in the list.
+    indices: Vec<u32>,
+}
+
+/// The sentinel stored in [`MovedProxyList::indices`] for proxies that are not in the list.
+const PROXY_NOT_PRESENT: u32 = u32::MAX;
+
+impl MovedProxyList {
+    /// Adds a proxy to the list if it is not already present.
+    ///
+    /// Returns `true` if the proxy was added.
+    #[inline]
+    pub fn push(&mut self, proxy_id: ProxyId) -> bool {
+        if self.indices.len() <= proxy_id.index() {
+            self.indices.resize(proxy_id.index() + 1, PROXY_NOT_PRESENT);
+        } else if self.indices[proxy_id.index()] != PROXY_NOT_PRESENT {
+            return false;
+        }
+
+        self.indices[proxy_id.index()] = self.proxies.len() as u32;
+        self.proxies.push(proxy_id);
+
+        true
+    }
+
+    /// Removes a proxy from the list. This may change the order of the remaining proxies.
+    ///
+    /// If the proxy is not present, nothing happens.
+    #[inline]
+    pub fn remove(&mut self, proxy_id: ProxyId) {
+        let Some(index) = self.indices.get_mut(proxy_id.index()) else {
+            return;
+        };
+        if *index == PROXY_NOT_PRESENT {
+            return;
+        }
+
+        let index = core::mem::replace(index, PROXY_NOT_PRESENT) as usize;
+        self.proxies.swap_remove(index);
+
+        // The proxy that was swapped into the removed slot needs its index updated.
+        if let Some(&swapped) = self.proxies.get(index) {
+            self.indices[swapped.index()] = index as u32;
+        }
+    }
+
+    /// Removes all proxies from the list.
+    #[inline]
+    pub fn clear(&mut self) {
+        for proxy_id in self.proxies.drain(..) {
+            self.indices[proxy_id.index()] = PROXY_NOT_PRESENT;
+        }
+    }
+}
+
+impl core::ops::Deref for MovedProxyList {
+    type Target = [ProxyId];
+
+    #[inline]
+    fn deref(&self) -> &[ProxyId] {
+        &self.proxies
+    }
 }
 
 /// A proxy representing a collider in the [`ColliderTree`].
@@ -125,14 +196,12 @@ impl ColliderTreeProxy {
 /// This stores temporary data structures and working memory used when modifying the tree.
 /// It is recommended to reuse a single instance of this struct for all operations on a tree
 /// to avoid unnecessary allocations.
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct ColliderTreeWorkspace {
     /// Builds the tree using PLOC (*Parallel, Locally Ordered Clustering*).
     pub ploc_builder: PlocBuilder,
     /// Restructures the BVH, optimizing node locations within the BVH hierarchy per SAH cost.
     pub reinsertion_optimizer: ReinsertionOptimizer,
-    /// A stack for tracking insertion candidates during proxy insertions.
-    pub insertion_stack: HeapStack<SiblingInsertionCandidate>,
     /// Temporary flagged nodes for partial rebuilds.
     pub temp_flags: Vec<bool>,
 }
@@ -142,18 +211,6 @@ impl Clone for ColliderTreeWorkspace {
         Self {
             ploc_builder: self.ploc_builder.clone(),
             reinsertion_optimizer: ReinsertionOptimizer::default(),
-            insertion_stack: self.insertion_stack.clone(),
-            temp_flags: Vec::new(),
-        }
-    }
-}
-
-impl Default for ColliderTreeWorkspace {
-    fn default() -> Self {
-        Self {
-            ploc_builder: PlocBuilder::default(),
-            reinsertion_optimizer: ReinsertionOptimizer::default(),
-            insertion_stack: HeapStack::new_with_capacity(2000),
             temp_flags: Vec::new(),
         }
     }
@@ -166,8 +223,7 @@ impl ColliderTree {
         let id = self.proxies.push(proxy) as u32;
 
         // Insert the proxy into the BVH.
-        self.bvh
-            .insert_primitive(aabb, id, &mut self.workspace.insertion_stack);
+        self.bvh.insert_primitive_greedy(aabb, id);
 
         // Add to moved proxies.
         self.moved_proxies.push(ProxyId::new(id));
@@ -185,12 +241,7 @@ impl ColliderTree {
             self.bvh.remove_primitive(proxy_id.id());
 
             // Remove from moved proxies.
-            for i in 0..self.moved_proxies.len() {
-                if self.moved_proxies[i] == proxy_id {
-                    self.moved_proxies.swap_remove(i);
-                    break;
-                }
-            }
+            self.moved_proxies.remove(proxy_id);
 
             Some(proxy)
         } else {

--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -21,7 +21,7 @@ use bevy::{
         query::QueryFilter,
         system::{StaticSystemParam, SystemChangeTick},
     },
-    platform::collections::HashSet,
+    platform::collections::HashMap,
     prelude::*,
 };
 use obvhs::aabb::Aabb;
@@ -420,6 +420,7 @@ fn add_to_tree_on<E: EntityEvent, B: Bundle, F: QueryFilter>(
             Has<Sensor>,
             Has<CollisionEventsEnabled>,
             Option<&ActiveCollisionHooks>,
+            Has<RigidBody>,
         ),
         F,
     >,
@@ -436,10 +437,18 @@ fn add_to_tree_on<E: EntityEvent, B: Bundle, F: QueryFilter>(
         is_sensor,
         has_contact_events,
         active_hooks,
+        is_body,
     )) = collider_query.get_mut(entity)
     else {
         return;
     };
+
+    // If the collider is on the same entity as a rigid body but does not have `ColliderOf` yet,
+    // it is about to be inserted by the `ColliderHierarchyPlugin`. Adding it to the standalone tree
+    // here would just be undone, so we wait for the `ColliderOf` insertion instead.
+    if is_body && collider_of.is_none() && *proxy_key == ColliderTreeProxyKey::PLACEHOLDER {
+        return;
+    }
 
     let (tree_type, is_body_disabled) =
         if let Some(Ok((rb, disabled))) = collider_of.map(|c| body_query.get(c.body)) {
@@ -464,6 +473,18 @@ fn add_to_tree_on<E: EntityEvent, B: Bundle, F: QueryFilter>(
     if *proxy_key != ColliderTreeProxyKey::PLACEHOLDER {
         let old_tree_type = proxy_key.tree_type();
         let old_tree = trees.tree_for_type_mut(old_tree_type);
+
+        // If the collider is already in the right tree, update the existing proxy in place.
+        if old_tree_type == tree_type
+            && let Some(old_proxy) = old_tree.get_proxy_mut(proxy_key.id())
+        {
+            *old_proxy = proxy;
+            old_tree.resize_proxy_aabb(proxy_key.id(), Aabb::from(enlarged_aabb.get()));
+            moved_proxies.insert(*proxy_key);
+            old_tree.moved_proxies.push(proxy_key.id());
+            return;
+        }
+
         old_tree.remove_proxy(proxy_key.id());
         moved_proxies.remove(&proxy_key);
     }
@@ -520,8 +541,8 @@ struct LastDynamicKinematicAabbUpdate(Tick);
 pub struct MovedProxies {
     /// A vector of moved proxy keys.
     proxies: Vec<ColliderTreeProxyKey>,
-    /// A set of moved proxy keys for quick lookup.
-    set: HashSet<ColliderTreeProxyKey>,
+    /// Maps a moved proxy key to its index in `proxies`.
+    indices: HashMap<ColliderTreeProxyKey, u32>,
 }
 
 impl MovedProxies {
@@ -536,7 +557,7 @@ impl MovedProxies {
     /// Returns `true` if the proxy with the given key has moved.
     #[inline]
     pub fn contains(&self, proxy_key: ColliderTreeProxyKey) -> bool {
-        self.set.contains(&proxy_key)
+        self.indices.contains_key(&proxy_key)
     }
 
     /// Inserts a moved proxy key.
@@ -544,7 +565,8 @@ impl MovedProxies {
     /// Returns `true` if the proxy key was not already present.
     #[inline]
     pub fn insert(&mut self, proxy_key: ColliderTreeProxyKey) -> bool {
-        if self.set.insert(proxy_key) {
+        let index = self.proxies.len() as u32;
+        if self.indices.try_insert(proxy_key, index).is_ok() {
             self.proxies.push(proxy_key);
             true
         } else {
@@ -552,16 +574,21 @@ impl MovedProxies {
         }
     }
 
-    /// Removes a moved proxy key. This uses a linear search,
-    /// and may change the order of the remaining keys.
+    /// Removes a moved proxy key. This may change the order of the remaining keys.
     ///
     /// If the proxy key is not present, nothing happens.
     #[inline]
     pub fn remove(&mut self, proxy_key: &ColliderTreeProxyKey) {
-        if self.set.remove(proxy_key)
-            && let Some(pos) = self.proxies.iter().position(|k| k == proxy_key)
-        {
-            self.proxies.swap_remove(pos);
+        let Some(index) = self.indices.remove(proxy_key) else {
+            return;
+        };
+
+        let index = index as usize;
+        self.proxies.swap_remove(index);
+
+        // The key that was swapped into the removed slot needs its index updated.
+        if let Some(swapped) = self.proxies.get(index) {
+            self.indices.insert(*swapped, index as u32);
         }
     }
 
@@ -569,7 +596,7 @@ impl MovedProxies {
     #[inline]
     pub fn clear(&mut self) {
         self.proxies.clear();
-        self.set.clear();
+        self.indices.clear();
     }
 }
 

--- a/src/diagnostics/entity_counters.rs
+++ b/src/diagnostics/entity_counters.rs
@@ -58,7 +58,6 @@ impl_diagnostic_paths! {
     }
 }
 
-// TODO: This is pretty inefficient.
 fn diagnostic_entity_counts(
     rigid_bodies_query: Query<&RigidBody>,
     colliders_query: Query<&ColliderMarker>,
@@ -69,25 +68,27 @@ fn diagnostic_entity_counts(
     #[cfg(feature = "3d")] spherical_joint_query: Query<&SphericalJoint>,
     mut diagnostics: ResMut<PhysicsEntityDiagnostics>,
 ) {
-    diagnostics.dynamic_body_count = rigid_bodies_query
-        .iter()
-        .filter(|rb| rb.is_dynamic())
-        .count() as u32;
-    diagnostics.kinematic_body_count = rigid_bodies_query
-        .iter()
-        .filter(|rb| rb.is_kinematic())
-        .count() as u32;
-    diagnostics.static_body_count = rigid_bodies_query
-        .iter()
-        .filter(|rb| rb.is_static())
-        .count() as u32;
-    diagnostics.collider_count = colliders_query.iter().count() as u32;
-    diagnostics.joint_count = fixed_joint_query.iter().count() as u32
-        + prismatic_joint_query.iter().count() as u32
-        + distance_joint_query.iter().count() as u32
-        + revolute_joint_query.iter().count() as u32;
+    // Count the body types in a single pass.
+    let (mut dynamic, mut kinematic, mut static_) = (0, 0, 0);
+    for rb in &rigid_bodies_query {
+        match rb {
+            RigidBody::Dynamic => dynamic += 1,
+            RigidBody::Kinematic => kinematic += 1,
+            RigidBody::Static => static_ += 1,
+        }
+    }
+    diagnostics.dynamic_body_count = dynamic;
+    diagnostics.kinematic_body_count = kinematic;
+    diagnostics.static_body_count = static_;
+
+    // These are archetypal queries, so counting them does not iterate the entities.
+    diagnostics.collider_count = colliders_query.count() as u32;
+    diagnostics.joint_count = fixed_joint_query.count() as u32
+        + prismatic_joint_query.count() as u32
+        + distance_joint_query.count() as u32
+        + revolute_joint_query.count() as u32;
     #[cfg(feature = "3d")]
     {
-        diagnostics.joint_count += spherical_joint_query.iter().count() as u32;
+        diagnostics.joint_count += spherical_joint_query.count() as u32;
     }
 }

--- a/src/dynamics/rigid_body/body_size_metrics.rs
+++ b/src/dynamics/rigid_body/body_size_metrics.rs
@@ -10,13 +10,13 @@ use bevy::{ecs::system::StaticSystemParam, prelude::*};
 
 use crate::{
     collision::collider::{
-        AnyCollider, ColliderContext, collider_hierarchy::RigidBodyColliders,
+        AnyCollider, ColliderContext,
+        collider_hierarchy::{ColliderOf, RigidBodyColliders},
         collider_transform::ColliderTransform,
     },
     dynamics::rigid_body::mass_properties::components::ComputedCenterOfMass,
     math::ToRealPrecision,
     schedule::{PhysicsSchedule, PhysicsStepSystems},
-    utils::{MIN_PAR_ITER_ENTITIES, ParallelQueryForEach},
 };
 
 /// Size metrics associated with a [`RigidBody`] and its colliders.
@@ -83,50 +83,63 @@ impl<C: AnyCollider> Plugin for BodySizeMetricsPlugin<C> {
     }
 }
 
+type BodySizeMetricsData = (
+    &'static mut BodySizeMetrics,
+    &'static RigidBodyColliders,
+    &'static ComputedCenterOfMass,
+);
+
 fn update_body_size_metrics<C: AnyCollider>(
-    mut bodies: Query<(
-        &mut BodySizeMetrics,
-        &RigidBodyColliders,
-        Ref<ComputedCenterOfMass>,
+    // Body size metrics only need updating when the center of mass
+    // or one of the colliders changes.
+    mut bodies: ParamSet<(
+        Query<BodySizeMetricsData, Changed<ComputedCenterOfMass>>,
+        Query<BodySizeMetricsData>,
     )>,
     colliders: Query<(Entity, &C, &ColliderTransform)>,
-    changed_colliders: Query<(), Or<(Changed<C>, Changed<ColliderTransform>)>>,
+    changed_colliders: Query<&ColliderOf, Or<(Changed<C>, Changed<ColliderTransform>)>>,
     context: StaticSystemParam<C::Context>,
 ) {
     let context = context.into_inner();
 
-    bodies.par_for_each_mut(
-        MIN_PAR_ITER_ENTITIES,
-        |(mut size_metrics, rb_colliders, com)| {
-            if !com.is_changed()
-                && !rb_colliders
-                    .iter()
-                    .any(|collider_entity| changed_colliders.contains(collider_entity))
-            {
-                // Neither the center of mass nor any of the colliders have changed.
-                return;
-            }
+    // Computes the minimum CCD thickness and maximum sweep radius over a body's colliders.
+    let compute = |rb_colliders: &RigidBodyColliders, com: &ComputedCenterOfMass| {
+        let mut ccd_thickness: f32 = f32::INFINITY;
+        let mut sweep_radius: f32 = 0.0;
 
-            let mut ccd_thickness: f32 = f32::INFINITY;
-            let mut sweep_radius: f32 = 0.0;
+        for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
+            // Compute the CCD thickness
+            let ctx = ColliderContext::new(entity, &context);
+            let thickness = collider.ccd_thickness_with_context(ctx);
+            ccd_thickness = ccd_thickness.min(thickness);
 
-            // Find the minimum CCD thickness and maximum sweep radius.
-            for (entity, collider, collider_transform) in colliders.iter_many(rb_colliders) {
-                // Compute the CCD thickness
-                let ctx = ColliderContext::new(entity, &context);
-                let thickness = collider.ccd_thickness_with_context(ctx);
-                ccd_thickness = ccd_thickness.min(thickness);
+            // Compute the sweep radius
+            let ctx = ColliderContext::new(entity, &context);
+            let point = com.0 - collider_transform.translation;
+            let distance_to_com = collider.max_distance_to_point_with_context(point.real(), ctx);
+            sweep_radius = sweep_radius.max(distance_to_com);
+        }
 
-                // Compute the sweep radius
-                let ctx = ColliderContext::new(entity, &context);
-                let point = com.0 - collider_transform.translation;
-                let distance_to_com =
-                    collider.max_distance_to_point_with_context(point.real(), ctx);
-                sweep_radius = sweep_radius.max(distance_to_com);
-            }
+        BodySizeMetrics {
+            ccd_thickness,
+            sweep_radius,
+        }
+    };
 
-            size_metrics.ccd_thickness = ccd_thickness;
-            size_metrics.sweep_radius = sweep_radius;
-        },
-    );
+    // Bodies whose center of mass changed.
+    for (mut size_metrics, rb_colliders, com) in &mut bodies.p0() {
+        *size_metrics = compute(rb_colliders, com);
+    }
+
+    // Bodies with a collider that changed. Note that bodies may be visited
+    // multiple times, but the end result will be the same.
+    if changed_colliders.is_empty() {
+        return;
+    }
+    let mut all_bodies = bodies.p1();
+    for collider_of in &changed_colliders {
+        if let Ok((mut size_metrics, rb_colliders, com)) = all_bodies.get_mut(collider_of.body) {
+            *size_metrics = compute(rb_colliders, com);
+        }
+    }
 }

--- a/src/dynamics/rigid_body/forces/plugin.rs
+++ b/src/dynamics/rigid_body/forces/plugin.rs
@@ -246,12 +246,17 @@ fn apply_local_acceleration(
     diagnostics.integrate_velocities += start.elapsed();
 }
 
-fn clear_accumulated_local_acceleration(mut query: Query<&mut AccumulatedLocalAcceleration>) {
-    query.iter_mut().for_each(|mut acceleration| {
+fn clear_accumulated_local_acceleration(
+    mut query: Query<&mut AccumulatedLocalAcceleration, Changed<AccumulatedLocalAcceleration>>,
+) {
+    for mut acceleration in &mut query {
+        // Change detection is bypassed here so that clearing does not mark the component
+        // as changed, which would cause the system to run again the next step.
+        let acceleration = acceleration.bypass_change_detection();
         acceleration.linear = Vector::ZERO;
         #[cfg(feature = "3d")]
         {
             acceleration.angular = AngularVector::ZERO;
         }
-    });
+    }
 }

--- a/src/physics_transform/mod.rs
+++ b/src/physics_transform/mod.rs
@@ -187,7 +187,7 @@ pub type PhysicsTransformSet = PhysicsTransformSystems;
 /// To account for hierarchies, transform propagation should be run before this system.
 #[allow(clippy::type_complexity)]
 pub fn transform_to_position(
-    mut query: Query<(&GlobalTransform, &mut Position, &mut Rotation)>,
+    mut query: Query<(Ref<GlobalTransform>, &mut Position, &mut Rotation)>,
     length_unit: Res<PhysicsLengthUnit>,
     last_physics_tick: Res<LastPhysicsTick>,
     system_tick: SystemChangeTick,
@@ -209,6 +209,12 @@ pub fn transform_to_position(
     query.par_for_each_mut(
         MIN_PAR_ITER_ENTITIES,
         |(global_transform, mut position, mut rotation)| {
+            let transform_changed = global_transform.is_added()
+                || is_changed_after_tick(global_transform, last_physics_tick, this_run);
+            if !transform_changed {
+                return;
+            }
+
             let affine = global_transform.affine();
 
             let position_changed = !position.is_added()


### PR DESCRIPTION
# Objective

Avian still has some overhead as we scale up the number of static bodies to 100,000 or even 1 million. A lot of this is redundant work that we can skip for stationary entities, and the remaining overhead is mainly change detection.

The bigger problem however is spawning and removing bodies. To even get to a million entities, we need to be able to spawn them in reasonable time, but currently even 200k takes 20 seconds, and the time is scaling _quadratically_. There are some serious inefficiencies here.

## Solution

Firstly, this PR reduces static scene overhead further. With a million static bodies, `FixedPostUpdate` drops from 14.3 ms to 7.8 ms. The remaining overhead could be eliminated almost entirely with improved change detection overhead, which should hopefully be possible once https://github.com/bevyengine/bevy/pull/25157 lands.

Secondly, this optimizes adding and removing bodies/colliders significantly. Previously, there was a quadratic linear search that was really degrading the scalability for bulk insertion and removal, and the BVH insertion algorithm was also fairly slow. The search has now been fixed, and the BVH insertion algorithm has been replaced with a Box2D-style greedy alternative that seems to be ~3.3x as fast; the resulting tree quality is slightly worse, but only temporarily, as the tree is optimized during the timestep anyway.

When comparing body spawning speed on main vs. this PR, I got the following results:

| bodies | main | this PR | perf |
| ---- | ---- | ---- | ----- |
| 50k | 1.39 s | 0.149 s | 9.4x |
| 100k | 5.09 s | 0.306 s | 16.6x |
| 200k | 19.48 s | 0.634 s | 30.7x |
| 1M | - | 3.7s | - |

Spawning cost now scales linearly instead of quadratically, and we can pretty comfortably spawn even millions of static bodies. Nice!