### PR TITLE
Pin CI nightly toolchain to work around rustc memory regression

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -96,8 +96,13 @@ jobs:
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v6
-            - uses: dtolnay/rust-toolchain@nightly
+            # Pinned: nightlies since late August 2026 need several times more memory
+            # to compile `bevy_render` and `bevy_pbr`, which gets the 16 GB runners killed.
+            # See https://github.com/rust-lang/rust/issues/161748.
+            # Unpin once a Bevy release includes https://github.com/bevyengine/bevy/pull/25512.
+            - uses: dtolnay/rust-toolchain@master
               with:
+                  toolchain: nightly-2026-08-16
                   components: llvm-tools-preview
             - uses: cargo-bins/cargo-binstall@main
             - name: Install Linux dependencies

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1543,10 +1543,12 @@ fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<VerticesIndices> {
 
     let idx = match indices {
         Indices::U16(idx) => idx
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|i| [i[0] as u32, i[1] as u32, i[2] as u32])
             .collect(),
-        Indices::U32(idx) => idx.chunks_exact(3).map(|i| [i[0], i[1], i[2]]).collect(),
+        Indices::U32(idx) => idx.as_chunks::<3>().0.to_vec(),
     };
 
     Some((vtx, idx))


### PR DESCRIPTION
# Objective

The test suite job has been failing on every PR since late August with exit code 143 while compiling `bevy_core_pipeline`. Recent nightlies need several times more memory to compile `bevy_render` and `bevy_pbr` (rust-lang/rust#161748), which kills the 16 GB runners.

## Solution

Pin the test job to `nightly-2026-08-16`, the last nightly that passed CI. Unpin once a Bevy release includes bevyengine/bevy#25512.

Also includes the `clippy::chunks_exact_to_as_chunks` fix from #1059 so the Lints job passes here as well; #1059 can be closed if this merges first.

## Testing

Measured peak rustc memory locally with the CI command and flags: `bevy_render` goes from 2.5 GB on the pinned nightly to 16.7 GB on the current one, independent of `-Zthreads`.
