### PR TITLE
Fix `ObvhsAabbExt::distance_to_point_squared`

### DIFF
--- a/src/collider_tree/obvhs_ext.rs
+++ b/src/collider_tree/obvhs_ext.rs
@@ -673,11 +673,8 @@ impl ObvhsAabbExt for Aabb {
         // so we convert to our Vec3A type.
         let min: Vec3A = self.min.to_array().into();
         let max: Vec3A = self.max.to_array().into();
-        let point_min = min - point;
-        let point_max = max - point;
-        let dist_min = point_min.max(Vec3A::ZERO);
-        let dist_max = point_max.min(Vec3A::ZERO);
-        dist_min.length_squared().min(dist_max.length_squared())
+        let delta = (min - point).max(Vec3A::ZERO) + (point - max).max(Vec3A::ZERO);
+        delta.length_squared()
     }
 
     #[inline(always)]

--- a/src/collider_tree/obvhs_ext.rs
+++ b/src/collider_tree/obvhs_ext.rs
@@ -723,3 +723,18 @@ pub fn obvhs_ray(ray: &Ray, max_distance: f32) -> obvhs::ray::Ray {
 
     obvhs::ray::Ray::new(origin, direction, 0.0, max_distance)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ObvhsAabbExt;
+    use bevy_math::Vec3A;
+    use obvhs::aabb::Aabb;
+
+    #[test]
+    fn distance_to_point_squared() {
+        let aabb = Aabb::new([0.0, 0.0, 0.0].into(), [1.0, 1.0, 1.0].into());
+        let point = Vec3A::new(2.0, 2.0, 0.5);
+
+        assert_eq!(aabb.distance_to_point_squared(point), 2.0);
+    }
+}


### PR DESCRIPTION
# Objective

Fixes #1042

The point-to-AABB distance computation is wrong in 0.7! This significantly regressed point projection performance.

## Solution

Fix it

## Testing

Added a regression test