### PR TITLE
Check for out of bounds in prepare_contact_constraints

### DIFF
--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -695,7 +695,9 @@ fn prepare_contact_constraints(
                 })
                 .1;
             let manifold_index = handle.manifold_index;
-            let Some(manifold) = &contact_pair.manifolds.get(manifold_index) else { continue; };
+            let Some(manifold) = &contact_pair.manifolds.get(manifold_index) else {
+                continue;
+            };
 
             if !contact_pair.generates_constraints() {
                 continue;

--- a/src/dynamics/solver/plugin.rs
+++ b/src/dynamics/solver/plugin.rs
@@ -695,7 +695,7 @@ fn prepare_contact_constraints(
                 })
                 .1;
             let manifold_index = handle.manifold_index;
-            let manifold = &contact_pair.manifolds[manifold_index];
+            let Some(manifold) = &contact_pair.manifolds.get(manifold_index) else { continue; };
 
             if !contact_pair.generates_constraints() {
                 continue;


### PR DESCRIPTION
# Objective

When I made a (dynamic) entity with ColliderConstructor::TrimeshFromMesh and launched it at another (static) entity of the same type it caused a crash:

index out of bounds: the len is 349 but the index is 349
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_bounds_check
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:271:5
   3: <usize as core::slice::index::SliceIndex<[avian3d::collision::contact_types::ContactManifold]>>::index
             at /usr/lib/sdk/rust-stable/lib/rustlib/src/rust/library/core/src/slice/index.rs:272:10
   4: <[avian3d::collision::contact_types::ContactManifold] as core::ops::index::Index<usize>>::index
             at /usr/lib/sdk/rust-stable/lib/rustlib/src/rust/library/core/src/slice/index.rs:19:15
   5: <alloc::vec::Vec<avian3d::collision::contact_types::ContactManifold> as core::ops::index::Index<usize>>::index
             at /usr/lib/sdk/rust-stable/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3864:9
   6: avian3d::dynamics::solver::plugin::prepare_contact_constraints::{closure#1}
             at /home/lort533/.var/app/com.vscodium.codium/data/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/avian3d-0.7.0/src/dynamics/solver/plugin.rs:398:51

## Solution

I've noticed theres some index mismatch going on, so to prevent a crash from happening I've applied a simple let-else, now it doesnt crash anymore.

## Testing

Although it works, the collision is weird (it kinda just stops itself in place) - I'm pretty sure there is something more to this issue, I'm not familiar with this code much so I can't tell what's going on, there is noticeable lag when the collision happens.

My environment is very simple, one entity made via:
```
WorldAssetRoot(asset_server.load(
    GltfAssetLabel::Scene(0)
        .from_asset("asset1.glb"),
)),
RigidBody::Static,
ColliderConstructorHierarchy::new(ColliderConstructor::TrimeshFromMesh)
```
and another with similar bundle but it's dynamic, has a mass, restitution and linear velocity. Worth noting none of these issues occur when using ConvexHullFromMesh or primitive colliders.

When I launched a simple Blender cube it didn't crash, but when I made a more complex mesh (uv sphere with 90 segments, 44 rings, 3.06 m radius) - lags and crashes upon collision. With my fix it lags but no longer crashes, doesn't behave as expected either. This should probably be marked as a bug - let me know if you're able to reproduce this issue.