### PR TITLE
Fix clippy chunks_exact_to_as_chunks lint in mesh index extraction

### DIFF
--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1543,10 +1543,12 @@ fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<VerticesIndices> {
 
     let idx = match indices {
         Indices::U16(idx) => idx
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|i| [i[0] as u32, i[1] as u32, i[2] as u32])
             .collect(),
-        Indices::U32(idx) => idx.chunks_exact(3).map(|i| [i[0], i[1], i[2]]).collect(),
+        Indices::U32(idx) => idx.as_chunks::<3>().0.to_vec(),
     };
 
     Some((vtx, idx))


### PR DESCRIPTION
Rust 1.98 clippy denies `chunks_exact` with a constant chunk size.
Use `as_chunks::<3>()` instead.