### PR TITLE
Fix island panic when a recycled contact has no island

### DIFF
--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -212,6 +212,9 @@ bitflags::bitflags! {
         const STATIC2 = 1 << 7;
         /// Set if the contact pair should have a custom contact modification hook applied.
         const MODIFY_CONTACTS = 1 << 8;
+        /// Set if the contact pair just stopped generating contact constraints,
+        /// for example because a collider became a sensor or was detached from its rigid body.
+        const STOPPED_GENERATING_CONSTRAINTS = 1 << 9;
     }
 }
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -219,9 +219,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                         contact_pair.collider2.index_u32(),
                     );
 
-                    if contact_pair.generates_constraints()
-                        && let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2)
-                    {
+                    // Unlink solver state even if GENERATE_CONSTRAINTS was already cleared.
+                    // Otherwise the island node and constraint handles outlive the pair,
+                    // and a recycled ContactId can panic with "Head contact has no island".
+                    if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2) {
                         self.contact_status_changes.push(
                             ContactStatusChange::StoppedGeneratingConstraints {
                                 contact_id,
@@ -260,8 +261,16 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     contact_pair
                         .flags
                         .set(ContactPairFlags::STARTED_TOUCHING, false);
+                    // Stop-touching already emitted Stopped. A leftover stop flag
+                    // would consume a later start and leave the pair constraintless.
+                    contact_pair
+                        .flags
+                        .set(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS, false);
 
                     if contact_pair.generates_constraints() {
+                        contact_pair
+                            .flags
+                            .set(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS, false);
                         self.contact_status_changes.push(
                             ContactStatusChange::StartedGeneratingConstraints(contact_id),
                         );
@@ -296,10 +305,14 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     contact_pair
                         .flags
                         .set(ContactPairFlags::STOPPED_TOUCHING, false);
+                    contact_pair
+                        .flags
+                        .set(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS, false);
+                    contact_pair
+                        .flags
+                        .set(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS, false);
 
-                    if contact_pair.generates_constraints()
-                        && let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2)
-                    {
+                    if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2) {
                         self.contact_status_changes.push(
                             ContactStatusChange::StoppedGeneratingConstraints {
                                 contact_id,
@@ -308,37 +321,58 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             },
                         );
                     }
-                } else if contact_pair.is_touching()
-                    && contact_pair
+                } else if contact_pair.is_touching() {
+                    let stopped_generating = contact_pair
+                        .flags
+                        .contains(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS);
+                    if stopped_generating {
+                        contact_pair
+                            .flags
+                            .set(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS, false);
+
+                        if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2)
+                        {
+                            self.contact_status_changes.push(
+                                ContactStatusChange::StoppedGeneratingConstraints {
+                                    contact_id,
+                                    body1,
+                                    body2,
+                                },
+                            );
+                        }
+                    }
+
+                    if contact_pair
                         .flags
                         .contains(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS)
-                {
-                    // The contact pair should start generating constraints.
-                    contact_pair
-                        .flags
-                        .set(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS, false);
+                    {
+                        contact_pair
+                            .flags
+                            .set(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS, false);
 
-                    self.contact_status_changes.push(
-                        ContactStatusChange::StartedGeneratingConstraints(contact_id),
-                    );
-                } else if contact_pair.is_touching()
-                    && contact_pair.generates_constraints()
-                    && contact_pair.manifold_count_change != 0
-                {
-                    // The contact pair is still touching, but the manifold count changed.
-                    // Let the solver add or remove the corresponding constraints.
-                    let delta = contact_pair.manifold_count_change;
-                    contact_pair.manifold_count_change = 0;
-
-                    if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2) {
                         self.contact_status_changes.push(
-                            ContactStatusChange::ManifoldCountChanged {
-                                contact: contact_id,
-                                body1,
-                                body2,
-                                delta,
-                            },
+                            ContactStatusChange::StartedGeneratingConstraints(contact_id),
                         );
+                    } else if !stopped_generating
+                        && contact_pair.generates_constraints()
+                        && contact_pair.manifold_count_change != 0
+                    {
+                        // The contact pair is still touching, but the manifold count changed.
+                        // Let the solver add or remove the corresponding constraints.
+                        let delta = contact_pair.manifold_count_change;
+                        contact_pair.manifold_count_change = 0;
+
+                        if let (Some(body1), Some(body2)) = (contact_pair.body1, contact_pair.body2)
+                        {
+                            self.contact_status_changes.push(
+                                ContactStatusChange::ManifoldCountChanged {
+                                    contact: contact_id,
+                                    body1,
+                                    body2,
+                                    delta,
+                                },
+                            );
+                        }
                     }
                 }
 
@@ -703,12 +737,18 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                     || body2_bundle.is_none()
                     || collider1.is_sensor
                     || collider2.is_sensor;
+                let was_generating = contacts.generates_constraints();
 
-                if !is_disabled && !contacts.generates_constraints() {
+                if !is_disabled && !was_generating {
                     // This can happen when a sensor is removed, or when a collider is attached to a body.
                     contacts
                         .flags
                         .set(ContactPairFlags::STARTED_GENERATING_CONSTRAINTS, true);
+                    contact_status_bits.set(contact_id);
+                } else if is_disabled && was_generating {
+                    contacts
+                        .flags
+                        .set(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS, true);
                     contact_status_bits.set(contact_id);
                 }
 

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -45,6 +45,9 @@
 mod sleeping;
 pub use sleeping::{IslandSleepingPlugin, SleepBody, SleepIslands, WakeBody, WakeIslands};
 
+#[cfg(test)]
+mod tests;
+
 use bevy::{
     ecs::{
         entity::{ComponentCloneCtx, SourceComponent},
@@ -504,10 +507,17 @@ impl PhysicsIslands {
     }
 
     /// Returns the slice of contact [`IslandNode`]s, indexed by [`ContactId`].
-    #[cfg(feature = "validate")]
+    #[cfg(any(test, feature = "validate"))]
     #[inline]
     pub(crate) fn contact_nodes(&self) -> &[Option<IslandNode<ContactId>>] {
         &self.contact_nodes
+    }
+
+    /// Test accessor for island contact-list validation.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn contact_nodes_for_test(&self) -> &[Option<IslandNode<ContactId>>] {
+        self.contact_nodes()
     }
 
     /// Returns the [`IslandNode`] linking the given joint to its island,
@@ -576,8 +586,14 @@ impl PhysicsIslands {
     ) -> Option<&PhysicsIsland> {
         let contact = contact_graph.get_edge_by_id(contact_id).unwrap();
 
-        debug_assert!(self.contact_node(contact_id).is_none());
         debug_assert!(contact.is_touching());
+
+        // ContactIds are recycled when a pair is destroyed. If Stopped was not applied
+        // before this Started, the old island node is still linked. Unlink it first so
+        // we do not overwrite the slot and leave `head_contact` pointing at a taken node.
+        if self.contact_node(contact_id).is_some() {
+            self.remove_contact(contact_id, body_islands);
+        }
 
         let (Some(body1), Some(body2)) = (contact.body1, contact.body2) else {
             return None;

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -45,7 +45,11 @@
 mod sleeping;
 pub use sleeping::{IslandSleepingPlugin, SleepBody, SleepIslands, WakeBody, WakeIslands};
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
 mod tests;
 
 use bevy::{
@@ -507,17 +511,17 @@ impl PhysicsIslands {
     }
 
     /// Returns the slice of contact [`IslandNode`]s, indexed by [`ContactId`].
-    #[cfg(any(test, feature = "validate"))]
+    #[cfg(any(
+        feature = "validate",
+        all(
+            test,
+            feature = "default-collider",
+            any(feature = "parry-f32", feature = "parry-f64")
+        )
+    ))]
     #[inline]
     pub(crate) fn contact_nodes(&self) -> &[Option<IslandNode<ContactId>>] {
         &self.contact_nodes
-    }
-
-    /// Test accessor for island contact-list validation.
-    #[cfg(test)]
-    #[inline]
-    pub(crate) fn contact_nodes_for_test(&self) -> &[Option<IslandNode<ContactId>>] {
-        self.contact_nodes()
     }
 
     /// Returns the [`IslandNode`] linking the given joint to its island,

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -590,14 +590,8 @@ impl PhysicsIslands {
     ) -> Option<&PhysicsIsland> {
         let contact = contact_graph.get_edge_by_id(contact_id).unwrap();
 
+        debug_assert!(self.contact_node(contact_id).is_none());
         debug_assert!(contact.is_touching());
-
-        // ContactIds are recycled when a pair is destroyed. If Stopped was not applied
-        // before this Started, the old island node is still linked. Unlink it first so
-        // we do not overwrite the slot and leave `head_contact` pointing at a taken node.
-        if self.contact_node(contact_id).is_some() {
-            self.remove_contact(contact_id, body_islands);
-        }
 
         let (Some(body1), Some(body2)) = (contact.body1, contact.body2) else {
             return None;

--- a/src/dynamics/solver/islands/tests.rs
+++ b/src/dynamics/solver/islands/tests.rs
@@ -1,0 +1,282 @@
+//! Regression tests for island contact accounting.
+//!
+//! These hit the real physics schedule: narrow phase records contact status
+//! changes, and the solver applies them to [`PhysicsIslands`].
+
+use core::time::Duration;
+
+use bevy::{prelude::*, time::TimeUpdateStrategy};
+
+use crate::{
+    collision::contact_types::{ContactGraph, ContactId},
+    dynamics::solver::islands::PhysicsIslands,
+    prelude::*,
+};
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn create_app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        TransformPlugin,
+        PhysicsPlugins::default(),
+        bevy::asset::AssetPlugin::default(),
+        #[cfg(feature = "bevy_scene")]
+        bevy::scene::ScenePlugin,
+        #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
+        bevy::mesh::MeshPlugin,
+    ))
+    .insert_resource(Gravity::ZERO)
+    .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_secs_f32(
+        1.0 / 60.0,
+    )));
+    app.finish();
+    app
+}
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn tick(app: &mut App) {
+    app.update();
+}
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn spawn_box(app: &mut App, body: RigidBody, pos: Vector) -> Entity {
+    #[cfg(feature = "2d")]
+    let collider = Collider::rectangle(1.0, 1.0);
+    #[cfg(feature = "3d")]
+    let collider = Collider::cuboid(1.0, 1.0, 1.0);
+
+    app.world_mut()
+        .spawn((Transform::default(), body, Position(pos), collider))
+        .id()
+}
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn generating_touching_count(app: &App) -> usize {
+    app.world()
+        .resource::<ContactGraph>()
+        .iter_active()
+        .filter(|pair| pair.is_touching() && pair.generates_constraints())
+        .count()
+}
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn island_contact_count(app: &App) -> u32 {
+    app.world()
+        .resource::<PhysicsIslands>()
+        .iter()
+        .map(|island| island.contact_count())
+        .sum()
+}
+
+/// Island contact lists must match touching constraint-generating pairs.
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn assert_island_contacts_match_graph(app: &App) {
+    assert_eq!(
+        island_contact_count(app) as usize,
+        generating_touching_count(app),
+        "island contact_count must match touching constraint-generating pairs"
+    );
+
+    let islands = app.world().resource::<PhysicsIslands>();
+    for island in islands.iter() {
+        island.validate_contacts(islands.contact_nodes_for_test());
+    }
+}
+
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn first_generating_contact_id(app: &App) -> ContactId {
+    app.world()
+        .resource::<ContactGraph>()
+        .iter_active()
+        .find(|pair| pair.is_touching() && pair.generates_constraints())
+        .map(|pair| pair.contact_id)
+        .expect("expected a touching constraint-generating contact")
+}
+
+/// Resting contacts stay linked through a normal separate-and-recontact cycle.
+#[test]
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn resting_contact_survives_separate_and_recontact() {
+    let mut app = create_app();
+
+    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+
+    app.world_mut()
+        .entity_mut(dynamic)
+        .insert(Position(Vector::Y * 20.0));
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert_eq!(generating_touching_count(&app), 0);
+    assert_island_contacts_match_graph(&app);
+
+    app.world_mut()
+        .entity_mut(dynamic)
+        .insert(Position(Vector::Y * 0.9));
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+}
+
+/// A duplicate Started for a live contact must not leave a stale head after Stopped.
+///
+/// This is the #1025 lifecycle: add_contact used to overwrite the island node for a
+/// ContactId that was already linked, so remove_contact left `head_contact` pointing
+/// at a taken slot. The next add then panicked with "Head contact has no island".
+#[test]
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn duplicate_started_then_stopped_does_not_leave_stale_head() {
+    let mut app = create_app();
+
+    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert_island_contacts_match_graph(&app);
+
+    let contact_id = first_generating_contact_id(&app);
+    app.world_mut()
+        .resource_mut::<ContactStatusChangeQueue>()
+        .push(ContactStatusChange::StartedGeneratingConstraints(
+            contact_id,
+        ));
+    tick(&mut app);
+    assert_island_contacts_match_graph(&app);
+
+    app.world_mut()
+        .entity_mut(dynamic)
+        .insert(Position(Vector::Y * 20.0));
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert_eq!(generating_touching_count(&app), 0);
+    assert_island_contacts_match_graph(&app);
+
+    app.world_mut()
+        .entity_mut(dynamic)
+        .insert(Position(Vector::Y * 0.9));
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+}
+
+/// Clearing GENERATE_CONSTRAINTS and then destroying the pair must unlink the island
+/// contact. Otherwise a later pair can reuse the ContactId while `head_contact` is stale.
+#[test]
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn disabled_pair_destroy_unlinks_island_contact() {
+    let mut app = create_app();
+
+    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+
+    {
+        let mut graph = app.world_mut().resource_mut::<ContactGraph>();
+        for pair in graph.iter_active_mut() {
+            pair.flags.remove(ContactPairFlags::GENERATE_CONSTRAINTS);
+        }
+    }
+
+    app.world_mut()
+        .entity_mut(dynamic)
+        .insert(Position(Vector::Y * 20.0));
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert_eq!(generating_touching_count(&app), 0);
+    assert_island_contacts_match_graph(&app);
+
+    spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+}
+
+/// A leftover generation-stop and a new start in the same still-touching visit
+/// must both be applied. Otherwise the start is dropped and the pair stays
+/// constraintless after re-enable.
+#[test]
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+fn leftover_stop_and_start_in_same_visit_relink() {
+    let mut app = create_app();
+    app.insert_resource(NarrowPhaseConfig {
+        recycle_distance: 0.0,
+        ..default()
+    });
+
+    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
+    spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+
+    for _ in 0..10 {
+        tick(&mut app);
+    }
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+
+    {
+        let mut graph = app.world_mut().resource_mut::<ContactGraph>();
+        for pair in graph.iter_active_mut() {
+            pair.flags.remove(ContactPairFlags::GENERATE_CONSTRAINTS);
+            pair.flags
+                .insert(ContactPairFlags::STOPPED_GENERATING_CONSTRAINTS);
+        }
+    }
+    tick(&mut app);
+    assert!(generating_touching_count(&app) >= 1);
+    assert_island_contacts_match_graph(&app);
+}

--- a/src/dynamics/solver/islands/tests.rs
+++ b/src/dynamics/solver/islands/tests.rs
@@ -49,7 +49,7 @@ fn tick(app: &mut App) {
     feature = "default-collider",
     any(feature = "parry-f32", feature = "parry-f64")
 ))]
-fn spawn_box(app: &mut App, body: RigidBody, pos: Vector) -> Entity {
+fn spawn_box(app: &mut App, body: RigidBody, pos: RVector) -> Entity {
     #[cfg(feature = "2d")]
     let collider = Collider::rectangle(1.0, 1.0);
     #[cfg(feature = "3d")]
@@ -98,7 +98,7 @@ fn assert_island_contacts_match_graph(app: &App) {
 
     let islands = app.world().resource::<PhysicsIslands>();
     for island in islands.iter() {
-        island.validate_contacts(islands.contact_nodes_for_test());
+        island.validate_contacts(islands.contact_nodes());
     }
 }
 
@@ -124,8 +124,8 @@ fn first_generating_contact_id(app: &App) -> ContactId {
 fn resting_contact_survives_separate_and_recontact() {
     let mut app = create_app();
 
-    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
-    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    spawn_box(&mut app, RigidBody::Static, RVector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, RVector::Y * 0.9);
 
     for _ in 0..10 {
         tick(&mut app);
@@ -135,7 +135,7 @@ fn resting_contact_survives_separate_and_recontact() {
 
     app.world_mut()
         .entity_mut(dynamic)
-        .insert(Position(Vector::Y * 20.0));
+        .insert(Position(RVector::Y * 20.0));
     for _ in 0..10 {
         tick(&mut app);
     }
@@ -144,7 +144,7 @@ fn resting_contact_survives_separate_and_recontact() {
 
     app.world_mut()
         .entity_mut(dynamic)
-        .insert(Position(Vector::Y * 0.9));
+        .insert(Position(RVector::Y * 0.9));
     for _ in 0..10 {
         tick(&mut app);
     }
@@ -165,8 +165,8 @@ fn resting_contact_survives_separate_and_recontact() {
 fn duplicate_started_then_stopped_does_not_leave_stale_head() {
     let mut app = create_app();
 
-    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
-    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    spawn_box(&mut app, RigidBody::Static, RVector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, RVector::Y * 0.9);
 
     for _ in 0..10 {
         tick(&mut app);
@@ -184,7 +184,7 @@ fn duplicate_started_then_stopped_does_not_leave_stale_head() {
 
     app.world_mut()
         .entity_mut(dynamic)
-        .insert(Position(Vector::Y * 20.0));
+        .insert(Position(RVector::Y * 20.0));
     for _ in 0..10 {
         tick(&mut app);
     }
@@ -193,7 +193,7 @@ fn duplicate_started_then_stopped_does_not_leave_stale_head() {
 
     app.world_mut()
         .entity_mut(dynamic)
-        .insert(Position(Vector::Y * 0.9));
+        .insert(Position(RVector::Y * 0.9));
     for _ in 0..10 {
         tick(&mut app);
     }
@@ -211,8 +211,8 @@ fn duplicate_started_then_stopped_does_not_leave_stale_head() {
 fn disabled_pair_destroy_unlinks_island_contact() {
     let mut app = create_app();
 
-    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
-    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    spawn_box(&mut app, RigidBody::Static, RVector::ZERO);
+    let dynamic = spawn_box(&mut app, RigidBody::Dynamic, RVector::Y * 0.9);
 
     for _ in 0..10 {
         tick(&mut app);
@@ -229,14 +229,14 @@ fn disabled_pair_destroy_unlinks_island_contact() {
 
     app.world_mut()
         .entity_mut(dynamic)
-        .insert(Position(Vector::Y * 20.0));
+        .insert(Position(RVector::Y * 20.0));
     for _ in 0..10 {
         tick(&mut app);
     }
     assert_eq!(generating_touching_count(&app), 0);
     assert_island_contacts_match_graph(&app);
 
-    spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    spawn_box(&mut app, RigidBody::Dynamic, RVector::Y * 0.9);
     for _ in 0..10 {
         tick(&mut app);
     }
@@ -259,8 +259,8 @@ fn leftover_stop_and_start_in_same_visit_relink() {
         ..default()
     });
 
-    spawn_box(&mut app, RigidBody::Static, Vector::ZERO);
-    spawn_box(&mut app, RigidBody::Dynamic, Vector::Y * 0.9);
+    spawn_box(&mut app, RigidBody::Static, RVector::ZERO);
+    spawn_box(&mut app, RigidBody::Dynamic, RVector::Y * 0.9);
 
     for _ in 0..10 {
         tick(&mut app);

--- a/src/dynamics/solver/islands/tests.rs
+++ b/src/dynamics/solver/islands/tests.rs
@@ -154,8 +154,8 @@ fn resting_contact_survives_separate_and_recontact() {
 
 /// A duplicate Started for a live contact must not leave a stale head after Stopped.
 ///
-/// This is the #1025 lifecycle: add_contact used to overwrite the island node for a
-/// ContactId that was already linked, so remove_contact left `head_contact` pointing
+/// This is the #1025 lifecycle: `add_contact` used to overwrite the island node for a
+/// `ContactId` that was already linked, so `remove_contact` left `head_contact` pointing
 /// at a taken slot. The next add then panicked with "Head contact has no island".
 #[test]
 #[cfg(all(
@@ -201,8 +201,8 @@ fn duplicate_started_then_stopped_does_not_leave_stale_head() {
     assert_island_contacts_match_graph(&app);
 }
 
-/// Clearing GENERATE_CONSTRAINTS and then destroying the pair must unlink the island
-/// contact. Otherwise a later pair can reuse the ContactId while `head_contact` is stale.
+/// Clearing `GENERATE_CONSTRAINTS` and then destroying the pair must unlink the island
+/// contact. Otherwise a later pair can reuse the `ContactId` while `head_contact` is stale.
 #[test]
 #[cfg(all(
     feature = "default-collider",

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -295,13 +295,18 @@ fn apply_contact_status_change(
                 return;
             };
 
-            // Add a contact constraint for each manifold.
-            for _ in 0..contact_pair.manifolds.len() {
-                constraint_graph.push_manifold(contact_pair);
+            // A duplicate Started for a live contact must not push extra manifolds.
+            // Recycled ContactIds should already have been unlinked by Stopped.
+            if constraint_graph.manifold_count(contact) == 0 {
+                for _ in 0..contact_pair.manifolds.len() {
+                    constraint_graph.push_manifold(contact_pair);
+                }
             }
 
             // Link the contact to an island.
-            if let Some(islands) = islands {
+            if let Some(islands) = islands
+                && islands.contact_node(contact).is_none()
+            {
                 let island = islands.add_contact(contact, body_islands, contact_graph);
 
                 if let Some(island) = island


### PR DESCRIPTION
# Objective

Fixes #1025

`add_contact` panics with `Head contact has no island` when a recycled `ContactId` still has a stale island node. that happens if a pair is destroyed or stops generating constraints without the solver unlinking it.

## Solution

narrow phase now queues `StoppedGeneratingConstraints` when a pair is destroyed or stops touching, even if `GENERATE_CONSTRAINTS` was already cleared. `StartedGeneratingConstraints` is idempotent so a duplicate start doesnt push extra manifolds or overwrite the island node.

if a stop-touching and a generation-stop land in the same update, the leftover stop flag is cleared. a later start in the same still-touching visit is applied after the stop instead of getting dropped.

Cursor Grok 4.6 helped trace the island node lifecycle and write the patch. i reviewed it.

## Testing

- `cargo test -p avian2d --lib -- dynamics::solver::islands::tests`
- covers normal separate/recontact, duplicate Started, destroy after `GENERATE_CONSTRAINTS` is cleared, and leftover stop+start in one visit
- `cargo fmt --all -- --check`
- `cargo clippy -p avian2d --lib --locked -- -D warnings`

happy to tweak if you'd rather keep the unlink only on the solver side