### PR TITLE
V2: Debug rendering for `SpatialQuery`

### DIFF
--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -205,6 +205,10 @@ required-features = ["3d", "default-collider", "diagnostic_ui"]
 name = "debugdump_3d"
 required-features = ["3d", "debug-plugin"]
 
+[[example]]
+name = "debug_render_3d"
+required-features = ["3d", "debug-plugin", "bevy_scene"]
+
 [[bench]]
 name = "velocity_projection"
 required-features = ["3d", "default-collider", "test"]

--- a/crates/avian3d/examples/debug_render_3d.rs
+++ b/crates/avian3d/examples/debug_render_3d.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use avian3d::{math::RVector, prelude::*};
+use bevy::prelude::*;
+
+fn main() {
+    App::default()
+        .add_plugins((
+            DefaultPlugins,
+            PhysicsPlugins::default(),
+            PhysicsDebugPlugin,
+        ))
+        .add_systems(Startup, scene.spawn())
+        .insert_resource(Cycle::new(Duration::from_millis(500)))
+        .add_systems(Update, (cast, move_wall))
+        .run();
+}
+
+fn scene() -> impl SceneList {
+    bsn_list![
+        (
+            Camera3d
+            template_value(Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y))
+        ),
+        (
+            Mesh3d(asset_value(Cuboid::new(8.0, 1.0, 1.0)))
+            MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))
+            Collider::cuboid(8.0, 1.0, 1.0)
+            Transform::from_xyz(0.0, 0.0, -2.0)
+            MoveLeft
+        ),
+    ]
+}
+
+#[derive(Resource, Deref, DerefMut)]
+struct Cycle(Timer);
+
+impl Cycle {
+    pub fn new(duration: Duration) -> Self {
+        Self(Timer::new(duration, TimerMode::Repeating))
+    }
+}
+
+fn cast(space: SpatialQuery, mut cycle: ResMut<Cycle>, time: Res<Time>) {
+    if cycle.tick(time.delta()).just_finished() {
+        let filter = SpatialQueryFilter::default();
+        let shape = Collider::sphere(0.5);
+
+        space.cast_ray(RVector::ZERO, Dir3::NEG_Z, 100.0, false, &filter);
+        space.cast_shape(
+            &shape,
+            RVector::new(1.0, 0.0, 0.0),
+            Quat::IDENTITY,
+            Dir3::NEG_Z,
+            &Default::default(),
+            &filter,
+        );
+        space.project_point(RVector::new(-1.0, 0.0, 0.0), false, &filter);
+        space.shape_intersections(
+            &shape,
+            RVector::new(-2.0, 0.0, -1.25),
+            Quat::IDENTITY,
+            &filter,
+        );
+    }
+}
+
+#[derive(Resource, Deref, DerefMut, Clone, Copy, Default)]
+struct MoveLeft(pub bool);
+
+fn move_wall(mut wall: Single<(&mut Transform, &mut MoveLeft)>, time: Res<Time>) {
+    let (transform, move_left) = &mut *wall;
+    let delta = 1.0 * time.delta_secs();
+
+    if ***move_left {
+        transform.translation.x -= delta;
+    } else {
+        transform.translation.x += delta;
+    }
+
+    if transform.translation.x <= -5.0 {
+        ***move_left = false;
+    } else if transform.translation.x >= 5.0 {
+        ***move_left = true;
+    }
+}

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -92,6 +92,16 @@ pub struct PhysicsGizmos {
     pub shapecast_point_color: Option<Color>,
     /// The color used for the hit normals in [shapecasts](spatial_query#shapecasting).
     pub shapecast_normal_color: Option<Color>,
+    /// The color used for the origin of [point projections](spatial_query#point-projection).
+    pub point_projection_origin_color: Option<Color>,
+    /// The color used for the projected points of [point projections](spatial_query#point-projection).
+    pub point_projection_color: Option<Color>,
+    /// The color used for the arrow when drawing [point projections](spatial_query#point-projection).
+    pub point_projection_arrow_color: Option<Color>,
+    /// The color used for the shape used for [shape intersection](SpatialQuery::shape_intersections) tests.
+    pub shape_intersection_shape_color: Option<Color>,
+    /// The color used for the intersecting colliders of [shape intersection](SpatialQuery::shape_intersections) tests.
+    pub shape_intersection_color: Option<Color>,
     /// The color used for the bounds of [`PhysicsIsland`](dynamics::solver::islands::PhysicsIsland)s.
     pub island_color: Option<Color>,
     /// The color used for [`ColliderTree`](crate::collider_tree) nodes.
@@ -125,6 +135,13 @@ impl Default for PhysicsGizmos {
             island_color: None,
             collider_tree_color: None,
             hide_meshes: false,
+            // --- TODO: decide on these ---
+            point_projection_origin_color: Some(Color::WHITE),
+            point_projection_color: Some(Color::WHITE),
+            point_projection_arrow_color: Some(Color::WHITE),
+            shape_intersection_shape_color: Some(Color::WHITE),
+            shape_intersection_color: Some(Color::WHITE),
+            // ------------------------------
         }
     }
 }
@@ -172,6 +189,13 @@ impl PhysicsGizmos {
             island_color: Some(RED.into()),
             collider_tree_color: Some(Color::WHITE),
             hide_meshes: true,
+            // --- TODO: decide on these ---
+            point_projection_origin_color: Some(Color::WHITE),
+            point_projection_color: Some(Color::WHITE),
+            point_projection_arrow_color: Some(Color::WHITE),
+            shape_intersection_shape_color: Some(Color::WHITE),
+            shape_intersection_color: Some(Color::WHITE),
+            // ------------------------------
         }
     }
 
@@ -201,6 +225,11 @@ impl PhysicsGizmos {
             island_color: None,
             collider_tree_color: None,
             hide_meshes: false,
+            point_projection_origin_color: None,
+            point_projection_color: None,
+            point_projection_arrow_color: None,
+            shape_intersection_shape_color: None,
+            shape_intersection_color: None,
         }
     }
 

--- a/src/debug_render/discrete.rs
+++ b/src/debug_render/discrete.rs
@@ -1,0 +1,33 @@
+use crate::prelude::*;
+use bevy::{prelude::*, utils::Parallel};
+
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct SpatialQueries(Parallel<Vec<DebugSpatialQuery>>);
+
+pub struct DebugSpatialQuery {
+    pub position: RVector,
+    pub data: DebugSpatialQueryData,
+}
+
+pub enum DebugSpatialQueryData {
+    Raycast {
+        direction: Dir,
+        max_distance: f32,
+        hits: Vec<RayHitData>,
+    },
+    Shapecast {
+        shape: Collider,
+        direction: Dir,
+        rotation: Rot,
+        max_distance: f32,
+        hits: Vec<ShapeHitData>,
+    },
+    PointProjection {
+        projection: RVector,
+    },
+    ShapeIntersections {
+        shape: Collider,
+        rotation: Rot,
+        hits: Vec<(Position, Rotation, Collider)>,
+    },
+}

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -5,10 +5,12 @@
 #![allow(clippy::unnecessary_cast)]
 
 mod configuration;
+mod discrete;
 mod gizmos;
 
 use bevy_math::bounding::Aabb3d;
 pub use configuration::*;
+pub(crate) use discrete::*;
 pub use gizmos::*;
 
 use crate::{
@@ -133,6 +135,7 @@ impl Plugin for PhysicsDebugPlugin {
                 ))]
                 debug_render_shapecasts,
                 debug_render_islands.run_if(resource_exists::<PhysicsIslands>),
+                debug_render_discrete_spatial_queries,
             )
                 .after(TransformSystems::Propagate)
                 .run_if(|store: Res<GizmoConfigStore>| store.config::<PhysicsGizmos>().0.enabled),
@@ -140,7 +143,8 @@ impl Plugin for PhysicsDebugPlugin {
         .add_systems(
             PostUpdate,
             change_mesh_visibility.before(VisibilitySystems::CalculateBounds),
-        );
+        )
+        .init_resource::<SpatialQueries>();
     }
 }
 
@@ -566,6 +570,114 @@ fn debug_render_islands(
                     Transform::IDENTITY,
                     color,
                 );
+            }
+        }
+    }
+}
+
+fn debug_render_discrete_spatial_queries(
+    mut gizmos: Gizmos<PhysicsGizmos>,
+    store: Res<GizmoConfigStore>,
+    mut queries: ResMut<SpatialQueries>,
+    length_unit: Res<PhysicsLengthUnit>,
+) {
+    let config = store.config::<PhysicsGizmos>().1;
+
+    for query in queries.drain() {
+        match query.data {
+            DebugSpatialQueryData::Raycast {
+                direction,
+                max_distance,
+                hits,
+            } => {
+                let arrow_color = config.raycast_color.unwrap_or(Color::NONE);
+                let point_color = config.raycast_point_color.unwrap_or(Color::NONE);
+                let normal_color = config.raycast_normal_color.unwrap_or(Color::NONE);
+
+                gizmos.draw_raycast(
+                    query.position,
+                    direction,
+                    max_distance,
+                    &hits,
+                    arrow_color,
+                    point_color,
+                    normal_color,
+                    **length_unit,
+                );
+            }
+            DebugSpatialQueryData::Shapecast {
+                shape,
+                direction,
+                rotation,
+                max_distance,
+                hits,
+            } => {
+                let arrow_color = config.shapecast_color.unwrap_or(Color::NONE);
+                let shape_color = config.shapecast_shape_color.unwrap_or(Color::NONE);
+                let point_color = config.shapecast_point_color.unwrap_or(Color::NONE);
+                let normal_color = config.shapecast_normal_color.unwrap_or(Color::NONE);
+
+                gizmos.draw_shapecast(
+                    &shape,
+                    query.position,
+                    rotation,
+                    direction,
+                    max_distance,
+                    &hits,
+                    arrow_color,
+                    shape_color,
+                    point_color,
+                    normal_color,
+                    **length_unit,
+                );
+            }
+            DebugSpatialQueryData::PointProjection { projection } => {
+                let origin_color = config.point_projection_origin_color.unwrap_or(Color::NONE);
+                let projection_color = config.point_projection_color.unwrap_or(Color::NONE);
+                let arrow_color = config.point_projection_arrow_color.unwrap_or(Color::NONE);
+
+                gizmos.draw_arrow(query.position, projection, 0.1 * **length_unit, arrow_color);
+
+                #[cfg(feature = "2d")]
+                {
+                    gizmos.circle_2d(
+                        projection.f32(),
+                        0.1 * **length_unit as f32,
+                        projection_color,
+                    );
+                    gizmos.circle_2d(
+                        query.position.f32(),
+                        0.1 * **length_unit as f32,
+                        origin_color,
+                    );
+                }
+
+                #[cfg(feature = "3d")]
+                {
+                    gizmos.sphere(
+                        projection.f32(),
+                        0.1 * **length_unit as f32,
+                        projection_color,
+                    );
+                    gizmos.sphere(
+                        query.position.f32(),
+                        0.1 * **length_unit as f32,
+                        origin_color,
+                    );
+                }
+            }
+            DebugSpatialQueryData::ShapeIntersections {
+                shape,
+                rotation,
+                hits,
+            } => {
+                let shape_color = config.shape_intersection_shape_color.unwrap_or(Color::NONE);
+                let hit_color = config.shape_intersection_color.unwrap_or(Color::NONE);
+
+                gizmos.draw_collider(&shape, query.position, rotation, shape_color);
+                for (position, rotation, collider) in hits {
+                    gizmos.draw_collider(&collider, *position, rotation, hit_color);
+                }
             }
         }
     }

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -257,26 +257,34 @@ impl RayCaster {
         hits.clear();
 
         if self.max_hits == 1 {
-            let first_hit = spatial_query.cast_ray(
+            let first_hit = spatial_query.cast_ray_predicate(
                 self.global_origin(),
                 self.global_direction(),
                 self.max_distance,
                 self.solid,
                 &self.query_filter,
+                &|_| true,
             );
 
             if let Some(hit) = first_hit {
                 hits.push(hit);
             }
         } else {
-            hits.extend(spatial_query.ray_hits(
+            spatial_query.ray_hits_callback(
                 self.global_origin(),
                 self.global_direction(),
                 self.max_distance,
-                self.max_hits,
                 self.solid,
                 &self.query_filter,
-            ));
+                |hit| {
+                    if hits.len() < self.max_hits as usize {
+                        hits.push(hit);
+                        true
+                    } else {
+                        false
+                    }
+                },
+            );
         }
     }
 

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -316,28 +316,36 @@ impl ShapeCaster {
         };
 
         if self.max_hits == 1 {
-            let first_hit = spatial_query.cast_shape(
+            let first_hit = spatial_query.cast_shape_predicate(
                 &self.shape,
                 self.global_origin,
                 self.global_shape_rotation,
                 self.global_direction,
                 &config,
                 &self.query_filter,
+                &|_| true,
             );
 
             if let Some(hit) = first_hit {
                 hits.push(hit);
             }
         } else {
-            hits.extend(spatial_query.shape_hits(
+            spatial_query.shape_hits_callback(
                 &self.shape,
                 self.global_origin,
                 self.global_shape_rotation,
                 self.global_direction,
-                self.max_hits,
                 &config,
                 &self.query_filter,
-            ));
+                |hit| {
+                    if hits.len() < self.max_hits as usize {
+                        hits.push(hit);
+                        true
+                    } else {
+                        false
+                    }
+                },
+            );
         }
     }
 }

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -61,6 +61,10 @@ pub struct SpatialQuery<'w, 's> {
     colliders: Query<'w, 's, (&'static Position, &'static Rotation, &'static Collider)>,
     aabbs: Query<'w, 's, &'static ColliderAabb>,
     collider_trees: Res<'w, ColliderTrees>,
+    #[cfg(feature = "debug-plugin")]
+    debug: Option<Res<'w, SpatialQueries>>,
+    #[cfg(feature = "debug-plugin")]
+    gizmos: Option<Res<'w, GizmoConfigStore>>,
 }
 
 impl SpatialQuery<'_, '_> {
@@ -116,7 +120,25 @@ impl SpatialQuery<'_, '_> {
         solid: bool,
         filter: &SpatialQueryFilter,
     ) -> Option<RayHitData> {
-        self.cast_ray_predicate(origin, direction, max_distance, solid, filter, &|_| true)
+        let out =
+            self.cast_ray_predicate(origin, direction, max_distance, solid, filter, &|_| true);
+
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: origin,
+                data: DebugSpatialQueryData::Raycast {
+                    direction,
+                    max_distance,
+                    hits: out.iter().cloned().collect(),
+                },
+            });
+        }
+
+        out
     }
 
     /// Casts a [ray](spatial_query#raycasting) and computes the closest [hit](RayHitData) with a collider.
@@ -294,6 +316,21 @@ impl SpatialQuery<'_, '_> {
             }
         });
 
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: origin,
+                data: DebugSpatialQueryData::Raycast {
+                    direction,
+                    max_distance,
+                    hits: hits.clone(),
+                },
+            })
+        }
+
         hits
     }
 
@@ -452,7 +489,10 @@ impl SpatialQuery<'_, '_> {
         config: &ShapeCastConfig,
         filter: &SpatialQueryFilter,
     ) -> Option<ShapeHitData> {
-        self.cast_shape_predicate(
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
+
+        let out = self.cast_shape_predicate(
             shape,
             origin,
             shape_rotation,
@@ -460,7 +500,26 @@ impl SpatialQuery<'_, '_> {
             config,
             filter,
             &|_| true,
-        )
+        );
+
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: origin,
+                data: DebugSpatialQueryData::Shapecast {
+                    shape: shape.clone(),
+                    direction,
+                    rotation: shape_rotation,
+                    max_distance: config.max_distance,
+                    hits: out.iter().cloned().collect(),
+                },
+            });
+        }
+
+        out
     }
 
     /// Casts a [shape](spatial_query#shapecasting) with a given rotation and computes the closest [hit](ShapeHitData)
@@ -661,6 +720,8 @@ impl SpatialQuery<'_, '_> {
         filter: &SpatialQueryFilter,
     ) -> Vec<ShapeHitData> {
         let mut hits = Vec::new();
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
 
         self.shape_hits_callback(
             shape,
@@ -678,6 +739,23 @@ impl SpatialQuery<'_, '_> {
                 }
             },
         );
+
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: origin,
+                data: DebugSpatialQueryData::Shapecast {
+                    shape: shape.clone(),
+                    direction,
+                    rotation: shape_rotation,
+                    max_distance: config.max_distance,
+                    hits: hits.clone(),
+                },
+            })
+        }
 
         hits
     }
@@ -847,7 +925,23 @@ impl SpatialQuery<'_, '_> {
         solid: bool,
         filter: &SpatialQueryFilter,
     ) -> Option<PointProjection> {
-        self.project_point_predicate(point, solid, filter, &|_| true)
+        let out = self.project_point_predicate(point, solid, filter, &|_| true);
+
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+            && let Some(out) = &out
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: point,
+                data: DebugSpatialQueryData::PointProjection {
+                    projection: out.point,
+                },
+            })
+        }
+
+        out
     }
 
     /// Finds the [projection](spatial_query#point-projection) of a given point on the closest [collider](Collider).
@@ -1181,6 +1275,8 @@ impl SpatialQuery<'_, '_> {
         filter: &SpatialQueryFilter,
     ) -> Vec<Entity> {
         let mut intersections = vec![];
+        #[cfg(feature = "debug-plugin")]
+        let shape_rotation = shape_rotation.into();
 
         self.shape_intersections_callback(
             shape,
@@ -1192,6 +1288,29 @@ impl SpatialQuery<'_, '_> {
                 true
             },
         );
+
+        #[cfg(feature = "debug-plugin")]
+        if let Some(gizmos) = &self.gizmos
+            && gizmos.config::<PhysicsGizmos>().0.enabled
+            && let Some(debug) = &self.debug
+        {
+            debug.borrow_local_mut().push(DebugSpatialQuery {
+                position: shape_position,
+                data: DebugSpatialQueryData::ShapeIntersections {
+                    shape: shape.clone(),
+                    rotation: shape_rotation,
+                    hits: intersections
+                        .iter()
+                        .filter_map(|e| {
+                            self.colliders
+                                .get(*e)
+                                .map(|(p, r, c)| (*p, *r, c.clone()))
+                                .ok()
+                        })
+                        .collect(),
+                },
+            })
+        }
 
         intersections
     }


### PR DESCRIPTION
# Objective

While #186 added debug rendering for continuous raycasts and shapecasts, other spatial queries are not rendered. The PR's description mentions that users could use a `PhysicsDebugRenderer` struct to accomplish this, but this struct seems to have since been removed, meaning the library now provides no direct means of visualizing discrete spatial queries (that is, methods called on the `SpatialQuery` struct).

Closes #426.

## Solution

This PR adds debug rendering to the following `SpatialQuery` methods:

- `cast_ray`
- `ray_hits`
- `cast_shape`
- `shape_hits`
- `project_point`
- `shape_intersections`

This is accomplished by leveraging Bevy's `Parallel` type in a resource to create multiple thread-local queues of spatial queries to be drawn. The queues are drained together and the gizmos are drawn in a single `PostUpdate` system. Each gizmo is only drawn for a single frame—this behavior could be changed or even configurable in the future if so desired.

The thread-local approach allows the relevant methods to gain this behavior without having to take `&mut self`. This creates two major improvements upon #1057:
1. There is no API breakage
2. The methods are still able to be run in parallel

In order to prevent redundant debug rendering, the continuous `RayCaster` and `ShapeCaster` methods now use the `_predicate` and `_callback` methods on the `SpatialQuery` parameter.

## Testing

This PR also adds an example for debug rendering of 3d spatial queries which demonstrates the functionality of the additions.

---

## Showcase

You can run the above-mentioned example with cargo run --example debug_render_3d.