### PR TITLE
Debug rendering for discrete spatial queries

### DIFF
--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -161,7 +161,7 @@ fn gamepad_input(mut movement_writer: MessageWriter<MovementAction>, gamepads: Q
 fn update_grounded(
     mut commands: Commands,
     mut query: Query<(Entity, &GroundDetection, &GlobalTransform)>,
-    spatial_query: SpatialQuery,
+    mut spatial_query: SpatialQuery,
 ) {
     for (entity, ground_detection, global_transform) in &mut query {
         let Some(collider) = &ground_detection.cast_shape else {

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -209,3 +209,7 @@ required-features = ["3d", "debug-plugin"]
 name = "velocity_projection"
 required-features = ["3d", "default-collider", "test"]
 harness = false
+
+[[example]]
+name = "debug_render_3d"
+required-features = ["3d", "debug-plugin", "bevy_scene"]

--- a/crates/avian3d/examples/debug_render_3d.rs
+++ b/crates/avian3d/examples/debug_render_3d.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use avian3d::{math::RVector, prelude::*};
+use bevy::prelude::*;
+
+fn main() {
+    App::default()
+        .add_plugins((
+            DefaultPlugins,
+            PhysicsPlugins::default(),
+            PhysicsDebugPlugin,
+        ))
+        .add_systems(Startup, scene.spawn())
+        .insert_resource(Cycle::new(Duration::from_secs(3)))
+        .add_systems(Update, (cast, move_wall))
+        .run();
+}
+
+fn scene() -> impl SceneList {
+    bsn_list![
+        (
+            Camera3d
+            template_value(Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y))
+        ),
+        (
+            Mesh3d(asset_value(Cuboid::new(8.0, 1.0, 1.0)))
+            MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))
+            Collider::cuboid(8.0, 1.0, 1.0)
+            Transform::from_xyz(0.0, 0.0, -2.0)
+            MoveLeft
+        ),
+    ]
+}
+
+#[derive(Resource, Deref, DerefMut)]
+struct Cycle(Timer);
+
+impl Cycle {
+    pub fn new(duration: Duration) -> Self {
+        Self(Timer::new(duration, TimerMode::Repeating))
+    }
+}
+
+fn cast(mut space: SpatialQuery, mut cycle: ResMut<Cycle>, time: Res<Time>) {
+    if cycle.tick(time.delta()).just_finished() {
+        let filter = SpatialQueryFilter::default();
+        let shape = Collider::sphere(0.5);
+
+        space.cast_ray(RVector::ZERO, Dir3::NEG_Z, 100.0, false, &filter);
+        space.cast_shape(
+            &shape,
+            RVector::new(1.0, 0.0, 0.0),
+            Quat::IDENTITY,
+            Dir3::NEG_Z,
+            &Default::default(),
+            &filter,
+        );
+        space.project_point(RVector::new(-1.0, 0.0, 0.0), false, &filter);
+        space.shape_intersections(
+            &shape,
+            RVector::new(-2.0, 0.0, -1.25),
+            Quat::IDENTITY,
+            &filter,
+        );
+    }
+}
+
+#[derive(Resource, Deref, DerefMut, Clone, Copy, Default)]
+struct MoveLeft(pub bool);
+
+fn move_wall(mut wall: Single<(&mut Transform, &mut MoveLeft)>, time: Res<Time>) {
+    let (transform, move_left) = &mut *wall;
+    let delta = 1.0 * time.delta_secs();
+
+    if ***move_left {
+        transform.translation.x -= delta;
+    } else {
+        transform.translation.x += delta;
+    }
+
+    if transform.translation.x <= -5.0 {
+        ***move_left = false;
+    } else if transform.translation.x >= 5.0 {
+        ***move_left = true;
+    }
+}

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use bevy::{color::palettes::css::*, prelude::*};
+use core::time::Duration;
 
 /// Gizmos used for debug rendering physics. See [`PhysicsDebugPlugin`]
 ///
@@ -92,6 +93,17 @@ pub struct PhysicsGizmos {
     pub shapecast_point_color: Option<Color>,
     /// The color used for the hit normals in [shapecasts](spatial_query#shapecasting).
     pub shapecast_normal_color: Option<Color>,
+    /// The color used for the origin in [point projections](spatial_query#point-projection).
+    pub point_projection_origin_color: Option<Color>,
+    /// The color used for the arrow in [point projections](spatial_query#point-projection).
+    pub point_projection_arrow_color: Option<Color>,
+    /// The color used for the projected point in [point projections](spatial_query#point-projection).
+    pub point_projection_point_color: Option<Color>,
+    /// The color used for the shapes in [shape intersections](SpatialQuery::shape_intersections).
+    pub shape_intersection_shape_color: Option<Color>,
+    /// The color used for the intersecting shapes in
+    /// [shape intersections](SpatialQuery::shape_intersections).
+    pub shape_intersection_hit_color: Option<Color>,
     /// The color used for the bounds of [`PhysicsIsland`](dynamics::solver::islands::PhysicsIsland)s.
     pub island_color: Option<Color>,
     /// The color used for [`ColliderTree`](crate::collider_tree) nodes.
@@ -99,6 +111,9 @@ pub struct PhysicsGizmos {
     /// Determines if the visibility of entities with [colliders](Collider) should be set to `Visibility::Hidden`,
     /// which will only show the debug renders.
     pub hide_meshes: bool,
+    /// How long discrete spatial queries (that is, methods called on [`SpatialQuery`]) should be
+    /// rendered.
+    pub temp_gizmo_lifetime: Duration,
 }
 
 impl Default for PhysicsGizmos {
@@ -122,6 +137,14 @@ impl Default for PhysicsGizmos {
             shapecast_shape_color: Some(Color::srgb(0.4, 0.6, 1.0)),
             shapecast_point_color: Some(YELLOW.into()),
             shapecast_normal_color: Some(PINK.into()),
+            // TODO: decide on these
+            point_projection_origin_color: Some(Color::WHITE),
+            point_projection_arrow_color: Some(Color::WHITE),
+            point_projection_point_color: Some(Color::WHITE),
+            shape_intersection_shape_color: Some(Color::WHITE),
+            shape_intersection_hit_color: Some(Color::WHITE),
+            temp_gizmo_lifetime: Duration::from_secs(2),
+            // ---------------------
             island_color: None,
             collider_tree_color: None,
             hide_meshes: false,
@@ -169,6 +192,14 @@ impl PhysicsGizmos {
             shapecast_shape_color: Some(Color::srgb(0.4, 0.6, 1.0)),
             shapecast_point_color: Some(YELLOW.into()),
             shapecast_normal_color: Some(PINK.into()),
+            // TODO: decide on these
+            point_projection_origin_color: Some(Color::WHITE),
+            point_projection_arrow_color: Some(Color::WHITE),
+            point_projection_point_color: Some(Color::WHITE),
+            shape_intersection_shape_color: Some(Color::WHITE),
+            shape_intersection_hit_color: Some(Color::WHITE),
+            temp_gizmo_lifetime: Duration::from_secs(2),
+            // ---------------------
             island_color: Some(RED.into()),
             collider_tree_color: Some(Color::WHITE),
             hide_meshes: true,
@@ -198,6 +229,12 @@ impl PhysicsGizmos {
             shapecast_shape_color: None,
             shapecast_point_color: None,
             shapecast_normal_color: None,
+            point_projection_origin_color: None,
+            point_projection_arrow_color: None,
+            point_projection_point_color: None,
+            shape_intersection_shape_color: None,
+            shape_intersection_hit_color: None,
+            temp_gizmo_lifetime: Duration::ZERO,
             island_color: None,
             collider_tree_color: None,
             hide_meshes: false,

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -30,6 +30,7 @@ use bevy::{
     },
     prelude::*,
 };
+use core::time::Duration;
 
 /// A plugin that renders physics objects and properties for debugging purposes.
 /// It is not enabled by default and must be added manually.
@@ -132,7 +133,10 @@ impl Plugin for PhysicsDebugPlugin {
                     any(feature = "parry-f32", feature = "parry-f64")
                 ))]
                 debug_render_shapecasts,
+                debug_render_project_point,
+                debug_render_shape_intersections,
                 debug_render_islands.run_if(resource_exists::<PhysicsIslands>),
+                temp_gizmos,
             )
                 .after(TransformSystems::Propagate)
                 .run_if(|store: Res<GizmoConfigStore>| store.config::<PhysicsGizmos>().0.enabled),
@@ -442,6 +446,23 @@ pub fn debug_render_constraint<T: Component + DebugRenderConstraint<N>, const N:
     }
 }
 
+#[derive(Component, Deref, DerefMut)]
+pub(crate) struct TempGizmo(pub Timer);
+
+impl TempGizmo {
+    pub fn new(lifetime: Duration) -> Self {
+        Self(Timer::new(lifetime, TimerMode::Repeating))
+    }
+}
+
+fn temp_gizmos(query: Query<(Entity, &mut TempGizmo)>, time: Res<Time>, mut commands: Commands) {
+    for (entity, mut temp_gizmo) in query {
+        if temp_gizmo.tick(time.delta()).is_finished() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
 fn debug_render_raycasts(
     query: Query<(&RayCaster, &RayHits)>,
     mut gizmos: Gizmos<PhysicsGizmos>,
@@ -467,7 +488,6 @@ fn debug_render_raycasts(
         );
     }
 }
-
 #[cfg(all(
     feature = "default-collider",
     any(feature = "parry-f32", feature = "parry-f64")
@@ -499,6 +519,75 @@ fn debug_render_shapecasts(
             normal_color,
             length_unit.0,
         );
+    }
+}
+
+#[derive(Component, Clone)]
+pub(crate) struct ProjectPoint {
+    pub origin: RVector,
+    pub point: RVector,
+}
+fn debug_render_project_point(
+    projections: Query<&ProjectPoint>,
+    mut gizmos: Gizmos<PhysicsGizmos>,
+    store: Res<GizmoConfigStore>,
+    length_unit: Res<PhysicsLengthUnit>,
+) {
+    let config = store.config::<PhysicsGizmos>().1;
+    for projection in projections {
+        let origin_color = config.point_projection_origin_color.unwrap_or(Color::NONE);
+        let arrow_color = config.point_projection_arrow_color.unwrap_or(Color::NONE);
+        let point_color = config.point_projection_point_color.unwrap_or(Color::NONE);
+
+        gizmos.draw_arrow(
+            projection.origin,
+            projection.point,
+            0.1 * **length_unit,
+            arrow_color,
+        );
+
+        #[cfg(feature = "2d")]
+        {
+            gizmos.circle_2d(projection.origin.f32(), 0.1 * **length_unit, origin_color);
+            gizmos.circle_2d(projection.point.f32(), 0.1 * **length_unit, point_color);
+        }
+        #[cfg(feature = "3d")]
+        {
+            gizmos.sphere(projection.origin.f32(), 0.1 * **length_unit, origin_color);
+            gizmos.sphere(projection.point.f32(), 0.1 * **length_unit, point_color);
+        }
+    }
+}
+
+#[derive(Component, Clone)]
+pub(crate) struct ShapeIntersections {
+    pub position: RVector,
+    pub rotation: Rot,
+    pub shape: Collider,
+    pub hits: Vec<(RVector, Rot, Collider)>,
+}
+
+fn debug_render_shape_intersections(
+    intersections: Query<&ShapeIntersections>,
+    mut gizmos: Gizmos<PhysicsGizmos>,
+    store: Res<GizmoConfigStore>,
+) {
+    let config = store.config::<PhysicsGizmos>().1;
+
+    for intersection in intersections {
+        let shape_color = config.shape_intersection_shape_color.unwrap_or(Color::NONE);
+        let hit_color = config.shape_intersection_hit_color.unwrap_or(Color::NONE);
+
+        gizmos.draw_collider(
+            &intersection.shape,
+            intersection.position,
+            intersection.rotation,
+            shape_color,
+        );
+
+        for (position, rotation, collider) in &intersection.hits {
+            gizmos.draw_collider(collider, *position, *rotation, hit_color);
+        }
     }
 }
 

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -395,9 +395,20 @@ fn update_shape_caster_positions(
     }
 }
 
+#[cfg(all(
+    feature = "debug-plugin",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+type TempFilter = Without<TempGizmo>;
+#[cfg(all(
+    not(feature = "debug-plugin"),
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
+type TempFilter = ();
+
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 fn raycast(
-    mut rays: Query<(Entity, &mut RayCaster, &mut RayHits)>,
+    mut rays: Query<(Entity, &mut RayCaster, &mut RayHits), TempFilter>,
     spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,
 ) {
@@ -416,7 +427,7 @@ fn raycast(
 
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 fn shapecast(
-    mut shape_casters: Query<(Entity, &mut ShapeCaster, &mut ShapeHits)>,
+    mut shape_casters: Query<(Entity, &mut ShapeCaster, &mut ShapeHits), TempFilter>,
     spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,
 ) {

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -257,26 +257,34 @@ impl RayCaster {
         hits.clear();
 
         if self.max_hits == 1 {
-            let first_hit = spatial_query.cast_ray(
+            let first_hit = spatial_query.cast_ray_predicate(
                 self.global_origin(),
                 self.global_direction(),
                 self.max_distance,
                 self.solid,
                 &self.query_filter,
+                &|_| true,
             );
 
             if let Some(hit) = first_hit {
                 hits.push(hit);
             }
         } else {
-            hits.extend(spatial_query.ray_hits(
+            spatial_query.ray_hits_callback(
                 self.global_origin(),
                 self.global_direction(),
                 self.max_distance,
-                self.max_hits,
                 self.solid,
                 &self.query_filter,
-            ));
+                |hit| {
+                    if hits.len() < self.max_hits as usize {
+                        hits.push(hit);
+                        true
+                    } else {
+                        false
+                    }
+                },
+            );
         }
     }
 
@@ -294,6 +302,10 @@ impl RayCaster {
 }
 
 fn on_add_ray_caster(mut world: DeferredWorld, ctx: HookContext) {
+    #[cfg(feature = "debug-plugin")]
+    if world.get::<TempGizmo>(ctx.entity).is_some() {
+        return;
+    }
     let ray_caster = world.get::<RayCaster>(ctx.entity).unwrap();
     let max_hits = if ray_caster.max_hits == u32::MAX {
         10

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -316,33 +316,45 @@ impl ShapeCaster {
         };
 
         if self.max_hits == 1 {
-            let first_hit = spatial_query.cast_shape(
+            let first_hit = spatial_query.cast_shape_predicate(
                 &self.shape,
                 self.global_origin,
                 self.global_shape_rotation,
                 self.global_direction,
                 &config,
                 &self.query_filter,
+                &|_| true,
             );
 
             if let Some(hit) = first_hit {
                 hits.push(hit);
             }
         } else {
-            hits.extend(spatial_query.shape_hits(
+            spatial_query.shape_hits_callback(
                 &self.shape,
                 self.global_origin,
                 self.global_shape_rotation,
                 self.global_direction,
-                self.max_hits,
                 &config,
                 &self.query_filter,
-            ));
+                |hit| {
+                    if hits.len() < self.max_hits as usize {
+                        hits.push(hit);
+                        true
+                    } else {
+                        false
+                    }
+                },
+            );
         }
     }
 }
 
 fn on_add_shape_caster(mut world: DeferredWorld, ctx: HookContext) {
+    #[cfg(feature = "debug-plugin")]
+    if world.get::<TempGizmo>(ctx.entity).is_some() {
+        return;
+    }
     let shape_caster = world.get::<ShapeCaster>(ctx.entity).unwrap();
     let max_hits = if shape_caster.max_hits == u32::MAX {
         10

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -61,6 +61,10 @@ pub struct SpatialQuery<'w, 's> {
     colliders: Query<'w, 's, (&'static Position, &'static Rotation, &'static Collider)>,
     aabbs: Query<'w, 's, &'static ColliderAabb>,
     collider_trees: Res<'w, ColliderTrees>,
+    #[cfg(feature = "debug-plugin")]
+    commands: Commands<'w, 's>,
+    #[cfg(feature = "debug-plugin")]
+    store: Res<'w, GizmoConfigStore>,
 }
 
 impl SpatialQuery<'_, '_> {
@@ -75,6 +79,12 @@ impl SpatialQuery<'_, '_> {
     /// - `solid`: If true *and* the ray origin is inside of a collider, the hit point will be the ray origin itself.
     ///   Otherwise, the collider will be treated as hollow, and the hit point will be at its boundary.
     /// - `filter`: A [`SpatialQueryFilter`] that determines which entities are included in the cast.
+    ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to cast a ray
+    /// with an immutable `SpatialQuery` or want to cast without creating a temporary gizmo, use
+    /// [`cast_ray_predicate`](SpatialQuery::cast_ray_predicate).
     ///
     /// # Example
     ///
@@ -109,14 +119,39 @@ impl SpatialQuery<'_, '_> {
     /// - [`SpatialQuery::ray_hits`]
     /// - [`SpatialQuery::ray_hits_callback`]
     pub fn cast_ray(
-        &self,
+        &mut self,
         origin: RVector,
         direction: Dir,
         max_distance: f32,
         solid: bool,
         filter: &SpatialQueryFilter,
     ) -> Option<RayHitData> {
-        self.cast_ray_predicate(origin, direction, max_distance, solid, filter, &|_| true)
+        let out =
+            self.cast_ray_predicate(origin, direction, max_distance, solid, filter, &|_| true);
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    RayCaster::new(origin, direction)
+                        .with_max_distance(max_distance)
+                        .with_solidness(solid)
+                        .with_query_filter(filter.clone()),
+                    RayHits(out.iter().cloned().collect()),
+                    TempGizmo::new(*temp_gizmo_lifetime),
+                ));
+            }
+        }
+
+        out
     }
 
     /// Casts a [ray](spatial_query#raycasting) and computes the closest [hit](RayHitData) with a collider.
@@ -239,6 +274,12 @@ impl SpatialQuery<'_, '_> {
     ///   Otherwise, the collider will be treated as hollow, and the hit point will be at its boundary.
     /// - `filter`: A [`SpatialQueryFilter`] that determines which entities are included in the cast.
     ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to cast a ray
+    /// with an immutable `SpatialQuery` or do not want to create a temporary gizmo, use
+    /// [`ray_hits_callback`](SpatialQuery::ray_hits_callback).
+    ///
     /// # Example
     ///
     /// ```
@@ -275,7 +316,7 @@ impl SpatialQuery<'_, '_> {
     /// - [`SpatialQuery::cast_ray_predicate`]
     /// - [`SpatialQuery::ray_hits_callback`]
     pub fn ray_hits(
-        &self,
+        &mut self,
         origin: RVector,
         direction: Dir,
         max_distance: f32,
@@ -293,6 +334,29 @@ impl SpatialQuery<'_, '_> {
                 false
             }
         });
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    RayCaster::new(origin, direction)
+                        .with_max_distance(max_distance)
+                        .with_max_hits(max_hits)
+                        .with_solidness(solid)
+                        .with_query_filter(filter.clone()),
+                    RayHits(hits.clone()),
+                    TempGizmo::new(*temp_gizmo_lifetime),
+                ));
+            }
+        }
 
         hits
     }
@@ -408,6 +472,12 @@ impl SpatialQuery<'_, '_> {
     /// - `config`: A [`ShapeCastConfig`] that determines the behavior of the cast.
     /// - `filter`: A [`SpatialQueryFilter`] that determines which entities are included in the cast.
     ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to cast a
+    /// shape with an immutable `SpatialQuery` or do not want to create a temporary gizmo, use
+    /// [`cast_shape_predicate`](SpatialQuery::cast_shape_predicate).
+    ///
     /// # Example
     ///
     /// ```
@@ -444,7 +514,7 @@ impl SpatialQuery<'_, '_> {
     /// - [`SpatialQuery::shape_hits_callback`]
     #[allow(clippy::too_many_arguments)]
     pub fn cast_shape(
-        &self,
+        &mut self,
         shape: &Collider,
         origin: RVector,
         shape_rotation: impl Into<Rot>,
@@ -452,7 +522,10 @@ impl SpatialQuery<'_, '_> {
         config: &ShapeCastConfig,
         filter: &SpatialQueryFilter,
     ) -> Option<ShapeHitData> {
-        self.cast_shape_predicate(
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
+
+        let out = self.cast_shape_predicate(
             shape,
             origin,
             shape_rotation,
@@ -460,7 +533,33 @@ impl SpatialQuery<'_, '_> {
             config,
             filter,
             &|_| true,
-        )
+        );
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    ShapeCaster::new(shape.clone(), origin, shape_rotation, direction)
+                        .with_max_distance(config.max_distance)
+                        .with_target_distance(config.target_distance)
+                        .with_compute_contact_on_penetration(config.compute_contact_on_penetration)
+                        .with_ignore_origin_penetration(config.ignore_origin_penetration)
+                        .with_query_filter(filter.clone()),
+                    ShapeHits(out.iter().cloned().collect()),
+                    TempGizmo::new(*temp_gizmo_lifetime),
+                ));
+            }
+        }
+
+        out
     }
 
     /// Casts a [shape](spatial_query#shapecasting) with a given rotation and computes the closest [hit](ShapeHitData)
@@ -613,6 +712,12 @@ impl SpatialQuery<'_, '_> {
     /// - `filter`: A [`SpatialQueryFilter`] that determines which entities are included in the cast.
     /// - `callback`: A callback function called for each hit.
     ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to cast a
+    /// shape with an immutable `SpatialQuery` or do not want to create a temporary gizmo, use
+    /// [`shape_hits_callback`](SpatialQuery::shape_hits_callback).
+    ///
     /// # Example
     ///
     /// ```
@@ -651,7 +756,7 @@ impl SpatialQuery<'_, '_> {
     /// - [`SpatialQuery::shape_hits_callback`]
     #[allow(clippy::too_many_arguments)]
     pub fn shape_hits(
-        &self,
+        &mut self,
         shape: &Collider,
         origin: RVector,
         shape_rotation: impl Into<Rot>,
@@ -660,6 +765,9 @@ impl SpatialQuery<'_, '_> {
         config: &ShapeCastConfig,
         filter: &SpatialQueryFilter,
     ) -> Vec<ShapeHitData> {
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
+
         let mut hits = Vec::new();
 
         self.shape_hits_callback(
@@ -678,6 +786,31 @@ impl SpatialQuery<'_, '_> {
                 }
             },
         );
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    ShapeCaster::new(shape.clone(), origin, shape_rotation, direction)
+                        .with_max_hits(max_hits)
+                        .with_max_distance(config.max_distance)
+                        .with_target_distance(config.target_distance)
+                        .with_compute_contact_on_penetration(config.compute_contact_on_penetration)
+                        .with_ignore_origin_penetration(config.ignore_origin_penetration)
+                        .with_query_filter(filter.clone()),
+                    ShapeHits(hits.clone()),
+                    TempGizmo::new(self.store.config::<PhysicsGizmos>().1.temp_gizmo_lifetime),
+                ));
+            }
+        }
 
         hits
     }
@@ -816,6 +949,12 @@ impl SpatialQuery<'_, '_> {
     ///   Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to project a
+    /// point with an immutable `SpatialQuery` or do not want to create a temporary gizmo, use
+    /// [`project_point_predicate`](SpatialQuery::project_point_predicate).
+    ///
     /// # Example
     ///
     /// ```
@@ -842,12 +981,35 @@ impl SpatialQuery<'_, '_> {
     ///
     /// - [`SpatialQuery::project_point_predicate`]
     pub fn project_point(
-        &self,
+        &mut self,
         point: RVector,
         solid: bool,
         filter: &SpatialQueryFilter,
     ) -> Option<PointProjection> {
-        self.project_point_predicate(point, solid, filter, &|_| true)
+        let out = self.project_point_predicate(point, solid, filter, &|_| true)?;
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    ProjectPoint {
+                        origin: point,
+                        point: out.point,
+                    },
+                    TempGizmo::new(self.store.config::<PhysicsGizmos>().1.temp_gizmo_lifetime),
+                ));
+            }
+        }
+
+        Some(out)
     }
 
     /// Finds the [projection](spatial_query#point-projection) of a given point on the closest [collider](Collider).
@@ -1146,6 +1308,12 @@ impl SpatialQuery<'_, '_> {
     /// - `shape_rotation`: The rotation of the shape.
     /// - `filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
+    /// # Mutability
+    ///
+    /// This method takes `&mut self` in order to enable debug rendering. If you need to test intersection
+    /// with an immutable `SpatialQuery` or do not want to create a temporary gizmo, use
+    /// [`shape_intersections_callback`](SpatialQuery::shape_intersections_callback).
+    ///
     /// # Example
     ///
     /// ```
@@ -1174,13 +1342,15 @@ impl SpatialQuery<'_, '_> {
     ///
     /// - [`SpatialQuery::shape_intersections_callback`]
     pub fn shape_intersections(
-        &self,
+        &mut self,
         shape: &Collider,
         shape_position: RVector,
         shape_rotation: impl Into<Rot>,
         filter: &SpatialQueryFilter,
     ) -> Vec<Entity> {
         let mut intersections = vec![];
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
 
         self.shape_intersections_callback(
             shape,
@@ -1192,6 +1362,38 @@ impl SpatialQuery<'_, '_> {
                 true
             },
         );
+
+        #[cfg(feature = "debug-plugin")]
+        {
+            let (
+                GizmoConfig { enabled, .. },
+                PhysicsGizmos {
+                    temp_gizmo_lifetime,
+                    ..
+                },
+            ) = self.store.config::<PhysicsGizmos>();
+
+            if *enabled && !temp_gizmo_lifetime.is_zero() {
+                self.commands.spawn((
+                    ShapeIntersections {
+                        shape: shape.clone(),
+                        position: shape_position,
+                        rotation: shape_rotation,
+                        hits: intersections
+                            .iter()
+                            .flat_map(|entity| {
+                                self.colliders
+                                    .get(*entity)
+                                    .map(|(position, rotation, collider)| {
+                                        (**position, (*rotation).into(), collider.clone())
+                                    })
+                            })
+                            .collect(),
+                    },
+                    TempGizmo::new(self.store.config::<PhysicsGizmos>().1.temp_gizmo_lifetime),
+                ));
+            }
+        }
 
         intersections
     }


### PR DESCRIPTION
# Objective

While #186 added debug rendering for continuous raycasts and shapecasts, other spatial queries are not rendered. The PR's description mentions that users could use a `PhysicsDebugRenderer` struct to accomplish this, but this struct seems to have since been removed, meaning the library now provides no direct means of visualizing discrete spatial queries (that is, methods called on the `SpatialQuery` struct).

Closes  #426.

## Solution

This PR adds debug rendering to the following `SpatialQuery` methods:
- `cast_ray`
- `ray_hits`
- `cast_shape`
- `shape_hits`
- `project_point`
- `shape_intersections`

This is accomplished by adding `Commands` and `GizmoConfigStore` to `SpatialQuery`'s fields and spawning entities with unique components that despawn after a configurable amount of time. These entities are not spawned if `PhysicsGizmos` is configured so as to not render them, and the code doesn't even run if the feature is not enabled. Raycasts and Shapecasts leverage the existing debug rendering code for `RayCaster` and `ShapeCaster` by spawning the respective entity alongside precomputed `RayHits` and `ShapeHits`. In order to prevent the caster components from clearing the hits components, some simple checks for the presence of the new `TempGizmo` component are added to their logic. Additionally, in order to prevent a feedback loop, the casters now directly call the `cast_*_predicate` functions each update.

## Testing

This PR also adds an example for debug rendering of 3d spatial queries which demonstrates the functionality of the additions.

---

## Showcase

You can run the above-mentioned example with `cargo run --example debug_render_3d`.

## Notes
An important side-effect of this change is that the aforementioned methods now take a mutable reference to self. However, all of these methods are actually convenience wrappers around lower-level `_predicate` and `_callback` methods, which I have deliberately left unchanged to allow an escape hatch for those who may need it (this is already being used by the PR itself as described above). I believe this is an acceptable compromise. One problem, though, is that the methods still take `&mut self` even when the `debug-plugin` feature is disabled, which is unnecessary. I don't know how this could be feasibly feature-gated, though it may be possible.

I also have no clue what colors should be used for `project_point` and `shape_intersections`. Right now, it's all just white as a placeholder.